### PR TITLE
Adding tests supporting function refs

### DIFF
--- a/src/__tests__/downshift.get-menu-props.js
+++ b/src/__tests__/downshift.get-menu-props.js
@@ -6,6 +6,7 @@ beforeEach(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
 afterEach(() => console.error.mockRestore())
 
 const Menu = ({innerRef, ...rest}) => <div ref={innerRef} {...rest} />
+const RefMenu = React.forwardRef((props, ref) => <div ref={ref} {...props} />)
 
 test('using a composite component and calling getMenuProps without a refKey results in an error', () => {
   const MyComponent = () => (
@@ -111,4 +112,30 @@ test('renders fine when rendering a composite component and applying getMenuProp
   )
   render(<MyComponent />)
   expect(console.error.mock.calls).toHaveLength(0)
+})
+
+test('has access to element when a ref function is passed to getMenuProps', () => {
+  const ref = {current: null}
+
+  const MyComponent = () => {
+    return (
+      <Downshift
+        children={({getMenuProps}) => (
+          <div>
+            <RefMenu
+              {...getMenuProps({
+                ref: e => {
+                  ref.current = e
+                },
+              })}
+            />
+          </div>
+        )}
+      />
+    )
+  }
+
+  render(<MyComponent />)
+  expect(ref.current).not.toBeNull()
+  expect(ref.current).toBeInstanceOf(HTMLDivElement)
 })


### PR DESCRIPTION
**What**: Adding test to show how a `ref` can be passed as a function to `getMenuProps`. 

**Why**: Docs are not clear about this feature. This is particularly useful when you need access to the menu element for positioning purposes using `getBoundingClientRect`.

**How**: Change exists already -- just adding a test to highlight the feature.

**Checklist**: Maybe?

- [ ] Documentation - N/A
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table
