### PR TITLE
docs(usage): change the usage codesandbox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ npm install --save downshift
 
 ## Usage
 
-> [Try it out in the browser](https://codesandbox.io/s/6z67jvklw3)
+> [Try it out in the browser](https://codesandbox.io/s/n9095)
 
 ```jsx
 import React from 'react'


### PR DESCRIPTION
Follow up on https://github.com/downshift-js/downshift/pull/721.

Forked the previous example from codesandbox, applied the new way to use `onChange`, and used that as the link from 'Try it yourself'.

@TLadd is it working now?