### PR TITLE
fix(set-a11y-status): perform cleanup after setting a status

### DIFF
--- a/src/__tests__/__snapshots__/set-a11y-status.js.snap
+++ b/src/__tests__/__snapshots__/set-a11y-status.js.snap
@@ -1,21 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`clears statuses when a change appears 1`] = `
-<div
-  aria-live="polite"
-  aria-relevant="additions text"
-  id="a11y-status-message"
-  role="status"
-  style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
->
-  <div
-    style="display: block;"
-  >
-    goodbye
-  </div>
-</div>
-`;
-
 exports[`does add anything for an empty string 1`] = `
 <div
   aria-live="polite"
@@ -34,15 +18,21 @@ exports[`escapes HTML 1`] = `
   role="status"
   style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
 >
-  <div
-    style="display: block;"
-  >
-    &lt;script&gt;alert("!!!")&lt;/script&gt;
-  </div>
+  &lt;script&gt;alert("!!!")&lt;/script&gt;
 </div>
 `;
 
-exports[`repeat statuses get appended as children 1`] = `
+exports[`performs cleanup after a timeout 1`] = `
+<div
+  aria-live="polite"
+  aria-relevant="additions text"
+  id="a11y-status-message"
+  role="status"
+  style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
+/>
+`;
+
+exports[`replaces the status with a different one 1`] = `
 <div
   aria-live="polite"
   aria-relevant="additions text"
@@ -50,21 +40,7 @@ exports[`repeat statuses get appended as children 1`] = `
   role="status"
   style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
 >
-  <div
-    style="display: none;"
-  >
-    hello
-  </div>
-  <div
-    style="display: none;"
-  >
-    hello
-  </div>
-  <div
-    style="display: block;"
-  >
-    hello
-  </div>
+  goodbye
 </div>
 `;
 
@@ -76,10 +52,6 @@ exports[`sets the status 1`] = `
   role="status"
   style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
 >
-  <div
-    style="display: block;"
-  >
-    hello
-  </div>
+  hello
 </div>
 `;

--- a/src/__tests__/set-a11y-status.js
+++ b/src/__tests__/set-a11y-status.js
@@ -1,3 +1,5 @@
+jest.useFakeTimers()
+
 beforeEach(() => {
   document.body.innerHTML = ''
 })
@@ -8,18 +10,8 @@ test('sets the status', () => {
   expect(document.body.firstChild).toMatchSnapshot()
 })
 
-test('repeat statuses get appended as children', () => {
+test('replaces the status with a different one', () => {
   const setA11yStatus = setup()
-  setA11yStatus('hello')
-  setA11yStatus('hello')
-  setA11yStatus('hello')
-  expect(document.body.firstChild).toMatchSnapshot()
-})
-
-test('clears statuses when a change appears', () => {
-  const setA11yStatus = setup()
-  setA11yStatus('hello')
-  setA11yStatus('hello')
   setA11yStatus('hello')
   setA11yStatus('goodbye')
   expect(document.body.firstChild).toMatchSnapshot()
@@ -34,6 +26,13 @@ test('does add anything for an empty string', () => {
 test('escapes HTML', () => {
   const setA11yStatus = setup()
   setA11yStatus('<script>alert("!!!")</script>')
+  expect(document.body.firstChild).toMatchSnapshot()
+})
+
+test('performs cleanup after a timeout', () => {
+  const setA11yStatus = setup()
+  setA11yStatus('hello')
+  jest.runAllTimers()
   expect(document.body.firstChild).toMatchSnapshot()
 })
 

--- a/src/set-a11y-status.js
+++ b/src/set-a11y-status.js
@@ -4,43 +4,27 @@ let statusDiv =
     ? null
     : document.getElementById('a11y-status-message')
 
-let statuses = []
+let cleanupTimerID
 
 /**
  * @param {String} status the status message
  */
 function setStatus(status) {
-  const isSameAsLast = statuses[statuses.length - 1] === status
-  if (isSameAsLast) {
-    statuses = [...statuses, status]
-  } else {
-    statuses = [status]
-  }
   const div = getStatusDiv()
-
-  // Remove previous children
-  while (div.lastChild) {
-    div.removeChild(div.firstChild)
+  if (!status) {
+    return
+  }
+  if (cleanupTimerID) {
+    clearTimeout(cleanupTimerID)
+    cleanupTimerID = null
   }
 
-  statuses.filter(Boolean).forEach((statusItem, index) => {
-    div.appendChild(getStatusChildDiv(statusItem, index))
-  })
-}
+  div.textContent = status
 
-/**
- * @param {String} status the status message
- * @param {Number} index the index
- * @return {HTMLElement} the child node
- */
-function getStatusChildDiv(status, index) {
-  const display = index === statuses.length - 1 ? 'block' : 'none'
-
-  const childDiv = document.createElement('div')
-  childDiv.style.display = display
-  childDiv.textContent = status
-
-  return childDiv
+  cleanupTimerID = setTimeout(() => {
+    div.textContent = ''
+    cleanupTimerID = null
+  }, 500)
 }
 
 /**


### PR DESCRIPTION
**What**:

Stops appending status messages and performs cleanup after setting them.

**Why**:

Screen reader will not re-narrate if we use this trick. Tried it also in the JQuery https://jqueryui.com/autocomplete/ implementation and if you append two or more statuses that are the same, one after another, they will not be re-narrated.

Cleans up after a timeout so that when users use Virtual Cursor from screen readers they will not bump into this status message, which would be confusing for them.

**How**:

Refactored the `setStatus` function to append text on top of the existing one. Also created a setTimeout for cleanup. If there will be a text overlapping over existing one, the clean up callback from the previous will be cleared.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
