### PR TITLE
fix - duplicate and wrong event trigger on ArrowDown and ArrowUp

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 81533,
-    "minified": 37657,
-    "gzipped": 9489
+    "bundled": 81215,
+    "minified": 37707,
+    "gzipped": 9505
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80158,
-    "minified": 36556,
-    "gzipped": 9379
+    "bundled": 79840,
+    "minified": 36606,
+    "gzipped": 9397
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93608,
-    "minified": 31791,
-    "gzipped": 9759
+    "bundled": 93276,
+    "minified": 31879,
+    "gzipped": 9780
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 107448,
-    "minified": 37754,
-    "gzipped": 11288
+    "bundled": 107116,
+    "minified": 37846,
+    "gzipped": 11306
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98332,
-    "minified": 33136,
-    "gzipped": 10347
+    "bundled": 98000,
+    "minified": 33230,
+    "gzipped": 10375
   },
   "dist/downshift.umd.js": {
-    "bundled": 136693,
-    "minified": 46655,
-    "gzipped": 13920
+    "bundled": 136361,
+    "minified": 46775,
+    "gzipped": 13940
   },
   "dist/downshift.esm.js": {
-    "bundled": 81067,
-    "minified": 37275,
-    "gzipped": 9407,
+    "bundled": 80749,
+    "minified": 37325,
+    "gzipped": 9423,
     "treeshaked": {
       "rollup": {
         "code": 652,
         "import_statements": 326
       },
       "webpack": {
-        "code": 27283
+        "code": 27361
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 79692,
-    "minified": 36174,
-    "gzipped": 9294,
+    "bundled": 79374,
+    "minified": 36224,
+    "gzipped": 9315,
     "treeshaked": {
       "rollup": {
         "code": 653,
         "import_statements": 327
       },
       "webpack": {
-        "code": 27292
+        "code": 27370
       }
     }
   }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -554,7 +554,6 @@ class Downshift extends Component {
                   this.getState().highlightedIndex,
                   itemCount,
                 ),
-                {type: stateChangeTypes.keyDownArrowDown},
               )
             }
           },
@@ -585,7 +584,6 @@ class Downshift extends Component {
                   this.getState().highlightedIndex,
                   itemCount,
                 ),
-                {type: stateChangeTypes.keyDownArrowDown},
               )
             }
           },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix for duplicate and wrong event call on ArrowDown and ArrowUp respectively.  #708 
<!-- Why are these changes necessary? -->

**Why**:
If user has an event handler for ArrowDown it will be invoked twice and the event handler for ArrowUp will both ArrowUp and ArrowDown handlers. 
<!-- How were these changes implemented? -->

**How**:
Solved by removing the event type set at `setHighlightedIndex` of ArrowDown and ArrowUp handlers.

Still those events are called while setting state

```js
this.internalSetState(
          {
            isOpen: true,
            // changing the state of event type
            type: stateChangeTypes.keyDownArrowUp, 
          },() => // cb
```
Changes made: 
```diff
@@ -554,7 +554,6 @@ class Downshift extends Component {
                   this.getState().highlightedIndex,
                   itemCount,
                 ),
-                {type: stateChangeTypes.keyDownArrowDown},
               )
             }
           },

@@ -585,7 +584,6 @@ class Downshift extends Component {
                   this.getState().highlightedIndex,
                   itemCount,
                 ),
-                {type: stateChangeTypes.keyDownArrowDown},
               )
             }
           },
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Note: *this is my **first** open source contribution on fix, so please be patience if I made any mistake*