### PR TITLE
fix(lint): change jest method that is breaking the build

### DIFF
--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -584,21 +584,31 @@ test(`getInputProps doesn't include event handlers when disabled is passed (for 
 })
 
 test('highlightedIndex is reset to defaultHighlightedIndex when inputValue changes', () => {
-  const DEFAULT_HIGHLIGHTED_INDEX = 0
-  const props = {defaultHighlightedIndex: DEFAULT_HIGHLIGHTED_INDEX}
+  const defaultHighlightedIndex = 0
   const {childrenSpy, arrowDownInput, changeInputValue} = renderDownshift({
-    props,
+    props: {defaultHighlightedIndex},
   })
 
   childrenSpy.mockClear()
-
   arrowDownInput() // highlightedIndex = 1
+  changeInputValue('r')
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      highlightedIndex: defaultHighlightedIndex,
+    }),
+  )
+})
 
+test('highlight should be removed on inputValue change if defaultHighlightedIndex is not provided', () => {
+  const {childrenSpy, arrowDownInput, changeInputValue} = renderDownshift()
+
+  childrenSpy.mockClear()
+  arrowDownInput() // highlightedIndex = 1
   changeInputValue('r')
 
   expect(childrenSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      highlightedIndex: DEFAULT_HIGHLIGHTED_INDEX,
+      highlightedIndex: null,
     }),
   )
 })

--- a/src/__tests__/downshift.misc-with-utils-mocked.js
+++ b/src/__tests__/downshift.misc-with-utils-mocked.js
@@ -44,5 +44,5 @@ test('does not scroll from an onMouseMove event', () => {
   // now let's make sure that we can still scroll items into view
   // ↓
   fireEvent.keyDown(input, {key: 'ArrowDown'})
-  expect(scrollIntoView).toHaveBeenCalled()
+  expect(scrollIntoView).toHaveBeenCalledWith(item, undefined)
 })


### PR DESCRIPTION
Fixes: 
`[lint]   47:26  error  Prefer toHaveBeenCalledWith(/* expected args */)  jest/prefer-called-with`