### PR TITLE
fix(highlight): Not allowing the highlight index to go to disabled items

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -26,8 +26,8 @@
   },
   "dist/downshift.umd.js": {
     "bundled": 108577,
-    "minified": 36895,
-    "gzipped": 11395
+    "minified": 36883,
+    "gzipped": 11392
   },
   "dist/downshift.esm.js": {
     "bundled": 54113,

--- a/docs/tests/combobox.js
+++ b/docs/tests/combobox.js
@@ -79,10 +79,12 @@ class Combobox extends Component {
                       {...getItemProps({
                         'data-testid': `downshift-item-${index}`,
                         item,
+                        disabled: item === 'Black',
                         style: {
                           backgroundColor:
                             highlightedIndex === index ? 'lightgray' : null,
                           fontWeight: selectedItem === item ? 'bold' : null,
+                          color: item === 'Black' ? 'lightgray' : null,
                         },
                       })}
                     >

--- a/src/__tests__/downshift.get-item-props.js
+++ b/src/__tests__/downshift.get-item-props.js
@@ -177,6 +177,51 @@ test(`disabled item can't be selected by pressing enter`, () => {
   expect(input.value).toBe('c')
 })
 
+test(`disabled item can't be highlighted when navigating via keyDown`, () => {
+  const items = [
+    {item: 'Chess', disabled: true},
+    {item: 'Dominion', disabled: true},
+    {item: 'Checkers'},
+  ]
+  const utils = renderDownshift({items})
+  const {input, arrowDownInput, enterOnInput} = utils
+
+  const firstItem = utils.queryByTestId('item-0')
+  expect(firstItem.hasAttribute('disabled')).toBe(true)
+  const secondItem = utils.queryByTestId('item-1')
+  expect(secondItem.hasAttribute('disabled')).toBe(true)
+
+  // ↓
+  arrowDownInput()
+  // ↓ (should skip the first and second option)
+  // ENTER to select
+  enterOnInput()
+  // item was not selected -> input value should still be 'c'
+  expect(input.value).toBe('Checkers')
+})
+
+test(`disabled item can't be highlighted when navigating via keyUp`, () => {
+  const items = [
+    {item: 'Chess', disabled: true},
+    {item: 'Dominion'},
+    {item: 'Checkers', disabled: true},
+  ]
+  const utils = renderDownshift({items})
+  const {input, arrowUpInput, enterOnInput} = utils
+
+  const firstItem = utils.queryByTestId('item-0')
+  expect(firstItem.hasAttribute('disabled')).toBe(true)
+  const thirdItem = utils.queryByTestId('item-2')
+  expect(thirdItem.hasAttribute('disabled')).toBe(true)
+
+  // ↑
+  arrowUpInput()
+  // ENTER to select
+  enterOnInput()
+  // item was not selected -> input value should still be 'c'
+  expect(input.value).toBe('Dominion')
+})
+
 function renderDownshift({
   items = [{item: 'Chess'}, {item: 'Dominion'}, {item: 'Checkers'}],
   props,

--- a/src/utils.js
+++ b/src/utils.js
@@ -271,9 +271,15 @@ function isPlainObject(obj) {
  * @param {number} moveAmount Number of positions to move. Negative to move backwards, positive forwards.
  * @param {number} baseIndex The initial position to move from.
  * @param {number} itemCount The total number of items.
+ * @param {Function} isItemDisabledAtIndex Method to check to see if the item is disabled
  * @returns {number} The new index after the move.
  */
-function getNextWrappingIndex(moveAmount, baseIndex, itemCount) {
+function getNextWrappingIndex(
+  moveAmount,
+  baseIndex,
+  itemCount,
+  isItemDisabledAtIndex,
+) {
   const itemsLastIndex = itemCount - 1
 
   if (
@@ -289,6 +295,16 @@ function getNextWrappingIndex(moveAmount, baseIndex, itemCount) {
   } else if (newIndex > itemsLastIndex) {
     newIndex = 0
   }
+
+  if (isItemDisabledAtIndex(newIndex)) {
+    return getNextWrappingIndex(
+      moveAmount,
+      baseIndex + (moveAmount < 0 ? -1 : 1),
+      itemCount,
+      isItemDisabledAtIndex,
+    )
+  }
+
   return newIndex
 }
 


### PR DESCRIPTION
Fixes: https://github.com/downshift-js/downshift/issues/728

**What**: Keyboard navigation still highlights items that are disabled

**Why**: Stop keyboard navigation from incorrectly highlighting disabled items

**How**: Add a check to recursively move if the item is disabled. Add checks to make sure if all items are disabled that there is a safe out.

**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
- [ ] Added myself to contributors table

Looking for feedback for this fix. Will clean everything up and write more tests if I am on the right path.
