### PR TITLE
feat(a11yStatus): add preventA11yStatusMessage prop

### DIFF
--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -6,6 +6,10 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import {render} from 'react-testing-library'
 import Downshift from '../'
+import setA11yStatus from '../set-a11y-status'
+
+jest.mock('../set-a11y-status')
+jest.useFakeTimers()
 
 beforeEach(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
 afterEach(() => console.error.mockRestore())
@@ -201,6 +205,34 @@ test('initializes with the initial* props', () => {
       selectedItem: initialState.initialSelectedItem,
     }),
   )
+})
+
+describe('updateA11yStatus', () => {
+  test('is called with getA11yStatusMessage function at open', () => {
+    const getA11yStatusMessageMock = jest.fn(() => 'test message')
+    const {openMenu} = setup({
+      getA11yStatusMessage: getA11yStatusMessageMock,
+    })
+
+    openMenu()
+    jest.runAllTimers()
+
+    expect(setA11yStatus).toHaveBeenCalledTimes(1)
+    expect(setA11yStatus).toHaveBeenCalledWith('test message')
+    expect(getA11yStatusMessageMock).toHaveBeenCalledTimes(1)
+    setA11yStatus.mockReset()
+  })
+
+  test('is not called if preventA11yStatusMessage prop is passed', () => {
+    const {openMenu} = setup({
+      preventA11yStatusMessage: true,
+    })
+
+    openMenu()
+    jest.runAllTimers()
+
+    expect(setA11yStatus).not.toHaveBeenCalled()
+  })
 })
 
 function setup({children = () => <div />, ...props} = {}) {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -36,6 +36,7 @@ class Downshift extends Component {
     initialInputValue: PropTypes.string,
     initialIsOpen: PropTypes.bool,
     getA11yStatusMessage: PropTypes.func,
+    preventA11yStatusMessage: PropTypes.bool,
     itemToString: PropTypes.func,
     onChange: PropTypes.func,
     onSelect: PropTypes.func,
@@ -996,7 +997,7 @@ class Downshift extends Component {
     this.internalSetState({isOpen: false}, cb)
   }
 
-  updateStatus = debounce(() => {
+  updateA11yStatus = debounce(() => {
     const state = this.getState()
     const item = this.items[state.highlightedIndex]
     const resultCount = this.getItemCount()
@@ -1096,7 +1097,7 @@ class Downshift extends Component {
 
       this.cleanup = () => {
         this.internalClearTimeouts()
-        this.updateStatus.cancel()
+        this.updateA11yStatus.cancel()
         this.props.environment.removeEventListener('mousedown', onMouseDown)
         this.props.environment.removeEventListener('mouseup', onMouseUp)
         this.props.environment.removeEventListener('touchstart', onTouchStart)
@@ -1150,8 +1151,8 @@ class Downshift extends Component {
     }
 
     /* istanbul ignore else (react-native) */
-    if (!isReactNative) {
-      this.updateStatus()
+    if (!this.props.preventA11yStatusMessage && !isReactNative) {
+      this.updateA11yStatus()
     }
   }
 


### PR DESCRIPTION
**What**:

Adds `preventA11yStatusMessage` prop to Downshift.

Closes https://github.com/downshift-js/downshift/issues/694.

**Why**:

In case a user wants to prevent our a11y message generation, he should be able to do so by supplying this prop.

**How**:

Added prop to the list of props. Still remains to be added: documentation.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
