### PR TITLE
fix(set-a11y-status): pass props.environment.document to getStatusDiv

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 54534,
-    "minified": 24063,
-    "gzipped": 6608
+    "bundled": 54715,
+    "minified": 24026,
+    "gzipped": 6601
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 53103,
-    "minified": 22913,
-    "gzipped": 6412
+    "bundled": 53284,
+    "minified": 22876,
+    "gzipped": 6404
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 65905,
-    "minified": 22489,
-    "gzipped": 7187
-  },
-  "preact/dist/downshift.umd.js": {
-    "bundled": 79226,
-    "minified": 27917,
-    "gzipped": 8621
+    "bundled": 66096,
+    "minified": 22452,
+    "gzipped": 7177
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 70784,
-    "minified": 23902,
-    "gzipped": 7808
+    "bundled": 70975,
+    "minified": 23865,
+    "gzipped": 7798
+  },
+  "preact/dist/downshift.umd.js": {
+    "bundled": 79417,
+    "minified": 27880,
+    "gzipped": 8612
   },
   "dist/downshift.umd.js": {
-    "bundled": 108626,
-    "minified": 36909,
-    "gzipped": 11373
+    "bundled": 108817,
+    "minified": 36872,
+    "gzipped": 11363
   },
   "dist/downshift.esm.js": {
-    "bundled": 54160,
-    "minified": 23772,
-    "gzipped": 6534,
+    "bundled": 54341,
+    "minified": 23735,
+    "gzipped": 6525,
     "treeshaked": {
       "rollup": {
-        "code": 373,
+        "code": 296,
         "import_statements": 296
       },
       "webpack": {
-        "code": 17964
+        "code": 17927
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 52749,
-    "minified": 22637,
-    "gzipped": 6339,
+    "bundled": 52930,
+    "minified": 22600,
+    "gzipped": 6332,
     "treeshaked": {
       "rollup": {
-        "code": 355,
+        "code": 278,
         "import_statements": 278
       },
       "webpack": {
-        "code": 17919
+        "code": 17882
       }
     }
   }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1005,7 +1005,7 @@ class Downshift extends Component {
     })
     this.previousResultCount = resultCount
 
-    setA11yStatus(status)
+    setA11yStatus(status, this.props.environment.document)
   }, 200)
 
   componentDidMount() {

--- a/src/set-a11y-status.js
+++ b/src/set-a11y-status.js
@@ -1,10 +1,6 @@
 import {debounce} from './utils'
 
-// istanbul ignore next
-let statusDiv =
-  typeof document === 'undefined'
-    ? null
-    : document.getElementById('a11y-status-message')
+let statusDiv
 
 const cleanupStatus = debounce(() => {
   getStatusDiv().textContent = ''
@@ -12,9 +8,10 @@ const cleanupStatus = debounce(() => {
 
 /**
  * @param {String} status the status message
+ * @param {Object} documentProp document passed by the user.
  */
-function setStatus(status) {
-  const div = getStatusDiv()
+function setStatus(status, documentProp) {
+  const div = getStatusDiv(documentProp)
   if (!status) {
     return
   }
@@ -24,14 +21,16 @@ function setStatus(status) {
 }
 
 /**
- * Get the status node or create it if it does not already exist
- * @return {HTMLElement} the status node
+ * Get the status node or create it if it does not already exist.
+ * @param {Object} documentProp document passed by the user.
+ * @return {HTMLElement} the status node.
  */
-function getStatusDiv() {
+function getStatusDiv(documentProp = document) {
   if (statusDiv) {
     return statusDiv
   }
-  statusDiv = document.createElement('div')
+
+  statusDiv = documentProp.createElement('div')
   statusDiv.setAttribute('id', 'a11y-status-message')
   statusDiv.setAttribute('role', 'status')
   statusDiv.setAttribute('aria-live', 'polite')
@@ -46,7 +45,7 @@ function getStatusDiv() {
     position: 'absolute',
     width: '1px',
   })
-  document.body.appendChild(statusDiv)
+  documentProp.body.appendChild(statusDiv)
   return statusDiv
 }
 


### PR DESCRIPTION
Downshift already supports getting `environment` as prop and uses it throughout the component. It should also be passed to set-a11y-status `setStatus` so that it will be used to create the status div in the correct `document`.