### PR TITLE
fix: remove 'ref is not a prop' warning

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1168,7 +1168,7 @@ function validateGetRootPropsCalledCorrectly(element, {refKey}) {
       `downshift: You returned a DOM element. You should not specify a refKey in getRootProps. You specified "${refKey}"`,
     )
   }
-  if (!getElementProps(element)[refKey] && !isForwardRef(element)) {
+  if (!isForwardRef(element) && !getElementProps(element)[refKey]) {
     // eslint-disable-next-line no-console
     console.error(
       `downshift: You must apply the ref prop "${refKey}" from getRootProps onto your root element.`,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
I've swapped the order of the operands in `validateGetRootPropsCalledCorrectly` to remove unnecessary warning from `react`.

<!-- Why are these changes necessary? -->

**Why**:
I'm messed up short-circuit logic in 3.1.3 and now getting this warning for composite components with `forwardRef` API.
![image](https://user-images.githubusercontent.com/15676655/47385043-9fc98480-d711-11e8-9e0b-4b4a55cdeb72.png)

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
