### PR TITLE
fix - Localize clearTimeout per useSelect mounted instances

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1074,6 +1074,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "edygar",
+      "name": "Edygar Oliveira"
+      "avatar_url": "https://avatars.githubusercontent.com/u/566280?v=3",
+      "profile": "https://github.com/edygar",
+      "contributions": [
+        "code",
+        "bug"
+      ]
     }
   ]
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 81533,
-    "minified": 37657,
-    "gzipped": 9489
+    "bundled": 81604,
+    "minified": 37781,
+    "gzipped": 9518
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80158,
-    "minified": 36556,
-    "gzipped": 9379
+    "bundled": 80229,
+    "minified": 36680,
+    "gzipped": 9409
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93608,
-    "minified": 31791,
-    "gzipped": 9759
+    "bundled": 93754,
+    "minified": 32007,
+    "gzipped": 9802
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 107448,
-    "minified": 37754,
-    "gzipped": 11288
+    "bundled": 107786,
+    "minified": 38046,
+    "gzipped": 11345
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98332,
-    "minified": 33136,
-    "gzipped": 10347
+    "bundled": 98478,
+    "minified": 33358,
+    "gzipped": 10393
   },
   "dist/downshift.umd.js": {
-    "bundled": 136693,
-    "minified": 46655,
-    "gzipped": 13920
+    "bundled": 137031,
+    "minified": 46977,
+    "gzipped": 13981
   },
   "dist/downshift.esm.js": {
-    "bundled": 81067,
-    "minified": 37275,
-    "gzipped": 9407,
+    "bundled": 81132,
+    "minified": 37393,
+    "gzipped": 9436,
     "treeshaked": {
       "rollup": {
         "code": 652,
         "import_statements": 326
       },
       "webpack": {
-        "code": 27283
+        "code": 27445
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 79692,
-    "minified": 36174,
-    "gzipped": 9294,
+    "bundled": 79757,
+    "minified": 36292,
+    "gzipped": 9324,
     "treeshaked": {
       "rollup": {
         "code": 653,
         "import_statements": 327
       },
       "webpack": {
-        "code": 27292
+        "code": 27454
       }
     }
   }

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -39,8 +39,6 @@ const defaultProps = {
       : window,
 }
 
-let clearTimeout
-
 useSelect.stateChangeTypes = stateChangeTypes
 
 function useSelect(userProps = {}) {
@@ -83,6 +81,7 @@ function useSelect(userProps = {}) {
   itemRefs.current = []
   const isInitialMount = useRef(true)
   const shouldScroll = useRef(true)
+  const clearTimeout = useRef(null)
 
   /* Effects */
   /* Sets a11y status message on changes in isOpen. */
@@ -121,7 +120,7 @@ function useSelect(userProps = {}) {
   useEffect(() => {
     // init the clean function here as we need access to dispatch.
     if (isInitialMount.current) {
-      clearTimeout = debounce(() => {
+      clearTimeout.current = debounce(() => {
         dispatch({
           type: stateChangeTypes.FunctionClearKeysSoFar,
         })
@@ -130,7 +129,7 @@ function useSelect(userProps = {}) {
     if (!keysSoFar) {
       return
     }
-    clearTimeout()
+    clearTimeout.current()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keysSoFar])
   /* Controls the focus on the menu or the toggle button. */


### PR DESCRIPTION
**What**:

Localize clearTimeout per useSelect mounted instances

**Why**:

Closes #794 

Previously, clearTimeout was previously at root level closure, causing each new mounted component that used the useSelect hook to override the previous reference, so every instance of the component was alway calling only the last instance's clearTimeout, never calling their own clearTimeout and therefore, never clearing the `keysSoFar` state. 

**How**:

Assigned resulting clearTimeout to a ref, instead of the root closure variable

**Checklist**:

- [ ] Documentation (N/A)
- [ ] Tests (N/A)
- [x] Ready to be merged
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
