### PR TITLE
Allow `null` item to be selected

### DIFF
--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -55,6 +55,24 @@ test('selectItemAtIndex can select item that is an empty string', () => {
   )
 })
 
+test('selectItemAtIndex can select item that is a null', () => {
+  const items = ['Chess', null]
+  const children = ({getItemProps}) => (
+    <div>
+      {items.map((item, index) => (
+        <div key={index} {...getItemProps({item})}>
+          {item}
+        </div>
+      ))}
+    </div>
+  )
+  const {selectItemAtIndex, childrenSpy} = setup({children})
+  selectItemAtIndex(1)
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({selectedItem: null}),
+  )
+})
+
 test('toggleMenu can take no arguments at all', () => {
   const {toggleMenu, childrenSpy} = setup()
   toggleMenu()

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -336,7 +336,7 @@ class Downshift extends Component {
 
   selectItemAtIndex = (itemIndex, otherStateToSet, cb) => {
     const item = this.items[itemIndex]
-    if (item == null) {
+    if (item === undefined) {
       return
     }
     this.selectItem(item, otherStateToSet, cb)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I'm currently unable to select `null` as an item.

**Why**:

A `null` happens to be a valid item in my use-case.

**How**:

I've updated item existence check in `selectItemAtIndex` to `item === undefined`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A - just a tiny change
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
