### PR TITLE
Add support for object refs in prop getters

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -517,8 +517,14 @@ class Downshift extends Component {
     this.getRootProps.refKey = refKey
     this.getRootProps.suppressRefError = suppressRefError
     const {isOpen} = this.getState()
+    const fnRef =
+      typeof ref === 'function'
+        ? ref
+        : current => {
+            if (ref) ref.current = current
+          }
     return {
-      [refKey]: callAll(ref, this.rootRef),
+      [refKey]: callAll(fnRef, this.rootRef),
       role: 'combobox',
       'aria-expanded': isOpen,
       'aria-haspopup': 'listbox',
@@ -858,9 +864,14 @@ class Downshift extends Component {
     this.getMenuProps.called = true
     this.getMenuProps.refKey = refKey
     this.getMenuProps.suppressRefError = suppressRefError
-
+    const fnRef =
+      typeof ref === 'function'
+        ? ref
+        : current => {
+            if (ref) ref.current = current
+          }
     return {
-      [refKey]: callAll(ref, this.menuRef),
+      [refKey]: callAll(fnRef, this.menuRef),
       role: 'listbox',
       'aria-labelledby': props && props['aria-label'] ? null : this.labelId,
       id: this.menuId,


### PR DESCRIPTION
- Support function refs in getRootProps
- Support function refs in getItemProps

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add support for object refs in prop getters.

<!-- Why are these changes necessary? -->

**Why**:
React has two types of refs and Downshift currently supports only one type, function refs. It doesn't fail gracefully when encountering the other type, object refs.

<!-- How were these changes implemented? -->

**How**:
Add a check for object refs and handle them appropriately.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
- I feel like documentation isn't necessary since this is a bug fix.
- Should I add a regression test?
- I tried to run `npm run add-contributor` but the script seems to be missing.
- Should I add an entry to the changelog?
