### PR TITLE
fixed index highlights in toggle and keydown

### DIFF
--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -269,6 +269,7 @@ test('navigation key down events do nothing when no items are rendered', () => {
     arrowUpInput,
     endOnInput,
     homeOnInput,
+    escapeOnInput,
     childrenSpy,
   } = renderDownshift({items: []})
   const keysOnInput = [arrowDownInput, arrowUpInput, endOnInput, homeOnInput]
@@ -278,6 +279,15 @@ test('navigation key down events do nothing when no items are rendered', () => {
     expect(childrenSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({highlightedIndex: null}),
     )
+    escapeOnInput() // close dropdown after each opening.
+  })
+  // ↓ ↑ end home
+  keysOnInput.forEach(keyOnInput => {
+    keyOnInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({highlightedIndex: null}),
+    )
+    // do not close dropdown, but still there should be no update.
   })
 })
 

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -90,55 +90,145 @@ test('manages arrow up and down behavior', () => {
   )
 })
 
-test('arrow down opens menu and highlights first item by default', () => {
-  const {arrowDownInput, childrenSpy} = renderDownshift()
-  // ↓
-  arrowDownInput()
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({isOpen: true, highlightedIndex: 0}),
-  )
-})
-
-test('arrow up opens menu and highlights last item by default', () => {
-  const {arrowUpInput, childrenSpy} = renderDownshift()
-  // ↑
-  arrowUpInput()
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      isOpen: true,
-      highlightedIndex: colors.length - 1,
-    }),
-  )
-})
-
-test('arrow down opens menu and highlights defaultHighlightedIndex + 1 if provided', () => {
-  const defaultHighlightedIndex = 2
-  const {arrowDownInput, childrenSpy} = renderDownshift({
-    props: {defaultHighlightedIndex},
+describe('arrow down opens menu and highlights item at index', () => {
+  test('0 by default', () => {
+    const {arrowDownInput, childrenSpy} = renderDownshift()
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({isOpen: true, highlightedIndex: 0}),
+    )
   })
-  // ↓
-  arrowDownInput()
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      isOpen: true,
-      highlightedIndex: defaultHighlightedIndex + 1,
-    }),
-  )
+
+  test('initialHighlightedIndex + 1', () => {
+    const initialHighlightedIndex = 3
+    const {arrowDownInput, childrenSpy} = renderDownshift({
+      // provide only highlightedIndex
+      props: {initialHighlightedIndex},
+    })
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: initialHighlightedIndex + 1,
+      }),
+    )
+  })
+
+  test('defaultHighlightedIndex + 1', () => {
+    const defaultHighlightedIndex = 2
+    const {arrowDownInput, childrenSpy} = renderDownshift({
+      // provide only defaultHighlightedIndex
+      props: {defaultHighlightedIndex},
+    })
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: defaultHighlightedIndex + 1,
+      }),
+    )
+  })
+
+  test('initialHighlightedIndex + 1 then defaultHighlightedIndex + 1', () => {
+    const initialHighlightedIndex = 3
+    const defaultHighlightedIndex = 2
+    const {arrowDownInput, escapeOnInput, childrenSpy} = renderDownshift({
+      // provide both initialHighlightedIndex defaultHighlightedIndex
+      props: {defaultHighlightedIndex, initialHighlightedIndex},
+    })
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: initialHighlightedIndex + 1,
+      }),
+    )
+    escapeOnInput()
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: defaultHighlightedIndex + 1,
+      }),
+    )
+  })
 })
 
-test('arrow up opens menu and highlights defaultHighlightedIndex - 1 if provided', () => {
-  const defaultHighlightedIndex = 2
-  const {arrowUpInput, childrenSpy} = renderDownshift({
-    props: {defaultHighlightedIndex},
+describe('arrow up opens menu and highlights item at index', () => {
+  test('length - 1 by default', () => {
+    const {arrowUpInput, childrenSpy} = renderDownshift()
+    // ↑
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: colors.length - 1,
+      }),
+    )
   })
-  // ↑
-  arrowUpInput()
-  expect(childrenSpy).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      isOpen: true,
-      highlightedIndex: defaultHighlightedIndex - 1,
-    }),
-  )
+
+  test('initialHighlightedIndex - 1', () => {
+    const initialHighlightedIndex = 3
+    const {arrowUpInput, childrenSpy} = renderDownshift({
+      // provide only highlightedIndex
+      props: {initialHighlightedIndex},
+    })
+    // ↓
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: initialHighlightedIndex - 1,
+      }),
+    )
+  })
+
+  test('defaultHighlightedIndex - 1', () => {
+    const defaultHighlightedIndex = 2
+    const {arrowUpInput, childrenSpy} = renderDownshift({
+      // provide only defaultHighlightedIndex
+      props: {defaultHighlightedIndex},
+    })
+    // ↓
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: defaultHighlightedIndex - 1,
+      }),
+    )
+  })
+
+  test('initialHighlightedIndex - 1 then defaultHighlightedIndex - 1', () => {
+    const initialHighlightedIndex = 3
+    const defaultHighlightedIndex = 2
+    const {arrowUpInput, escapeOnInput, childrenSpy} = renderDownshift({
+      // provide both initialHighlightedIndex defaultHighlightedIndex
+      props: {defaultHighlightedIndex, initialHighlightedIndex},
+    })
+    // ↓
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: initialHighlightedIndex - 1,
+      }),
+    )
+    escapeOnInput()
+    // ↓
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: defaultHighlightedIndex - 1,
+      }),
+    )
+  })
 })
 
 test('navigation key down events do nothing when no items are rendered', () => {

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -157,6 +157,22 @@ describe('arrow down opens menu and highlights item at index', () => {
       }),
     )
   })
+
+  test('highlightedIndex if controlled', () => {
+    const highlightedIndex = 2
+    const {arrowDownInput, childrenSpy} = renderDownshift({
+      // control highlightedIndex
+      props: {highlightedIndex},
+    })
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex,
+      }),
+    )
+  })
 })
 
 describe('arrow up opens menu and highlights item at index', () => {
@@ -226,6 +242,22 @@ describe('arrow up opens menu and highlights item at index', () => {
       expect.objectContaining({
         isOpen: true,
         highlightedIndex: defaultHighlightedIndex - 1,
+      }),
+    )
+  })
+
+  test('highlightedIndex if controlled', () => {
+    const highlightedIndex = 2
+    const {arrowUpInput, childrenSpy} = renderDownshift({
+      // control highlightedIndex
+      props: {highlightedIndex},
+    })
+    // ↓
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex,
       }),
     )
   })

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -194,7 +194,7 @@ describe('arrow up opens menu and highlights item at index', () => {
       // provide only highlightedIndex
       props: {initialHighlightedIndex},
     })
-    // ↓
+    // ↑
     arrowUpInput()
     expect(childrenSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -210,7 +210,7 @@ describe('arrow up opens menu and highlights item at index', () => {
       // provide only defaultHighlightedIndex
       props: {defaultHighlightedIndex},
     })
-    // ↓
+    // ↑
     arrowUpInput()
     expect(childrenSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -227,7 +227,7 @@ describe('arrow up opens menu and highlights item at index', () => {
       // provide both initialHighlightedIndex defaultHighlightedIndex
       props: {defaultHighlightedIndex, initialHighlightedIndex},
     })
-    // ↓
+    // ↑
     arrowUpInput()
     expect(childrenSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -236,7 +236,7 @@ describe('arrow up opens menu and highlights item at index', () => {
       }),
     )
     escapeOnInput()
-    // ↓
+    // ↑
     arrowUpInput()
     expect(childrenSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -252,7 +252,7 @@ describe('arrow up opens menu and highlights item at index', () => {
       // control highlightedIndex
       props: {highlightedIndex},
     })
-    // ↓
+    // ↑
     arrowUpInput()
     expect(childrenSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -174,6 +174,21 @@ describe('arrow down opens menu and highlights item at index', () => {
     )
   })
 
+  test('0 if defaultHighlightedIndex is out of bounds', () => {
+    const {arrowDownInput, childrenSpy} = renderDownshift({
+      // provide only defaultHighlightedIndex
+      props: {defaultHighlightedIndex: colors.length + 5},
+    })
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: 0,
+      }),
+    )
+  })
+
   test('highlightedIndex if controlled', () => {
     const highlightedIndex = 2
     const {arrowDownInput, childrenSpy} = renderDownshift({
@@ -267,6 +282,21 @@ describe('arrow up opens menu and highlights item at index', () => {
     const {arrowUpInput, childrenSpy} = renderDownshift({
       // provide only defaultHighlightedIndex
       props: {defaultHighlightedIndex},
+    })
+    // ↑
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: colors.length - 1,
+      }),
+    )
+  })
+
+  test('length - 1 if defaultHighlightedIndex is out of bounds', () => {
+    const {arrowUpInput, childrenSpy} = renderDownshift({
+      // provide only defaultHighlightedIndex
+      props: {defaultHighlightedIndex: colors.length + 5},
     })
     // ↑
     arrowUpInput()

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -158,6 +158,22 @@ describe('arrow down opens menu and highlights item at index', () => {
     )
   })
 
+  test('0 if defaultHighlightedIndex is length - 1', () => {
+    const defaultHighlightedIndex = colors.length - 1
+    const {arrowDownInput, childrenSpy} = renderDownshift({
+      // provide only defaultHighlightedIndex
+      props: {defaultHighlightedIndex},
+    })
+    // ↓
+    arrowDownInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: 0,
+      }),
+    )
+  })
+
   test('highlightedIndex if controlled', () => {
     const highlightedIndex = 2
     const {arrowDownInput, childrenSpy} = renderDownshift({
@@ -242,6 +258,22 @@ describe('arrow up opens menu and highlights item at index', () => {
       expect.objectContaining({
         isOpen: true,
         highlightedIndex: defaultHighlightedIndex - 1,
+      }),
+    )
+  })
+
+  test('length - 1 if defaultHighlightedIndex is 0', () => {
+    const defaultHighlightedIndex = 0
+    const {arrowUpInput, childrenSpy} = renderDownshift({
+      // provide only defaultHighlightedIndex
+      props: {defaultHighlightedIndex},
+    })
+    // ↑
+    arrowUpInput()
+    expect(childrenSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        highlightedIndex: colors.length - 1,
       }),
     )
   })

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -136,7 +136,7 @@ describe('arrow down opens menu and highlights item at index', () => {
     const initialHighlightedIndex = 3
     const defaultHighlightedIndex = 2
     const {arrowDownInput, escapeOnInput, childrenSpy} = renderDownshift({
-      // provide both initialHighlightedIndex defaultHighlightedIndex
+      // provide both initialHighlightedIndex and defaultHighlightedIndex
       props: {defaultHighlightedIndex, initialHighlightedIndex},
     })
     // ↓
@@ -161,7 +161,7 @@ describe('arrow down opens menu and highlights item at index', () => {
   test('0 if defaultHighlightedIndex is length - 1', () => {
     const defaultHighlightedIndex = colors.length - 1
     const {arrowDownInput, childrenSpy} = renderDownshift({
-      // provide only defaultHighlightedIndex
+      // provide defaultHighlightedIndex as last in the list.
       props: {defaultHighlightedIndex},
     })
     // ↓
@@ -176,7 +176,7 @@ describe('arrow down opens menu and highlights item at index', () => {
 
   test('0 if defaultHighlightedIndex is out of bounds', () => {
     const {arrowDownInput, childrenSpy} = renderDownshift({
-      // provide only defaultHighlightedIndex
+      // provide defaultHighlightedIndex as invalid
       props: {defaultHighlightedIndex: colors.length + 5},
     })
     // ↓
@@ -222,7 +222,7 @@ describe('arrow up opens menu and highlights item at index', () => {
   test('initialHighlightedIndex - 1', () => {
     const initialHighlightedIndex = 3
     const {arrowUpInput, childrenSpy} = renderDownshift({
-      // provide only highlightedIndex
+      // provide only initialHighlightedIndex
       props: {initialHighlightedIndex},
     })
     // ↑
@@ -255,7 +255,7 @@ describe('arrow up opens menu and highlights item at index', () => {
     const initialHighlightedIndex = 3
     const defaultHighlightedIndex = 2
     const {arrowUpInput, escapeOnInput, childrenSpy} = renderDownshift({
-      // provide both initialHighlightedIndex defaultHighlightedIndex
+      // provide both initialHighlightedIndex and defaultHighlightedIndex
       props: {defaultHighlightedIndex, initialHighlightedIndex},
     })
     // ↑
@@ -280,7 +280,7 @@ describe('arrow up opens menu and highlights item at index', () => {
   test('length - 1 if defaultHighlightedIndex is 0', () => {
     const defaultHighlightedIndex = 0
     const {arrowUpInput, childrenSpy} = renderDownshift({
-      // provide only defaultHighlightedIndex
+      // provide defaultHighlightedIndex as first in the list
       props: {defaultHighlightedIndex},
     })
     // ↑
@@ -295,7 +295,7 @@ describe('arrow up opens menu and highlights item at index', () => {
 
   test('length - 1 if defaultHighlightedIndex is out of bounds', () => {
     const {arrowUpInput, childrenSpy} = renderDownshift({
-      // provide only defaultHighlightedIndex
+      // provide defaultHighlightedIndex as invalid
       props: {defaultHighlightedIndex: colors.length + 5},
     })
     // ↑

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -545,11 +545,9 @@ class Downshift extends Component {
           const itemCount = self.getItemCount()
           if (itemCount > 0) {
             const {highlightedIndex} = self.getState()
-            const newIndex =
-              typeof highlightedIndex === 'number'
-                ? getNextWrappingIndex(1, highlightedIndex, itemCount)
-                : 0
-            self.setHighlightedIndex(newIndex)
+            self.setHighlightedIndex(
+              getNextWrappingIndex(1, highlightedIndex, itemCount),
+            )
           }
         })
       }
@@ -569,11 +567,9 @@ class Downshift extends Component {
           const itemCount = self.getItemCount()
           if (itemCount > 0) {
             const {highlightedIndex} = self.getState()
-            const newIndex =
-              typeof highlightedIndex === 'number'
-                ? getNextWrappingIndex(-1, highlightedIndex, itemCount)
-                : itemCount - 1
-            self.setHighlightedIndex(newIndex)
+            self.setHighlightedIndex(
+              getNextWrappingIndex(-1, highlightedIndex, itemCount),
+            )
           }
         })
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -276,7 +276,11 @@ function isPlainObject(obj) {
 function getNextWrappingIndex(moveAmount, baseIndex, itemCount) {
   const itemsLastIndex = itemCount - 1
 
-  if (baseIndex === null) {
+  if (
+    typeof baseIndex !== 'number' ||
+    baseIndex < 0 ||
+    baseIndex >= itemCount
+  ) {
     baseIndex = moveAmount > 0 ? -1 : itemsLastIndex + 1
   }
   let newIndex = baseIndex + moveAmount

--- a/src/utils.js
+++ b/src/utils.js
@@ -265,13 +265,15 @@ function isPlainObject(obj) {
 }
 
 /**
- * Returns the new index in the list, in a circular way.
+ * Returns the new index in the list, in a circular way. If next value is out of bonds from the total,
+ * it will wrap to either 0 or itemCount - 1.
+ *
  * @param {number} moveAmount Number of positions to move. Negative to move backwards, positive forwards.
  * @param {number} baseIndex The initial position to move from.
  * @param {number} itemCount The total number of items.
  * @returns {number} The new index after the move.
  */
-function getNewIndex(moveAmount, baseIndex, itemCount) {
+function getNextWrappingIndex(moveAmount, baseIndex, itemCount) {
   const itemsLastIndex = itemCount - 1
 
   if (baseIndex === null) {
@@ -305,5 +307,5 @@ export {
   pickState,
   isPlainObject,
   normalizeArrowKey,
-  getNewIndex,
+  getNextWrappingIndex,
 }


### PR DESCRIPTION
**What**:

Fixes item highlights in the case of passing `highlightedIndex`, `defaultHighlightedIndex` and `initialHighlightedIndex`. Handles both toggle and opening by keyDown and keyUp. Also has some code refactoring + unit tests for `getInputProps`. Planning to also add unit tests for `getToggleButtonProps`.


- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->


