### PR TITLE
fix(keyDownHandlers): call setState instead of toggle when opening

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 55310,
-    "minified": 24410,
-    "gzipped": 6717
+    "bundled": 55288,
+    "minified": 24464,
+    "gzipped": 6721
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 53879,
-    "minified": 23260,
-    "gzipped": 6520
+    "bundled": 53857,
+    "minified": 23314,
+    "gzipped": 6524
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 66472,
-    "minified": 22649,
-    "gzipped": 7222
+    "bundled": 66454,
+    "minified": 22673,
+    "gzipped": 7224
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 79245,
-    "minified": 27908,
-    "gzipped": 8581
+    "bundled": 79227,
+    "minified": 27932,
+    "gzipped": 8585
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 71353,
-    "minified": 23943,
-    "gzipped": 7793
+    "bundled": 71335,
+    "minified": 23967,
+    "gzipped": 7795
   },
   "dist/downshift.umd.js": {
-    "bundled": 108644,
-    "minified": 36913,
-    "gzipped": 11344
+    "bundled": 108626,
+    "minified": 36937,
+    "gzipped": 11349
   },
   "dist/downshift.esm.js": {
-    "bundled": 54936,
-    "minified": 24119,
-    "gzipped": 6646,
+    "bundled": 54914,
+    "minified": 24173,
+    "gzipped": 6649,
     "treeshaked": {
       "rollup": {
-        "code": 16998,
+        "code": 17022,
         "import_statements": 354
       },
       "webpack": {
-        "code": 18295
+        "code": 18319
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 53525,
-    "minified": 22984,
-    "gzipped": 6450,
+    "bundled": 53503,
+    "minified": 23038,
+    "gzipped": 6454,
     "treeshaked": {
       "rollup": {
-        "code": 16988,
+        "code": 17012,
         "import_statements": 336
       },
       "webpack": {
-        "code": 18250
+        "code": 18274
       }
     }
   }

--- a/src/__tests__/downshift.get-button-props.js
+++ b/src/__tests__/downshift.get-button-props.js
@@ -59,6 +59,15 @@ test('on button blur does not reset the state when the mouse is down', () => {
   expect(childrenSpy).not.toHaveBeenCalled()
 })
 
+test('on open it will highlight item if state has highlightedIndex', () => {
+  const highlightedIndex = 4
+  const {button, childrenSpy} = setup({props: {highlightedIndex}})
+  fireEvent.click(button)
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({highlightedIndex}),
+  )
+})
+
 test('getToggleButtonProps returns all given props', () => {
   const buttonProps = {'data-foo': 'bar'}
   const Button = jest.fn(props => <button {...props} />)
@@ -113,17 +122,24 @@ describe('Expect timer to trigger on process.env.NODE_ENV !== test value', () =>
   })
 })
 
-function setup({buttonProps, Button = props => <button {...props} />} = {}) {
+function setup({
+  buttonProps,
+  props,
+  Button = propsArg => <button {...propsArg} />,
+} = {}) {
   let renderArg
   const childrenSpy = jest.fn(controllerArg => {
     renderArg = controllerArg
     return (
       <div>
+        {/* Added items to test toggleMenu with highlight. */}
+        <div {...controllerArg.getItemProps({item: 'test item', index: 0})} />
+        <div {...controllerArg.getItemProps({item: 'test item2', index: 1})} />
         <Button {...controllerArg.getToggleButtonProps(buttonProps)} />
       </div>
     )
   })
-  const utils = render(<Downshift>{childrenSpy}</Downshift>)
+  const utils = render(<Downshift {...props}>{childrenSpy}</Downshift>)
   const button = utils.container.querySelector('button')
   return {...utils, button, childrenSpy, ...renderArg}
 }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -540,16 +540,25 @@ class Downshift extends Component {
           type: stateChangeTypes.keyDownArrowDown,
         })
       } else {
-        const self = this
-        this.toggleMenu({type: stateChangeTypes.keyDownArrowDown}, () => {
-          const itemCount = self.getItemCount()
-          if (itemCount > 0) {
-            const {highlightedIndex} = self.getState()
-            self.setHighlightedIndex(
-              getNextWrappingIndex(1, highlightedIndex, itemCount),
-            )
-          }
-        })
+        this.internalSetState(
+          {
+            isOpen: true,
+            type: stateChangeTypes.keyDownArrowDown,
+          },
+          () => {
+            const itemCount = this.getItemCount()
+            if (itemCount > 0) {
+              this.setHighlightedIndex(
+                getNextWrappingIndex(
+                  1,
+                  this.getState().highlightedIndex,
+                  itemCount,
+                ),
+                {type: stateChangeTypes.keyDownArrowDown},
+              )
+            }
+          },
+        )
       }
     },
 
@@ -562,16 +571,25 @@ class Downshift extends Component {
           type: stateChangeTypes.keyDownArrowUp,
         })
       } else {
-        const self = this
-        this.toggleMenu({type: stateChangeTypes.keyDownArrowUp}, () => {
-          const itemCount = self.getItemCount()
-          if (itemCount > 0) {
-            const {highlightedIndex} = self.getState()
-            self.setHighlightedIndex(
-              getNextWrappingIndex(-1, highlightedIndex, itemCount),
-            )
-          }
-        })
+        this.internalSetState(
+          {
+            isOpen: true,
+            type: stateChangeTypes.keyDownArrowUp,
+          },
+          () => {
+            const itemCount = this.getItemCount()
+            if (itemCount > 0) {
+              this.setHighlightedIndex(
+                getNextWrappingIndex(
+                  -1,
+                  this.getState().highlightedIndex,
+                  itemCount,
+                ),
+                {type: stateChangeTypes.keyDownArrowDown},
+              )
+            }
+          },
+        )
       }
     },
 


### PR DESCRIPTION
I really hope this is the final version for this area. Previously I used `toggleMenu` when opening by arrow keys but that implied two calls for `setHighlightedIndex` which was not necessary.