### PR TITLE
Add onItemSelected callback prop for useSelect

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -15,9 +15,9 @@
     "gzipped": 9935
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 109019,
-    "minified": 38372,
-    "gzipped": 11471
+    "bundled": 108855,
+    "minified": 38364,
+    "gzipped": 11469
   },
   "dist/downshift.umd.min.js": {
     "bundled": 99442,
@@ -30,30 +30,30 @@
     "gzipped": 14078
   },
   "dist/downshift.esm.js": {
-    "bundled": 82789,
-    "minified": 38106,
-    "gzipped": 9633,
+    "bundled": 82625,
+    "minified": 38098,
+    "gzipped": 9628,
     "treeshaked": {
       "rollup": {
-        "code": 629,
+        "code": 636,
         "import_statements": 303
       },
       "webpack": {
-        "code": 27848
+        "code": 27842
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 81479,
-    "minified": 37039,
-    "gzipped": 9530,
+    "bundled": 81315,
+    "minified": 37031,
+    "gzipped": 9525,
     "treeshaked": {
       "rollup": {
-        "code": 630,
+        "code": 637,
         "import_statements": 304
       },
       "webpack": {
-        "code": 27891
+        "code": 27885
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82381,
-    "minified": 38042,
-    "gzipped": 9598
+    "bundled": 83006,
+    "minified": 38407,
+    "gzipped": 9690
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 81090,
-    "minified": 36994,
-    "gzipped": 9498
+    "bundled": 81715,
+    "minified": 37359,
+    "gzipped": 9587
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93792,
-    "minified": 32003,
-    "gzipped": 9813
+    "bundled": 94803,
+    "minified": 32304,
+    "gzipped": 9935
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 107824,
-    "minified": 38043,
-    "gzipped": 11343
+    "bundled": 109019,
+    "minified": 38372,
+    "gzipped": 11471
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98431,
-    "minified": 33321,
-    "gzipped": 10377
+    "bundled": 99442,
+    "minified": 33622,
+    "gzipped": 10508
   },
   "dist/downshift.umd.js": {
-    "bundled": 136984,
-    "minified": 46941,
-    "gzipped": 13963
+    "bundled": 138015,
+    "minified": 47262,
+    "gzipped": 14078
   },
   "dist/downshift.esm.js": {
-    "bundled": 81619,
-    "minified": 37532,
-    "gzipped": 9478,
+    "bundled": 82789,
+    "minified": 38106,
+    "gzipped": 9633,
     "treeshaked": {
       "rollup": {
         "code": 629,
         "import_statements": 303
       },
       "webpack": {
-        "code": 27541
+        "code": 27848
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 80309,
-    "minified": 36465,
-    "gzipped": 9374,
+    "bundled": 81479,
+    "minified": 37039,
+    "gzipped": 9530,
     "treeshaked": {
       "rollup": {
         "code": 630,
         "import_statements": 304
       },
       "webpack": {
-        "code": 27584
+        "code": 27891
       }
     }
   }

--- a/src/hooks/useSelect/__tests__/.eslintrc
+++ b/src/hooks/useSelect/__tests__/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "jsx-a11y/label-has-for": "off",
+    "jsx-a11y/click-events-have-key-events": "off",
+    "react/prop-types": "off",
+    "react/display-name": "off",
+    "react/no-deprecated": "off",
+    "no-console": "off"
+  }
+}

--- a/src/hooks/useSelect/__tests__/propCallbacks.test.js
+++ b/src/hooks/useSelect/__tests__/propCallbacks.test.js
@@ -1,0 +1,48 @@
+import {
+  ItemClick,
+  MenuKeyDownEnter,
+  FunctionSelectItem,
+  MenuKeyDownArrowDown,
+} from '../stateChangeTypes'
+import propCallbacks from '../propCallbacks'
+
+describe('useSelectCallbacks', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => console.error.mockRestore())
+
+  it('should perform onItemSelected for 3 specific stateChangeTypes', () => {
+    const props = {onItemSelected: jest.fn()}
+    const newState = {selectedItem: 'abc'}
+    const actionTypes = [ItemClick, MenuKeyDownEnter, FunctionSelectItem]
+
+    for (let index = 0; index < actionTypes.length; index++) {
+      const action = {type: actionTypes[index], props}
+      propCallbacks(action, newState)
+    }
+
+    expect(props.onItemSelected).toHaveBeenCalledTimes(3)
+    expect(props.onItemSelected).toHaveBeenCalledWith(newState)
+  })
+
+  it('should not error if no onItemSelected is passed', () => {
+    const action = {type: ItemClick, props: {}}
+    const newState = {selectedItem: 'abc'}
+
+    propCallbacks(action, newState)
+
+    expect(console.error).toHaveBeenCalledTimes(0)
+  })
+
+  it('should not perform callback on other stateChangeTypes', () => {
+    const props = {onItemSelected: jest.fn()}
+    const action = {type: MenuKeyDownArrowDown, props}
+    const newState = {selectedItem: 'abc'}
+
+    propCallbacks(action, newState)
+
+    expect(props.onItemSelected).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -559,4 +559,22 @@ describe('props', () => {
       )
     })
   })
+
+  describe('onItemSelected', () => {
+    it('is called every time item is clicked (even if same item)', () => {
+      const onItemSelected = jest.fn()
+      const wrapper = setup({isOpen: true, onItemSelected})
+      const item = wrapper.getByTestId(dataTestIds.item(0))
+
+      fireEvent.click(item)
+      fireEvent.click(item)
+
+      expect(onItemSelected).toBeCalledTimes(2)
+      expect(onItemSelected).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedItem: items[0],
+        }),
+      )
+    })
+  })
 })

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -25,6 +25,7 @@ import {
   propTypes,
 } from './utils'
 import * as stateChangeTypes from './stateChangeTypes'
+import useSelectCallbacks from './propCallbacks'
 
 const validatePropTypes = getPropTypesValidator(useSelect, propTypes)
 const defaultProps = {
@@ -65,7 +66,12 @@ function useSelect(userProps = {}) {
   const [
     {isOpen, highlightedIndex, selectedItem, keysSoFar},
     dispatchWithoutProps,
-  ] = useEnhancedReducer(downshiftSelectReducer, initialState, props)
+  ] = useEnhancedReducer(
+    downshiftSelectReducer,
+    initialState,
+    props,
+    useSelectCallbacks,
+  )
   const dispatch = action => dispatchWithoutProps({props, ...action})
 
   // IDs generation.

--- a/src/hooks/useSelect/propCallbacks.js
+++ b/src/hooks/useSelect/propCallbacks.js
@@ -1,0 +1,28 @@
+import {
+  ItemClick,
+  MenuKeyDownEnter,
+  FunctionSelectItem,
+} from './stateChangeTypes'
+
+export default function selectCallbacks(action, newState) {
+  handleOnItemSelectedCallback(action, newState)
+}
+
+function handleOnItemSelectedCallback(action, newState) {
+  if (!action.props.onItemSelected) return
+
+  if (wasItemSelected(action)) {
+    action.props.onItemSelected(newState)
+  }
+}
+
+function wasItemSelected(action) {
+  switch (action.type) {
+    case ItemClick:
+    case MenuKeyDownEnter:
+    case FunctionSelectItem:
+      return true
+    default:
+      return false
+  }
+}

--- a/src/hooks/useSelect/utils.js
+++ b/src/hooks/useSelect/utils.js
@@ -115,6 +115,7 @@ const propTypes = {
   onHighlightedIndexChange: PropTypes.func,
   onStateChange: PropTypes.func,
   onIsOpenChange: PropTypes.func,
+  onItemSelected: PropTypes.func,
   environment: PropTypes.shape({
     addEventListener: PropTypes.func,
     removeEventListener: PropTypes.func,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -114,7 +114,12 @@ function callOnChangeProps(props, state, changes) {
   }
 }
 
-function useEnhancedReducer(reducer, initialState, props) {
+function useEnhancedReducer(
+  reducer,
+  initialState,
+  props,
+  performParentCallbacks,
+) {
   const enhancedReducer = useCallback(
     (state, action) => {
       state = getState(state, action.props)
@@ -124,10 +129,11 @@ function useEnhancedReducer(reducer, initialState, props) {
       const newState = stateReducer(state, {...action, changes})
 
       callOnChangeProps(action.props, state, newState)
+      performParentCallbacks(action, newState)
 
       return newState
     },
-    [reducer],
+    [performParentCallbacks, reducer],
   )
 
   const [state, dispatch] = useReducer(enhancedReducer, initialState)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This PR addresses https://github.com/downshift-js/downshift/issues/793

<!-- Why are these changes necessary? -->

**Why**: This provides a callback for users to see when an item is selected in the dropdown (even if it was the same item).

<!-- How were these changes implemented? -->

**How**: I added a new parameter to `useEnhancedReducer` called `performParentCallbacks`.

This allows the parent hook to pass in some of its own callbacks into the enhanced reducer. It takes two parameters, because that's all I need to use in the current implementation:
- `action`: The action performed, defined by parent reducer. This allows us to the action's type, which are `stateChangeTypes` defined within `useSelect`
- `newState`: The outgoing state from the reducer

In hooks/useSelect, I added a new file: `propCallbacks.js`. This file will be passed into useEnhancedReducer, and allows prop callbacks to be defined on `useSelect` that the enhanced reducer may not know about

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I feel like this is a little messy, so I'm happy to hear thoughts on this. It seems a little funky to have both `onSelectedItemChange` and `onItemSelected` defined on the same component.

I also didn't use Commitizen for the commits.. should I have done that? I can copy over with new commit messages if we feel these changes are OK.