### PR TITLE
Add type definitions for scrollIntoView prop

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -70,6 +70,7 @@ export interface DownshiftProps<Item> {
   getItemId?: (index?: number) => string
   environment?: Environment
   onOuterClick?: (stateAndHelpers: ControllerStateAndHelpers<Item>) => void
+  scrollIntoView?: (node: HTMLElement, menuNode: HTMLElement) => void
   onUserAction?: (
     options: StateChangeOptions<Item>,
     stateAndHelpers: ControllerStateAndHelpers<Item>,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added a type definition for the `scrollIntoView` prop.

<!-- Why are these changes necessary? -->

**Why**:

While the docs describe the type signature of `scrollIntoView`, not having it in the typings file makes TypeScript fail when using this prop.

<!-- How were these changes implemented? -->

**How**:

Added a new key with type definitions to the `DownshiftProps` definition in `typings`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Also, big thanks to everyone that maintains this library, using downshift has  made my life a _ton_ easier so very happy to give back a little 😎