### PR TITLE
Run stateReducer over stateToSet passed to onInputValueChange

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82078,
-    "minified": 38025,
-    "gzipped": 9601
+    "bundled": 82191,
+    "minified": 38067,
+    "gzipped": 9607
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80787,
-    "minified": 36977,
-    "gzipped": 9500
+    "bundled": 80900,
+    "minified": 37019,
+    "gzipped": 9508
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93847,
-    "minified": 32054,
-    "gzipped": 9859
+    "bundled": 93966,
+    "minified": 32096,
+    "gzipped": 9863
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 107911,
-    "minified": 38110,
-    "gzipped": 11396
+    "bundled": 108030,
+    "minified": 38152,
+    "gzipped": 11403
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98486,
-    "minified": 33372,
-    "gzipped": 10422
+    "bundled": 98605,
+    "minified": 33414,
+    "gzipped": 10426
   },
   "dist/downshift.umd.js": {
-    "bundled": 137071,
-    "minified": 47008,
-    "gzipped": 14011
+    "bundled": 137190,
+    "minified": 47050,
+    "gzipped": 14014
   },
   "dist/downshift.esm.js": {
-    "bundled": 81697,
-    "minified": 37716,
-    "gzipped": 9541,
+    "bundled": 81810,
+    "minified": 37758,
+    "gzipped": 9548,
     "treeshaked": {
       "rollup": {
         "code": 629,
         "import_statements": 303
       },
       "webpack": {
-        "code": 27590
+        "code": 27632
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 80387,
-    "minified": 36649,
-    "gzipped": 9439,
+    "bundled": 80500,
+    "minified": 36691,
+    "gzipped": 9443,
     "treeshaked": {
       "rollup": {
         "code": 630,
         "import_statements": 304
       },
       "webpack": {
-        "code": 27633
+        "code": 27675
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,36 +1,36 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82191,
+    "bundled": 82377,
     "minified": 38067,
     "gzipped": 9607
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80900,
+    "bundled": 81086,
     "minified": 37019,
     "gzipped": 9508
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93966,
+    "bundled": 94158,
     "minified": 32096,
     "gzipped": 9863
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 108030,
+    "bundled": 108222,
     "minified": 38152,
     "gzipped": 11403
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98605,
+    "bundled": 98797,
     "minified": 33414,
     "gzipped": 10426
   },
   "dist/downshift.umd.js": {
-    "bundled": 137190,
+    "bundled": 137382,
     "minified": 47050,
     "gzipped": 14014
   },
   "dist/downshift.esm.js": {
-    "bundled": 81810,
+    "bundled": 81996,
     "minified": 37758,
     "gzipped": 9548,
     "treeshaked": {
@@ -44,7 +44,7 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 80500,
+    "bundled": 80686,
     "minified": 36691,
     "gzipped": 9443,
     "treeshaked": {

--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -261,6 +261,7 @@ test('selecting an item calls onInputValueChange with reduced state', () => {
     onInputValueChange: onInputValueChangeSpy,
   })
   selectItem('bar')
+  expect(onInputValueChangeSpy).toHaveBeenCalledTimes(1)
   expect(onInputValueChangeSpy).toHaveReturnedWith(
     expect.objectContaining({selectedItem: 'foo'}),
   )
@@ -281,6 +282,7 @@ test('onInputValueChange is called when reduced state includes inputValue', () =
   })
   openMenu()
   expect(onInputValueChangeSpy).toHaveBeenCalledTimes(1)
+  expect(onInputValueChangeSpy).toHaveBeenCalledWith('baz', expect.any(Object))
 })
 
 test('onInputValueChange is not called when reduced state does not include inputValue', () => {
@@ -295,7 +297,7 @@ test('onInputValueChange is not called when reduced state does not include input
     onInputValueChange: onInputValueChangeSpy,
   })
   selectItem('bar')
-  expect(onInputValueChangeSpy).toHaveBeenCalledTimes(0)
+  expect(onInputValueChangeSpy).not.toHaveBeenCalled()
 })
 
 function mouseDownAndUp(node) {

--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -250,6 +250,54 @@ test('controlled highlighted index change scrolls the item into view', () => {
   )
 })
 
+test('selecting an item calls onInputValueChange with reduced state', () => {
+  const stateReducer = (_, changes) => ({
+    ...changes,
+    selectedItem: 'foo',
+  })
+  const onInputValueChangeSpy = jest.fn((_, stateAndHelpers) => stateAndHelpers)
+  const {selectItem} = setup({
+    stateReducer,
+    onInputValueChange: onInputValueChangeSpy,
+  })
+  selectItem('bar')
+  expect(onInputValueChangeSpy).toHaveReturnedWith(
+    expect.objectContaining({selectedItem: 'foo'}),
+  )
+})
+
+test('onInputValueChange is called when reduced state includes inputValue', () => {
+  const stateReducer = (_, changes) => {
+    return {
+      ...changes,
+      inputValue: 'baz',
+    }
+  }
+  const onInputValueChangeSpy = jest.fn(() => null)
+  const {openMenu} = setup({
+    stateReducer,
+    inputValue: 'foo',
+    onInputValueChange: onInputValueChangeSpy,
+  })
+  openMenu()
+  expect(onInputValueChangeSpy).toHaveBeenCalledTimes(1)
+})
+
+test('onInputValueChange is not called when reduced state does not include inputValue', () => {
+  const stateReducer = (_, changes) => {
+    delete changes.inputValue
+    return changes
+  }
+  const onInputValueChangeSpy = jest.fn(() => null)
+  const {selectItem} = setup({
+    stateReducer,
+    inputValue: 'foo',
+    onInputValueChange: onInputValueChangeSpy,
+  })
+  selectItem('bar')
+  expect(onInputValueChangeSpy).toHaveBeenCalledTimes(0)
+})
+
 function mouseDownAndUp(node) {
   fireEvent.mouseDown(node)
   fireEvent.mouseUp(node)

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -342,6 +342,9 @@ class Downshift extends Component {
     // preserving the cursor position.
     // See https://github.com/downshift-js/downshift/issues/217 for more info.
     if (!isStateToSetFunction) {
+      // Run stateReducer over the stateToSet before we check
+      // whether it hasOwnProperty because we are able to
+      // add / remove the inputValue using the stateReducer
       const newStateToSet = this.props.stateReducer(this.state, stateToSet)
       if (newStateToSet.hasOwnProperty('inputValue')) {
         this.props.onInputValueChange(newStateToSet.inputValue, {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -341,11 +341,14 @@ class Downshift extends Component {
     // the input change as soon as possible. This avoids issues with
     // preserving the cursor position.
     // See https://github.com/downshift-js/downshift/issues/217 for more info.
-    if (!isStateToSetFunction && stateToSet.hasOwnProperty('inputValue')) {
-      this.props.onInputValueChange(stateToSet.inputValue, {
-        ...this.getStateAndHelpers(),
-        ...stateToSet,
-      })
+    if (!isStateToSetFunction) {
+      const newStateToSet = this.props.stateReducer(this.state, stateToSet)
+      if (newStateToSet.hasOwnProperty('inputValue')) {
+        this.props.onInputValueChange(newStateToSet.inputValue, {
+          ...this.getStateAndHelpers(),
+          ...newStateToSet,
+        })
+      }
     }
     return this.setState(
       state => {
@@ -833,10 +836,8 @@ class Downshift extends Component {
         !!this.props.environment.document.activeElement &&
         !!this.props.environment.document.activeElement.dataset &&
         this.props.environment.document.activeElement.dataset.toggle &&
-        (this._rootNode &&
-          this._rootNode.contains(
-            this.props.environment.document.activeElement,
-          ))
+        this._rootNode &&
+        this._rootNode.contains(this.props.environment.document.activeElement)
       if (!this.isMouseDown && !downshiftButtonIsActive) {
         this.reset({type: stateChangeTypes.blurInput})
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixes #819 

<!-- Why are these changes necessary? -->

**Why**: Right now depending on how `internalSetState` is being called (as a state object or function) the `stateAndHelpers` param has either been run through the `stateReducer` or it hasn't, this PR addresses this and makes both implementations work the same.

<!-- How were these changes implemented? -->

**How**: I run the `stateToSet` through the `stateReducer` and pass that state to the `onInputValueChange` function, exactly how it's being done within the functional `setState` just below.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I have added a couple of tests that make sure the bugs that I identified aren't a problem anymore, not sure if they're done in the best way or not though so any feedback on that one would be appreciated.
