### PR TITLE
fix: environment undefined in props on cleanup

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1083,21 +1083,22 @@ class Downshift extends Component {
           )
         }
       }
+      const {environment} = this.props
 
-      this.props.environment.addEventListener('mousedown', onMouseDown)
-      this.props.environment.addEventListener('mouseup', onMouseUp)
-      this.props.environment.addEventListener('touchstart', onTouchStart)
-      this.props.environment.addEventListener('touchmove', onTouchMove)
-      this.props.environment.addEventListener('touchend', onTouchEnd)
+      environment.addEventListener('mousedown', onMouseDown)
+      environment.addEventListener('mouseup', onMouseUp)
+      environment.addEventListener('touchstart', onTouchStart)
+      environment.addEventListener('touchmove', onTouchMove)
+      environment.addEventListener('touchend', onTouchEnd)
 
       this.cleanup = () => {
         this.internalClearTimeouts()
         this.updateStatus.cancel()
-        this.props.environment.removeEventListener('mousedown', onMouseDown)
-        this.props.environment.removeEventListener('mouseup', onMouseUp)
-        this.props.environment.removeEventListener('touchstart', onTouchStart)
-        this.props.environment.removeEventListener('touchmove', onTouchMove)
-        this.props.environment.removeEventListener('touchend', onTouchEnd)
+        environment.removeEventListener('mousedown', onMouseDown)
+        environment.removeEventListener('mouseup', onMouseUp)
+        environment.removeEventListener('touchstart', onTouchStart)
+        environment.removeEventListener('touchmove', onTouchMove)
+        environment.removeEventListener('touchend', onTouchEnd)
       }
     }
   }


### PR DESCRIPTION
**What**:

Fixes environment being `undefined` on `this.props` on cleanup

**Why**:

Closes #725

**How**:

Destructure `environment` from `this.props` before cleanup so we have access to it in the cleanup. This is one reason why hooks are awesome. Because they do this by default.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
