### PR TITLE
feat(api): added prop for initial highlight index

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ This component allows you to render the items based on the user input. It
 renders a `div` with another `div` for your items and a `div` for the menu
 status (for accessibility purposes)
 
+#### defaultHighlightedIndex
+
+> `number`
+
+This is the initial `Item` that will be highlighted when first opening the menu.
+
 #### children
 
 > `function({})` | *required*

--- a/examples/pages/semantic-ui/index.js
+++ b/examples/pages/semantic-ui/index.js
@@ -69,7 +69,10 @@ const Item = glamorous(Autocomplete.Item, {
   },
 )
 const onAttention = '&:hover, &:focus'
-const Input = glamorous(Autocomplete.Input, {rootEl: 'input'})(
+const Input = glamorous(Autocomplete.Input, {
+  rootEl: 'input',
+  forwardProps: ['getValue'],
+})(
   {
     width: '100%',
     fontSize: 14,
@@ -104,7 +107,10 @@ const Input = glamorous(Autocomplete.Input, {rootEl: 'input'})(
       null),
 )
 
-const Menu = glamorous(Autocomplete.Menu, {rootEl: 'div'})({
+const Menu = glamorous(Autocomplete.Menu, {
+  rootEl: 'div',
+  forwardProps: ['defaultHighlightedIndex'],
+})({
   maxHeight: '20rem',
   overflowY: 'auto',
   overflowX: 'hidden',
@@ -167,7 +173,7 @@ function SemanticUIAutocomplete() {
               </ControllerButton>}
           </Div>)}
       </Autocomplete.Controller>
-      <Menu>
+      <Menu defaultHighlightedIndex={0}>
         {({inputValue, highlightedIndex, selectedItem}) =>
           // prettier-ignore
           (inputValue ? advancedFilter(items, inputValue) : items)

--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,7 @@ class Menu extends Component {
 
   static propTypes = {
     ref: PropTypes.func,
+    defaultHighlightedIndex: PropTypes.number,
     children: PropTypes.func.isRequired,
   }
 
@@ -174,6 +175,7 @@ class Menu extends Component {
   reset = cb => {
     this.setState(Menu.initialState, cb)
   }
+
   changeHighlighedIndex = moveAmount => {
     const {highlightedIndex} = this.state
     const baseIndex = highlightedIndex === null ? -1 : highlightedIndex
@@ -191,6 +193,7 @@ class Menu extends Component {
       highlightedIndex: newIndex,
     })
   }
+
   setHighlightedIndex = highlightedIndex => {
     this.setState({highlightedIndex})
   }
@@ -252,19 +255,28 @@ class Menu extends Component {
   }
 
   componentDidUpdate() {
+    const {isOpen} = this.context[AUTOCOMPLETE_CONTEXT].state
+    if (this.lastOpenState !== isOpen) {
+      if (isOpen === true) {
+        this.setHighlightedIndex(this.props.defaultHighlightedIndex)
+      }
+      this.lastOpenState = isOpen
+    }
     this.maybeScrollToHighlightedElement()
   }
 
   componentWillUnmount() {
     this.autocomplete.removeMenu(this)
   }
+
   render() {
     if (!this.autocomplete.state.isOpen) {
       return null
     }
     const {inputValue} = this.autocomplete.state
     const {highlightedIndex} = this.state
-    const {children, ...rest} = this.props
+    // eslint-disable-next-line no-unused-vars
+    const {defaultHighlightedIndex, children, ...rest} = this.props
     return (
       <div {...rest} ref={this.ref}>
         <div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Pertaining to https://github.com/kentcdodds/react-autocompletely/issues/3
<!-- Why are these changes necessary? -->
**Why**:
To allow a user to define the initial highlighted index when the `Menu` first opens.
<!-- How were these changes implemented? -->
**How**:
Added a `defaultHighlightedIndex` prop.
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
This actually doesn't work yet, I wanted to get your feedback on how you think this should be handled. I got stuck and couldn't figure it out 😞 if you have any ideas here and can point me in the right direction I can get it fixed 😁 