### PR TITLE
fix(ie11): added extra guard condition for ie11 issue

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -814,6 +814,7 @@ class Downshift extends Component {
     this.internalSetTimeout(() => {
       const downshiftButtonIsActive =
         this.props.environment.document &&
+        !!this.props.environment.document.activeElement &&
         !!this.props.environment.document.activeElement.dataset &&
         this.props.environment.document.activeElement.dataset.toggle &&
         (this._rootNode &&


### PR DESCRIPTION
**What**:
Fixes: 
> Unable to get property 'dataset' of undefined or null reference
errors on IE11.

**Why**:
We're using downshift on our webpage that (unfortunately) still needs to support IE11. We noticed bunch of errors in our error tracking pointing to downshift.
 
**How**:
I added additional guard clause to `inputHandleBlur` that verifies that `activeElement` on which `dataset` is called actually exists.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table
