### PR TITLE
fix(rollup): imports and revert added namedExports

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 81684,
-    "minified": 37987,
-    "gzipped": 9530
+    "bundled": 81341,
+    "minified": 37651,
+    "gzipped": 9471
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 79932,
-    "minified": 36516,
-    "gzipped": 9354
+    "bundled": 79966,
+    "minified": 36550,
+    "gzipped": 9356
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 101249,
-    "minified": 35121,
-    "gzipped": 11501
+    "bundled": 101318,
+    "minified": 35173,
+    "gzipped": 11515
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 115089,
-    "minified": 41092,
-    "gzipped": 13013
+    "bundled": 115158,
+    "minified": 41144,
+    "gzipped": 13029
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 106251,
-    "minified": 36447,
-    "gzipped": 12109
+    "bundled": 106042,
+    "minified": 36525,
+    "gzipped": 12082
   },
   "dist/downshift.umd.js": {
-    "bundled": 144612,
-    "minified": 49969,
-    "gzipped": 15728
+    "bundled": 144403,
+    "minified": 50045,
+    "gzipped": 15663
   },
   "dist/downshift.esm.js": {
-    "bundled": 80934,
-    "minified": 37317,
-    "gzipped": 9452,
+    "bundled": 80879,
+    "minified": 37277,
+    "gzipped": 9393,
     "treeshaked": {
       "rollup": {
-        "code": 533,
-        "import_statements": 420
+        "code": 673,
+        "import_statements": 347
       },
       "webpack": {
-        "code": 27255
+        "code": 27308
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 79215,
-    "minified": 35872,
-    "gzipped": 9265,
+    "bundled": 79504,
+    "minified": 36176,
+    "gzipped": 9274,
     "treeshaked": {
       "rollup": {
-        "code": 534,
-        "import_statements": 421
+        "code": 674,
+        "import_statements": 348
       },
       "webpack": {
-        "code": 27264
+        "code": 27317
       }
     }
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,18 +8,6 @@ config.plugins[cjsPluginIndex] = commonjs({
   include: 'node_modules/**',
   namedExports: {
     'react-is': ['isForwardRef'],
-    react: ['useReducer', 'useEffect', 'useRef', 'useState'],
-    'node_modules/keyboard-key/src/keyboardKey.js': ['getKey'],
-    'prop-types': [
-      'func',
-      'string',
-      'any',
-      'bool',
-      'number',
-      'array',
-      'checkPropTypes',
-      'shape',
-    ],
   },
 })
 

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -1,4 +1,4 @@
-import * as keyboardKey from 'keyboard-key'
+import keyboardKey from 'keyboard-key'
 import {fireEvent, cleanup} from '@testing-library/react'
 import {act} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-disabled-tests */
-import * as keyboardKey from 'keyboard-key'
+import keyboardKey from 'keyboard-key'
 import {act as rtlAct} from '@testing-library/react-hooks'
 import {act} from 'react-dom/test-utils'
 import {fireEvent, cleanup} from '@testing-library/react'

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-disabled-tests */
-import * as keyboardKey from 'keyboard-key'
+import keyboardKey from 'keyboard-key'
 import {fireEvent, cleanup} from '@testing-library/react'
 import {act as rtlAct} from '@testing-library/react-hooks'
 import {act} from 'react-dom/test-utils'

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -1,6 +1,6 @@
 import {act} from 'react-dom/test-utils'
 import {renderHook} from '@testing-library/react-hooks'
-import * as keyboardKey from 'keyboard-key'
+import keyboardKey from 'keyboard-key'
 import {fireEvent, cleanup} from '@testing-library/react'
 import {setup, dataTestIds, items, defaultIds} from '../testUtils'
 import useSelect from '..'

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-statements */
 import {useReducer, useRef, useEffect} from 'react'
-import * as keyboardKey from 'keyboard-key'
+import keyboardKey from 'keyboard-key'
 import {useId} from '@reach/auto-id'
 import {
   getElementIds,

--- a/src/hooks/useSelect/utils.js
+++ b/src/hooks/useSelect/utils.js
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types'
+import PropTypes from 'prop-types'
 import {getNextWrappingIndex} from '../utils'
 
 const defaultStateValues = {

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types'
+import PropTypes from 'prop-types'
 
 function getElementIds(
   generateDefaultId,


### PR DESCRIPTION
replaced `import * as X` with `import X from`. Also reverted added rollup named exports added by https://github.com/downshift-js/downshift/pull/747