### PR TITLE
Fix 'jsx-no-useless-fragment' error updating eslint-plugin-react

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1074,6 +1074,15 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "epeicher",
+      "name": "Roberto Aranda",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/3519124?s=460&v=4",
+      "profile": "https://github.com/epeicher",
+      "contributions": [
+        "bug"
+      ]
     }
   ]
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 81533,
-    "minified": 37657,
-    "gzipped": 9489
+    "bundled": 81571,
+    "minified": 37785,
+    "gzipped": 9518
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80158,
-    "minified": 36556,
-    "gzipped": 9379
+    "bundled": 80196,
+    "minified": 36684,
+    "gzipped": 9409
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93608,
-    "minified": 31791,
-    "gzipped": 9759
+    "bundled": 93721,
+    "minified": 31979,
+    "gzipped": 9801
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 107448,
-    "minified": 37754,
-    "gzipped": 11288
+    "bundled": 107753,
+    "minified": 38018,
+    "gzipped": 11341
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98332,
-    "minified": 33136,
-    "gzipped": 10347
+    "bundled": 98445,
+    "minified": 33330,
+    "gzipped": 10392
   },
   "dist/downshift.umd.js": {
-    "bundled": 136693,
-    "minified": 46655,
-    "gzipped": 13920
+    "bundled": 136998,
+    "minified": 46949,
+    "gzipped": 13976
   },
   "dist/downshift.esm.js": {
-    "bundled": 81067,
-    "minified": 37275,
-    "gzipped": 9407,
+    "bundled": 81105,
+    "minified": 37403,
+    "gzipped": 9437,
     "treeshaked": {
       "rollup": {
         "code": 652,
         "import_statements": 326
       },
       "webpack": {
-        "code": 27283
+        "code": 27409
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 79692,
-    "minified": 36174,
-    "gzipped": 9294,
+    "bundled": 79730,
+    "minified": 36302,
+    "gzipped": 9325,
     "treeshaked": {
       "rollup": {
         "code": 653,
         "import_statements": 327
       },
       "webpack": {
-        "code": 27292
+        "code": 27418
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "docz": "^1.2.0",
     "docz-theme-default": "^1.2.0",
     "eslint-plugin-cypress": "^2.6.1",
-    "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react": "7.16.0",
     "flow-bin": "^0.102.0",
     "flow-coverage-report": "^0.6.0",
     "jest-dom": "^3.0.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Update eslint-plugin-react

<!-- Why are these changes necessary? -->

**Why**:
The following error was being returned when running `npm run validate` or `npm run lint`:
```sh
error  Definition for rule 'react/jsx-no-useless-fragment' was not found  react/jsx-no-useless-fragment
```

<!-- How were these changes implemented? -->

**How**:
Updating the version in `package.json`
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
