### PR TITLE
perf: remove keyboardKey library and replace its uses

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 81595,
-    "minified": 37712,
-    "gzipped": 9519
+    "bundled": 81533,
+    "minified": 37657,
+    "gzipped": 9489
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80220,
-    "minified": 36611,
-    "gzipped": 9411
+    "bundled": 80158,
+    "minified": 36556,
+    "gzipped": 9379
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 101568,
-    "minified": 35156,
-    "gzipped": 11572
+    "bundled": 93608,
+    "minified": 31791,
+    "gzipped": 9759
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 115408,
-    "minified": 41208,
-    "gzipped": 13099
+    "bundled": 107448,
+    "minified": 37754,
+    "gzipped": 11288
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 106292,
-    "minified": 36590,
-    "gzipped": 12148
+    "bundled": 98332,
+    "minified": 33136,
+    "gzipped": 10347
   },
   "dist/downshift.umd.js": {
-    "bundled": 144653,
-    "minified": 50109,
-    "gzipped": 15730
+    "bundled": 136693,
+    "minified": 46655,
+    "gzipped": 13920
   },
   "dist/downshift.esm.js": {
-    "bundled": 81109,
-    "minified": 37315,
-    "gzipped": 9435,
+    "bundled": 81067,
+    "minified": 37275,
+    "gzipped": 9407,
     "treeshaked": {
       "rollup": {
-        "code": 673,
-        "import_statements": 347
+        "code": 652,
+        "import_statements": 326
       },
       "webpack": {
-        "code": 27374
+        "code": 27283
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 79734,
-    "minified": 36214,
-    "gzipped": 9324,
+    "bundled": 79692,
+    "minified": 36174,
+    "gzipped": 9294,
     "treeshaked": {
       "rollup": {
-        "code": 674,
-        "import_statements": 348
+        "code": 653,
+        "import_statements": 327
       },
       "webpack": {
-        "code": 27383
+        "code": 27292
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@babel/runtime": "^7.4.5",
     "@reach/auto-id": "^0.2.0",
     "compute-scroll-into-view": "^1.0.9",
-    "keyboard-key": "1.0.4",
     "prop-types": "^15.7.2",
     "react-is": "^16.9.0"
   },

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -1,4 +1,3 @@
-import keyboardKey from 'keyboard-key'
 import {fireEvent, cleanup} from '@testing-library/react'
 import {act} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'
@@ -245,7 +244,7 @@ describe('getItemProps', () => {
       const wrapper = setup({initialIsOpen: true, scrollIntoView})
       const menu = wrapper.getByTestId(dataTestIds.menu)
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.End})
+      fireEvent.keyDown(menu, {key: 'End'})
       expect(scrollIntoView).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable jest/no-disabled-tests */
-import keyboardKey from 'keyboard-key'
 import {act as rtlAct} from '@testing-library/react-hooks'
 import {act} from 'react-dom/test-utils'
 import {fireEvent, cleanup} from '@testing-library/react'
@@ -122,7 +121,7 @@ describe('getMenuProps', () => {
 
         menuRef({focus: noop})
         result.current.toggleMenu()
-        onKeyDown({keyCode: keyboardKey.Escape, preventDefault: noop})
+        onKeyDown({key: 'Escape', preventDefault: noop})
       })
 
       expect(userOnKeyDown).toHaveBeenCalledTimes(1)
@@ -160,7 +159,7 @@ describe('getMenuProps', () => {
 
         menuRef({focus: noop})
         result.current.toggleMenu()
-        onKeyDown({keyCode: keyboardKey.Escape, preventDefault: noop})
+        onKeyDown({key: 'Escape', preventDefault: noop})
       })
 
       expect(userOnKeyDown).toHaveBeenCalledTimes(1)
@@ -180,7 +179,7 @@ describe('getMenuProps', () => {
 
         menuRef({focus: noop})
         result.current.toggleMenu()
-        onBlur({keyCode: keyboardKey.Escape, preventDefault: noop})
+        onBlur({key: 'Escape', preventDefault: noop})
       })
 
       expect(userOnBlur).toHaveBeenCalledTimes(1)
@@ -345,7 +344,7 @@ describe('getMenuProps', () => {
           const wrapper = setup({isOpen: true})
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(menu, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(items.length - 1),
@@ -357,7 +356,7 @@ describe('getMenuProps', () => {
           const wrapper = setup({isOpen: true, initialHighlightedIndex})
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(menu, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(initialHighlightedIndex - 1),
@@ -370,7 +369,7 @@ describe('getMenuProps', () => {
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
           fireEvent.keyDown(menu, {
-            keyCode: keyboardKey.ArrowUp,
+            key: 'ArrowUp',
             shiftKey: true,
           })
 
@@ -385,7 +384,7 @@ describe('getMenuProps', () => {
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
           fireEvent.keyDown(menu, {
-            keyCode: keyboardKey.ArrowUp,
+            key: 'ArrowUp',
             shiftKey: true,
           })
 
@@ -398,7 +397,7 @@ describe('getMenuProps', () => {
           const wrapper = setup({isOpen: true, initialHighlightedIndex: 0})
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(menu, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(0),
@@ -413,7 +412,7 @@ describe('getMenuProps', () => {
           })
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(menu, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(items.length - 1),
@@ -426,7 +425,7 @@ describe('getMenuProps', () => {
           const wrapper = setup({isOpen: true})
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(menu, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(0),
@@ -437,7 +436,7 @@ describe('getMenuProps', () => {
           const wrapper = setup({isOpen: true, initialHighlightedIndex})
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(menu, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(initialHighlightedIndex + 1),
@@ -450,7 +449,7 @@ describe('getMenuProps', () => {
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
           fireEvent.keyDown(menu, {
-            keyCode: keyboardKey.ArrowDown,
+            key: 'ArrowDown',
             shiftKey: true,
           })
 
@@ -465,7 +464,7 @@ describe('getMenuProps', () => {
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
           fireEvent.keyDown(menu, {
-            keyCode: keyboardKey.ArrowDown,
+            key: 'ArrowDown',
             shiftKey: true,
           })
 
@@ -481,7 +480,7 @@ describe('getMenuProps', () => {
           })
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(menu, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(items.length - 1),
@@ -496,7 +495,7 @@ describe('getMenuProps', () => {
           })
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(menu, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(0),
@@ -508,7 +507,7 @@ describe('getMenuProps', () => {
         const wrapper = setup({isOpen: true, initialHighlightedIndex: 2})
         const menu = wrapper.getByTestId(dataTestIds.menu)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.End})
+        fireEvent.keyDown(menu, {key: 'End'})
 
         expect(menu.getAttribute('aria-activedescendant')).toBe(
           defaultIds.getItemId(items.length - 1),
@@ -519,7 +518,7 @@ describe('getMenuProps', () => {
         const wrapper = setup({isOpen: true, initialHighlightedIndex: 2})
         const menu = wrapper.getByTestId(dataTestIds.menu)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Home})
+        fireEvent.keyDown(menu, {key: 'Home'})
 
         expect(menu.getAttribute('aria-activedescendant')).toBe(
           defaultIds.getItemId(0),
@@ -530,7 +529,7 @@ describe('getMenuProps', () => {
         const wrapper = setup({initialIsOpen: true, initialHighlightedIndex: 2})
         const menu = wrapper.getByTestId(dataTestIds.menu)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
+        fireEvent.keyDown(menu, {key: 'Escape'})
 
         expect(menu.childNodes).toHaveLength(0)
       })
@@ -541,7 +540,7 @@ describe('getMenuProps', () => {
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
         menu.focus()
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
+        fireEvent.keyDown(menu, {key: 'Escape'})
 
         expect(document.activeElement).toBe(toggleButton)
       })
@@ -555,7 +554,7 @@ describe('getMenuProps', () => {
         const menu = wrapper.getByTestId(dataTestIds.menu)
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Enter})
+        fireEvent.keyDown(menu, {key: 'Enter'})
 
         expect(menu.childNodes).toHaveLength(0)
         expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
@@ -570,7 +569,7 @@ describe('getMenuProps', () => {
         const menu = wrapper.getByTestId(dataTestIds.menu)
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Enter})
+        fireEvent.keyDown(menu, {key: 'Enter'})
 
         expect(toggleButton.textContent).toEqual(items[defaultHighlightedIndex])
         expect(menu.childNodes).toHaveLength(items.length)
@@ -585,7 +584,7 @@ describe('getMenuProps', () => {
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
         menu.focus()
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Enter})
+        fireEvent.keyDown(menu, {key: 'Enter'})
 
         expect(document.activeElement).toBe(toggleButton)
       })
@@ -599,7 +598,7 @@ describe('getMenuProps', () => {
         const menu = wrapper.getByTestId(dataTestIds.menu)
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Tab})
+        fireEvent.keyDown(menu, {key: 'Tab'})
 
         expect(menu.childNodes).toHaveLength(0)
         expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
@@ -615,7 +614,7 @@ describe('getMenuProps', () => {
         const menu = wrapper.getByTestId(dataTestIds.menu)
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Tab, shiftKey: true})
+        fireEvent.keyDown(menu, {key: 'Tab', shiftKey: true})
 
         expect(menu.childNodes).toHaveLength(0)
         expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
@@ -626,7 +625,7 @@ describe('getMenuProps', () => {
         const menu = wrapper.getByTestId(dataTestIds.menu)
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Tab, shiftKey: true})
+        fireEvent.keyDown(menu, {key: 'Tab', shiftKey: true})
 
         expect(document.activeElement).toBe(toggleButton)
       })
@@ -640,8 +639,8 @@ describe('getMenuProps', () => {
         const menu = wrapper.getByTestId(dataTestIds.menu)
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Alt})
-        fireEvent.keyDown(menu, {keyCode: keyboardKey.Control})
+        fireEvent.keyDown(menu, {key: 'Alt'})
+        fireEvent.keyDown(menu, {key: 'Control'})
 
         expect(document.activeElement).toBe(menu)
         expect(toggleButton.textContent).toEqual(items[2])

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable jest/no-disabled-tests */
-import keyboardKey from 'keyboard-key'
 import {fireEvent, cleanup} from '@testing-library/react'
 import {act as rtlAct} from '@testing-library/react-hooks'
 import {act} from 'react-dom/test-utils'
@@ -122,7 +121,7 @@ describe('getToggleButtonProps', () => {
 
         menuRef({focus: noop})
         toggleButtonRef({})
-        onKeyDown({keyCode: keyboardKey.ArrowDown, preventDefault: noop})
+        onKeyDown({key: 'ArrowDown', preventDefault: noop})
       })
 
       expect(userOnKeyDown).toHaveBeenCalledTimes(1)
@@ -167,7 +166,7 @@ describe('getToggleButtonProps', () => {
         toggleButtonRef({focus: noop})
         menuRef({focus: noop})
         onKeyDown({
-          keyCode: keyboardKey.ArrowDown,
+          key: 'ArrowDown',
           preventDefault: noop,
         })
       })
@@ -421,7 +420,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(items.length - 1),
@@ -434,7 +433,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(selectedIndex - 1),
@@ -447,14 +446,14 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(initialHighlightedIndex),
           )
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(menu, {key: 'Escape'})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(items.length - 1),
@@ -467,14 +466,14 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(defaultHighlightedIndex),
           )
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(menu, {key: 'Escape'})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowUp'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(defaultHighlightedIndex),
@@ -487,7 +486,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
           fireEvent.keyDown(toggleButton, {
-            keyCode: keyboardKey.ArrowUp,
+            key: 'ArrowUp',
             preventDefault,
           })
 
@@ -499,7 +498,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowUp})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowUp'})
 
           expect(document.activeElement).toBe(menu)
         })
@@ -511,7 +510,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(0),
@@ -524,7 +523,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(selectedIndex + 1),
@@ -537,14 +536,14 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(initialHighlightedIndex),
           )
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(menu, {key: 'Escape'})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(0),
@@ -557,14 +556,14 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(defaultHighlightedIndex),
           )
 
-          fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(menu, {key: 'Escape'})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowDown'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
             defaultIds.getItemId(defaultHighlightedIndex),
@@ -578,7 +577,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
           fireEvent.keyDown(toggleButton, {
-            keyCode: keyboardKey.ArrowDown,
+            key: 'ArrowDown',
             preventDefault,
           })
 
@@ -590,7 +589,7 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
-          fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.ArrowDown})
+          fireEvent.keyDown(toggleButton, {key: 'ArrowDown'})
 
           expect(document.activeElement).toBe(menu)
         })
@@ -601,8 +600,8 @@ describe('getToggleButtonProps', () => {
         const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
         const menu = wrapper.getByTestId(dataTestIds.menu)
 
-        fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.Alt})
-        fireEvent.keyDown(toggleButton, {keyCode: keyboardKey.Control})
+        fireEvent.keyDown(toggleButton, {key: 'Alt'})
+        fireEvent.keyDown(toggleButton, {key: 'Control'})
 
         expect(toggleButton.textContent).toEqual('Elements')
         expect(menu.getAttribute('aria-activedescendant')).toBeNull()

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -1,6 +1,5 @@
 import {act} from 'react-dom/test-utils'
 import {renderHook} from '@testing-library/react-hooks'
-import keyboardKey from 'keyboard-key'
 import {fireEvent, cleanup} from '@testing-library/react'
 import {setup, dataTestIds, items, defaultIds} from '../testUtils'
 import useSelect from '..'
@@ -221,17 +220,17 @@ describe('props', () => {
         defaultIds.getItemId(highlightedIndex),
       )
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
+      fireEvent.keyDown(menu, {key: 'ArrowDown'})
       expect(menu.getAttribute('aria-activedescendant')).toBe(
         defaultIds.getItemId(highlightedIndex),
       )
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.End})
+      fireEvent.keyDown(menu, {key: 'End'})
       expect(menu.getAttribute('aria-activedescendant')).toBe(
         defaultIds.getItemId(highlightedIndex),
       )
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowUp})
+      fireEvent.keyDown(menu, {key: 'ArrowUp'})
       expect(menu.getAttribute('aria-activedescendant')).toBe(
         defaultIds.getItemId(highlightedIndex),
       )
@@ -254,7 +253,7 @@ describe('props', () => {
       fireEvent.click(toggleButton)
       expect(menu.childNodes).toHaveLength(items.length)
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
+      fireEvent.keyDown(menu, {key: 'Escape'})
       expect(menu.childNodes).toHaveLength(items.length)
 
       fireEvent.blur(menu)
@@ -272,8 +271,8 @@ describe('props', () => {
 
       expect(toggleButton.textContent).toEqual(items[2])
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.Enter})
+      fireEvent.keyDown(menu, {key: 'ArrowDown'})
+      fireEvent.keyDown(menu, {key: 'Enter'})
 
       expect(toggleButton.textContent).toEqual(items[2])
 
@@ -296,8 +295,8 @@ describe('props', () => {
         defaultIds.getItemId(expectedHighlightedIndex),
       )
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.Enter})
+      fireEvent.keyDown(menu, {key: 'ArrowDown'})
+      fireEvent.keyDown(menu, {key: 'Enter'})
 
       expect(toggleButton.textContent).toEqual(items[expectedHighlightedIndex])
 
@@ -319,8 +318,8 @@ describe('props', () => {
         defaultIds.getItemId(expectedHighlightedIndex),
       )
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.Enter})
+      fireEvent.keyDown(menu, {key: 'ArrowDown'})
+      fireEvent.keyDown(menu, {key: 'Enter'})
 
       expect(toggleButton.textContent).toEqual(items[expectedHighlightedIndex])
 
@@ -345,7 +344,7 @@ describe('props', () => {
       fireEvent.keyDown(menu, {key: 'c'})
       expect(stateReducer).toHaveBeenCalledTimes(2)
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowUp})
+      fireEvent.keyDown(menu, {key: 'ArrowUp'})
       expect(stateReducer).toHaveBeenCalledTimes(3)
 
       fireEvent.click(toggleButton)
@@ -481,7 +480,7 @@ describe('props', () => {
       const wrapper = setup({initialIsOpen: true, onHighlightedIndexChange})
       const menu = wrapper.getByTestId(dataTestIds.menu)
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
+      fireEvent.keyDown(menu, {key: 'ArrowDown'})
       expect(onHighlightedIndexChange).toHaveBeenCalledWith(
         expect.objectContaining({
           highlightedIndex: 0,
@@ -498,10 +497,10 @@ describe('props', () => {
       })
       const menu = wrapper.getByTestId(dataTestIds.menu)
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowUp})
+      fireEvent.keyDown(menu, {key: 'ArrowUp'})
       expect(onHighlightedIndexChange).not.toHaveBeenCalled()
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.Home})
+      fireEvent.keyDown(menu, {key: 'Home'})
       expect(onHighlightedIndexChange).not.toHaveBeenCalled()
     })
   })
@@ -512,7 +511,7 @@ describe('props', () => {
       const wrapper = setup({initialIsOpen: true, onIsOpenChange})
       const menu = wrapper.getByTestId(dataTestIds.menu)
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.Escape})
+      fireEvent.keyDown(menu, {key: 'Escape'})
       expect(onIsOpenChange).toHaveBeenCalledWith(
         expect.objectContaining({
           isOpen: false,
@@ -544,7 +543,7 @@ describe('props', () => {
         }),
       )
 
-      fireEvent.keyDown(menu, {keyCode: keyboardKey.ArrowDown})
+      fireEvent.keyDown(menu, {key: 'ArrowDown'})
       expect(onStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
           highlightedIndex: 0,

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable max-statements */
 import {useRef, useEffect} from 'react'
-import keyboardKey from 'keyboard-key'
 import {useId} from '@reach/auto-id'
 import {
   getElementIds,
@@ -16,6 +15,7 @@ import {
   callAll,
   debounce,
   scrollIntoView as defaultScrollIntoView,
+  normalizeArrowKey,
 } from '../../utils'
 import downshiftSelectReducer from './reducer'
 import {
@@ -236,7 +236,7 @@ function useSelect(userProps = {}) {
 
   // Event handlers.
   const menuHandleKeyDown = event => {
-    const key = keyboardKey.getKey(event)
+    const key = normalizeArrowKey(event)
     if (key && menuKeyDownHandlers[key]) {
       menuKeyDownHandlers[key](event)
     } else if (isAcceptedCharacterKey(key)) {
@@ -262,7 +262,7 @@ function useSelect(userProps = {}) {
     })
   }
   const toggleButtonHandleKeyDown = event => {
-    const key = keyboardKey.getKey(event)
+    const key = normalizeArrowKey(event)
     if (key && toggleButtonKeyDownHandlers[key]) {
       toggleButtonKeyDownHandlers[key](event)
     } else if (isAcceptedCharacterKey(key)) {


### PR DESCRIPTION
Added as part of 3.3.0 but will remove it to shave the bundle size a bit.