### PR TITLE
Allow custom toString methods on objects

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -75,7 +75,7 @@ class Downshift extends Component {
       if (i == null) {
         return ''
       }
-      if (process.env.NODE_ENV !== 'production' && isPlainObject(i)) {
+      if (process.env.NODE_ENV !== 'production' && isPlainObject(i) && !i.hasOwnProperty('toString')) {
         //eslint-disable-next-line no-console
         console.warn(
           'downshift: An object was passed to the default implementation of `itemToString`. You should probably provide your own `itemToString` implementation. Please refer to the `itemToString` API documentation.',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow the use of dynamic toString methods on suggestion items, without showing an error in the console.

<!-- Why are these changes necessary? -->

**Why**:

For my use case, I required a dynamic suggestion renderers to display different suggestion components based on user input. Specifying a custom `toString` method on the item allows that

```html
<Suggestions length={suggestions.length} {...getMenuProps()}>
  {handler.describe(query)}

  {suggestions.map((item, index) => (
    <Suggestion
      {...getItemProps({
        key: handler.toString(item),
        index,
        item: {
          ...item,
          toString: () => handler.toString(item)
        },
        selected: highlightedIndex === index
      })}
    >
      {handler.suggestion(item)}
    </Suggestion>
  ))}
</Suggestions>
```

<!-- How were these changes implemented? -->

**How**:

It now suppresses any errors a custom `toString` method exists on the object

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
