### PR TITLE
fix(native): focus input on button clicked (#334)

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -564,6 +564,7 @@ class Downshift extends Component {
     event.preventDefault()
 
     if (
+      /* istanbul ignore next (react-native) */
       preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'` &&
       this._inputNode
     ) {
@@ -574,6 +575,7 @@ class Downshift extends Component {
     // don't give the button the focus properly.
     /* istanbul ignore if (can't reasonably test this) */
     if (
+      /* istanbul ignore next (react-native) */
       !preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'` &&
       this.props.environment.document.activeElement ===
         this.props.environment.document.body

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -562,15 +562,25 @@ class Downshift extends Component {
 
   button_handleClick = event => {
     event.preventDefault()
+
+    if (
+      preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'` &&
+      this._inputNode
+    ) {
+      this._inputNode.focus()
+    }
+
     // handle odd case for Safari and Firefox which
     // don't give the button the focus properly.
     /* istanbul ignore if (can't reasonably test this) */
     if (
+      !preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'` &&
       this.props.environment.document.activeElement ===
-      this.props.environment.document.body
+        this.props.environment.document.body
     ) {
       event.target.focus()
     }
+
     this.toggleMenu({type: Downshift.stateChangeTypes.clickButton})
   }
 
@@ -610,7 +620,16 @@ class Downshift extends Component {
 
   /////////////////////////////// INPUT
 
-  getInputProps = ({onKeyDown, onBlur, onChange, onInput, ...rest} = {}) => {
+  inputRef = node => (this._inputNode = node)
+
+  getInputProps = ({
+    onKeyDown,
+    onBlur,
+    onChange,
+    onInput,
+    refKey = 'ref',
+    ...rest
+  } = {}) => {
     this.getInputProps.called = true
     if (this.getLabelProps.called && rest.id && rest.id !== this.inputId) {
       throw new Error(
@@ -659,6 +678,9 @@ class Downshift extends Component {
       ...eventHandlers,
       ...rest,
       id: this.inputId,
+      [refKey]: preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'`
+        ? this.inputRef
+        : null,
     }
   }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Prevent error in button_handleClick, and refocus `TextInput` if exists - both only in react-native environment.

<!-- Why are these changes necessary? -->

**Why**:
#334 
In the context of react-native, when we use a button instead of text input, `Cannot read property activeElement of undefined error` has thrown. The cause was a check for document object in native environment. Also, We wanted to re-focus the `TextInput` element if one exists. 

<!-- How were these changes implemented? -->

**How**:

 in order to refocus the `TextInput` after a button click, `refKey` added to `getInputProps`, and  assigned only in react-native using `inputNode` method, as in `rootNode` and `getRootProps`. 
For disabling focusing the event target in react-native, I simply added `!preval`module.exports = process.env.BUILD_REACT_NATIVE === 'true'``.


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
The `refKey` props still need documentation and tests for react-native.

Thanks!
