### PR TITLE
fix(preact): remove hooks from build

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,55 +5,55 @@
     "gzipped": 9598
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 81090,
-    "minified": 36994,
-    "gzipped": 9498
+    "bundled": 53373,
+    "minified": 22913,
+    "gzipped": 6425
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93792,
-    "minified": 32003,
-    "gzipped": 9813
+    "bundled": 66232,
+    "minified": 22631,
+    "gzipped": 7213
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 107824,
-    "minified": 38043,
-    "gzipped": 11343
+    "bundled": 79745,
+    "minified": 28135,
+    "gzipped": 8660
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98431,
-    "minified": 33321,
-    "gzipped": 10377
+    "bundled": 98773,
+    "minified": 33403,
+    "gzipped": 10417
   },
   "dist/downshift.umd.js": {
-    "bundled": 136984,
-    "minified": 46941,
-    "gzipped": 13963
+    "bundled": 137346,
+    "minified": 47043,
+    "gzipped": 14012
   },
   "dist/downshift.esm.js": {
-    "bundled": 81619,
-    "minified": 37532,
-    "gzipped": 9478,
+    "bundled": 82000,
+    "minified": 37733,
+    "gzipped": 9539,
     "treeshaked": {
       "rollup": {
         "code": 629,
         "import_statements": 303
       },
       "webpack": {
-        "code": 27541
+        "code": 27621
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 80309,
-    "minified": 36465,
-    "gzipped": 9374,
+    "bundled": 53071,
+    "minified": 22681,
+    "gzipped": 6361,
     "treeshaked": {
       "rollup": {
-        "code": 630,
-        "import_statements": 304
+        "code": 278,
+        "import_statements": 278
       },
       "webpack": {
-        "code": 27584
+        "code": 18030
       }
     }
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,10 @@
 const commonjs = require('rollup-plugin-commonjs')
 const config = require('kcd-scripts/dist/config/rollup.config.js')
 
+if (JSON.parse(process.env.BUILD_PREACT)) {
+  config.input = 'src/index.preact.js'
+}
+
 const cjsPluginIndex = config.plugins.findIndex(
   plugin => plugin.name === 'commonjs',
 )

--- a/src/index.preact.js
+++ b/src/index.preact.js
@@ -1,0 +1,2 @@
+export {default} from './downshift'
+export {resetIdCounter} from './utils'


### PR DESCRIPTION
## What

This removes the Downshift hooks from the Preact build because they're not compatible with the main Preact package.

## Why

The [React ESM build](https://unpkg.com/browse/downshift@3.4.0/dist/downshift.esm.js) generates this import:

```js
import { cloneElement, Component, useCallback, useReducer, useState, useEffect, useRef } from 'preact';
```

The current [Preact build](https://unpkg.com/browse/downshift@3.4.0/preact/dist/downshift.esm.js) generated this import:

```js
import { cloneElement, Component, useCallback, useReducer, useState, useEffect, useRef } from 'preact';
```

However, Preact hooks are exported from `preact/hooks` (not `preact`). Since they don't exist in `preact`, it throws in some environments (e.g. building a library with Rollup).

## How

This PR results in this import in the Preact ESM bundle:

```js
import { cloneElement, Component } from 'preact';
```

Not exporting Downshift hooks in the Preact for now has two benefits:

- **Makes the Preact build work in all environments**
- **Decreases the bundle size from 80Kb to 52Kb**

> Note that having added hooks to the main build without bumping the `react` peer dependency makes it error for people using React < 16 as well as Preact users.

## Checklist

- [x] Ready to be merged
