### PR TITLE
Simplify TS typings

### DIFF
--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
-import Downshift, {StateChangeOptions, DownshiftInterface} from '../'
+import Downshift, {StateChangeOptions} from '../'
 
 type Item = string
-const TypedDownShift: DownshiftInterface<Item> = Downshift
 
 interface Props {}
 
@@ -27,7 +26,7 @@ export default class App extends React.Component<Props, State> {
     const items = this.state.items
 
     return (
-      <TypedDownShift onChange={this.onChange}>
+      <Downshift onChange={this.onChange}>
         {({
           getToggleButtonProps,
           getInputProps,
@@ -69,7 +68,7 @@ export default class App extends React.Component<Props, State> {
             ) : null}
           </div>
         )}
-      </TypedDownShift>
+      </Downshift>
     )
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -203,10 +203,10 @@ export type ChildrenFunction<Item> = (
   options: ControllerStateAndHelpers<Item>,
 ) => React.ReactNode
 
-export type DownshiftInterface<Item> = React.ComponentClass<
+export default class Downshift<Item = any> extends React.Component<
   DownshiftProps<Item>
-> & {
-  stateChangeTypes: {
+> {
+  static stateChangeTypes: {
     unknown: StateChangeTypes.unknown
     mouseUp: StateChangeTypes.mouseUp
     itemMouseEnter: StateChangeTypes.itemMouseEnter
@@ -225,6 +225,4 @@ export type DownshiftInterface<Item> = React.ComponentClass<
   }
 }
 
-declare const Downshift: DownshiftInterface<any>
-export default Downshift
 export function resetIdCounter(): void


### PR DESCRIPTION
This simplifies TypeScript typings and allows to use `Downshift` instance with generic parameter.

It's possibly a breaking change, because I've removed `DownshiftInterface` as it's no longer needed.

Fixes #693 


**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table
