### PR TITLE
fix(TS): correct TypeScript typings for useSelect

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -265,25 +265,25 @@ export enum UseSelectStateChangeTypes {
 export interface UseSelectProps<Item> {
   items: Item[]
   itemToString?: (item: Item) => string
-  getA11yStatusMessage: (options: UseSelectA11yMessageOptions<Item>) => string
-  getA11ySelectionMessage: (
+  getA11yStatusMessage?: (options: UseSelectA11yMessageOptions<Item>) => string
+  getA11ySelectionMessage?: (
     options: UseSelectA11yMessageOptions<Item>,
   ) => string
-  circularNavigation: boolean
-  highlightedIndex: number
-  initialHighlightedIndex: number
-  defaultHighlightedIndex: number
-  isOpen: boolean
-  initialIsOpen: boolean
-  defaultIsOpen: boolean
-  selectedItem: Item
-  initialSelectedItem: Item
-  defaultSelectedItem: Item
-  id: string
-  labelId: string
-  menuId: string
-  toggleButtonId: string
-  getItemId: (index: number) => string
+  circularNavigation?: boolean
+  highlightedIndex?: number
+  initialHighlightedIndex?: number
+  defaultHighlightedIndex?: number
+  isOpen?: boolean
+  initialIsOpen?: boolean
+  defaultIsOpen?: boolean
+  selectedItem?: Item
+  initialSelectedItem?: Item
+  defaultSelectedItem?: Item
+  id?: string
+  labelId?: string
+  menuId?: string
+  toggleButtonId?: string
+  getItemId?: (index: number) => string
   stateReducer?: (
     state: UseSelectState<Item>,
     changes: UseSelectStateChangeOptions<Item>,
@@ -359,5 +359,5 @@ export type UseSelectInterface<Item> = (
 }
 
 export function useSelect<Item>(
-  props: UseSelectInterface<Item>,
+  props: UseSelectProps<Item>,
 ): UseSelectReturnValue<Item>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes #763
<!-- Why are these changes necessary? -->

**Why**:

#763
<!-- How were these changes implemented? -->

**How**:

Made everything except items in UseSelectProps optional and made useSelect accept UseSelectProps instead of UseSelectInterface
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
`npm run add-contributor` prints following:

```
> downshift@0.0.0-semantically-released add-contributor <downshift>
> kcd-scripts contributors add

<downshift>/node_modules/kcd-scripts/dist/run-script.js:49
    throw new Error(`Unknown script "${script}".`);
    ^

Error: Unknown script "contributors".
    at spawnScript (<downshift>/node_modules/kcd-scripts/dist/run-script.js:49:11)
    at Object.<anonymous> (<downshift>/node_modules/kcd-scripts/dist/run-script.js:12:3)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (<downshift>/node_modules/kcd-scripts/dist/index.js:15:1)
```