### PR TITLE
Update docs to mention onChange can be called with null

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ const items = [
 
 render(
   <Downshift
-    onChange={selection => alert(`You selected ${selection.value}`)}
+    onChange={selection => alert(
+      selection ? `You selected ${selection.value}` : 'Selection Cleared'
+    )}
     itemToString={item => (item ? item.value : '')}
   >
     {({
@@ -221,11 +223,9 @@ compute the `inputValue`).
 > `function(selectedItem: any, stateAndHelpers: object)` | optional, no useful
 > default
 
-Called when the user selects an item and the selected item has changed. Called
-with the item that was selected and the new state of `downshift`. (see
-`onStateChange` for more info on `stateAndHelpers`).
+Called when the selected item changes, either by the user selecting an item or the user clearing the selection. Called with the item that was selected or `null` and the new state of `downshift`. (see `onStateChange` for more info on `stateAndHelpers`).
 
-- `selectedItem`: The item that was just selected
+- `selectedItem`: The item that was just selected. `null` if the selection was cleared.
 - `stateAndHelpers`: This is the same thing your `children` function is
   called with (see [Children Function](#children-function))
 


### PR DESCRIPTION

Closes #719

**What**:

Update docs to mention onChange can be called with null when selection is cleared.

**Why**:

As discussed in #719, version 3.2.10 changed the behavior of the escape key to clear the selection and call onChange with null. This updates the docs to make that clear.

**Checklist**:

- [X] Documentation
- [ ] Tests N/A
- [X] Ready to be merged

PR in downshift-examples already merged: https://github.com/kentcdodds/downshift-examples/pull/15

I think we'll also want to update the [Try it out in the browser](https://codesandbox.io/s/6z67jvklw3) link in the README, but I'm not sure how to go about updating it.