### PR TITLE
fix(useSelect): don't select item at blur

### DIFF
--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -588,7 +588,7 @@ Downshift has a few events for which it provides implicit handlers. Several of t
 - `Home`: Moves `highlightedIndex` to first position.
 - `Enter`: If there is a highlighted option, it will select it, close the menu and move focus to the toggle button (unless `defaultIsOpen` is true).
 - `Escape`: It will close the menu without selecting anything and move focus to the toggle button.
-- `Blur(Tab, Shift+Tab, MouseClick outside)`: If there is a highlighted option, it will select it, close the menu and move focus either to the toggle button (if `Shift+Tab`), next tabbable element (if `Tab`) or whatever was clicked.
+- `Blur(Tab, Shift+Tab, MouseClick outside)`: It will close the menu and move focus either to the toggle button (if `Shift+Tab`), next tabbable element (if `Tab`) or whatever was clicked. It will not select the highlighted item anymore, if any.
 
 #### Item
 

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -667,6 +667,22 @@ describe('getMenuProps', () => {
         expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
       })
 
+      test('the open menu will be closed and highlighted item will not be selected if the highlight by mouse leaves the menu', () => {
+        const initialHighlightedIndex = 2
+        const wrapper = setup({
+          initialIsOpen: true,
+          initialHighlightedIndex,
+        })
+        const menu = wrapper.getByTestId(dataTestIds.menu)
+        const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
+
+        fireEvent.mouseLeave(menu)
+        fireEvent.blur(menu)
+
+        expect(menu.childNodes).toHaveLength(0)
+        expect(toggleButton.textContent).toEqual('Elements')
+      })
+
       test.skip('by clicking outside it should behave normnally but the toggleButton should not be focused', () => {
         const initialHighlightedIndex = 2
         const wrapper = setup({

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -601,11 +601,11 @@ describe('getMenuProps', () => {
         fireEvent.keyDown(menu, {key: 'Tab'})
 
         expect(menu.childNodes).toHaveLength(0)
-        expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
+        expect(toggleButton.textContent).toEqual('Elements')
       })
 
       // Special case test.
-      test('shift+tab it closes the menu and selects highlighted item', () => {
+      test('shift+tab it closes the menu', () => {
         const initialHighlightedIndex = 2
         const wrapper = setup({
           initialIsOpen: true,
@@ -617,7 +617,7 @@ describe('getMenuProps', () => {
         fireEvent.keyDown(menu, {key: 'Tab', shiftKey: true})
 
         expect(menu.childNodes).toHaveLength(0)
-        expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
+        expect(toggleButton.textContent).toEqual('Elements')
       })
 
       test('shift+tab it has the focus moved to toggleButton', () => {
@@ -651,8 +651,22 @@ describe('getMenuProps', () => {
       })
     })
 
+    describe('on mouse leave', () => {
+      test('the highlightedIndex should be reset', () => {
+        const wrapper = setup({
+          initialIsOpen: true,
+          initialHighlightedIndex: 2,
+        })
+        const menu = wrapper.getByTestId(dataTestIds.menu)
+
+        fireEvent.mouseLeave(menu)
+
+        expect(menu.getAttribute('aria-activedescendant')).toBeNull()
+      })
+    })
+
     describe('on blur', () => {
-      test('the open menu will be closed and highlighted item will be selected', () => {
+      test('the open menu will be closed and highlighted item will not be selected', () => {
         const initialHighlightedIndex = 2
         const wrapper = setup({
           initialIsOpen: true,
@@ -664,7 +678,7 @@ describe('getMenuProps', () => {
         fireEvent.blur(menu)
 
         expect(menu.childNodes).toHaveLength(0)
-        expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
+        expect(toggleButton.textContent).toEqual('Elements')
       })
 
       test('the open menu will be closed and highlighted item will not be selected if the highlight by mouse leaves the menu', () => {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -255,6 +255,11 @@ function useSelect(userProps = {}) {
       })
     }
   }
+  const menuHandleMouseLeave = () => {
+    dispatch({
+      type: stateChangeTypes.MenuMouseLeave,
+    })
+  }
   const toggleButtonHandleClick = () => {
     dispatch({
       type: stateChangeTypes.ToggleButtonClick,
@@ -328,6 +333,7 @@ function useSelect(userProps = {}) {
   const getMenuProps = ({
     onKeyDown,
     onBlur,
+    onMouseLeave,
     refKey = 'ref',
     ref,
     ...rest
@@ -344,6 +350,7 @@ function useSelect(userProps = {}) {
     }),
     onKeyDown: callAllEventHandlers(onKeyDown, menuHandleKeyDown),
     onBlur: callAllEventHandlers(onBlur, menuHandleBlur),
+    onMouseLeave: callAllEventHandlers(onMouseLeave, menuHandleMouseLeave),
     ...rest,
   })
   const getToggleButtonProps = ({

--- a/src/hooks/useSelect/reducer.js
+++ b/src/hooks/useSelect/reducer.js
@@ -92,6 +92,11 @@ export default function downshiftSelectReducer(state, action) {
         }
       }
       break
+    case stateChangeTypes.MenuMouseLeave:
+      changes = {
+        highlightedIndex: -1,
+      }
+      break
     case stateChangeTypes.ToggleButtonKeyDownCharacter:
       {
         const lowercasedKey = action.key

--- a/src/hooks/useSelect/reducer.js
+++ b/src/hooks/useSelect/reducer.js
@@ -24,9 +24,6 @@ export default function downshiftSelectReducer(state, action) {
       changes = {
         isOpen: false,
         highlightedIndex: -1,
-        ...(state.highlightedIndex >= 0 && {
-          selectedItem: props.items[state.highlightedIndex],
-        }),
       }
       break
     case stateChangeTypes.MenuKeyDownArrowDown:

--- a/src/hooks/useSelect/stateChangeTypes.js
+++ b/src/hooks/useSelect/stateChangeTypes.js
@@ -10,6 +10,7 @@ export const MenuKeyDownEnd = productionEnum('__menu_keydown_end__')
 export const MenuKeyDownEnter = productionEnum('__menu_keydown_enter__')
 export const MenuKeyDownCharacter = productionEnum('__menu_keydown_character__')
 export const MenuBlur = productionEnum('__menu_blur__')
+export const MenuMouseLeave = productionEnum('__menu_mouse_leave__')
 export const ItemMouseMove = productionEnum('__item_mouse_move__')
 export const ItemClick = productionEnum('__item_click__')
 export const ToggleButtonKeyDownCharacter = productionEnum(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -247,6 +247,7 @@ export enum UseSelectStateChangeTypes {
   MenuKeyDownEnter = '__menu_keydown_enter__',
   MenuKeyDownCharacter = '__menu_keydown_character__',
   MenuBlur = '__menu_blur__',
+  MenuMouseLeave = '__menu_mouse_leave__',
   ItemMouseMove = '__item_mouse_move__',
   ItemClick = '__item_click__',
   ToggleButtonKeyDownCharacter = '__togglebutton_keydown_character__',
@@ -342,6 +343,7 @@ export type UseSelectInterface<Item> = (
     MenuKeyDownEnter: UseSelectStateChangeTypes.MenuKeyDownEnter
     MenuKeyDownCharacter: UseSelectStateChangeTypes.MenuKeyDownCharacter
     MenuBlur: UseSelectStateChangeTypes.MenuBlur
+    MenuMouseLeave: UseSelectStateChangeTypes.MenuMouseLeave
     ItemMouseMove: UseSelectStateChangeTypes.ItemMouseMove
     ItemClick: UseSelectStateChangeTypes.ItemClick
     ToggleButtonKeyDownCharacter: UseSelectStateChangeTypes.ToggleButtonKeyDownCharacter


### PR DESCRIPTION
Should fix https://github.com/downshift-js/downshift/issues/780

Will reset `highlightedIndex` on mouse leave from menu.
Will not select item on Tab, Shift Tab, and mouse click outside.

ToDo:
- Update Documentation.