### PR TITLE
docs(useSelect hook): add `refKey` prop description for getItemProps

### DIFF
--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -519,6 +519,7 @@ The main difference from vanilla `Downshift` is that we require the items as pro
 Optional properties:
 
 - `disabled`: If this is set to `true`, then all of the downshift item event handlers will be omitted. Items will not be highlighted when hovered, and items will not be selected when clicked.
+`refKey`: if you're rendering a composite component, that component will need to accept a prop which it forwards to the root DOM element. Commonly, folks call this `innerRef`. So you'd call: `getItemProps({item, index, refKey: 'innerRef'})` and your composite component would forward like: `<li ref={props.innerRef} />`. However, if you are just rendering a primitive component like `<div>`, there is no need to specify this property.
 
 #### `getToggleButtonProps`
 


### PR DESCRIPTION




<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: In the docs for the `useSelect` hook, I've added an item to the optional properties list of `getItemProps`, as it was not clear from the documentation at the time that this was necessary, and I had to read the `useSelect` hook source code to find this solution.



<!-- Why are these changes necessary? -->

**Why**: In developing an accessible dropdown menu with Downshift using composite components, I noticed that I needed to set the `refKey` attribute not only on the composite _menu_ component, but also on the composite _item_ components as well. Without setting this in both places, the code did not work and the docs did not explain anything about this.

<!-- How were these changes implemented? -->

**How**: A small edit to the docs.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests (N/A)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
