### PR TITLE
fix(useSelect): respect disabled option passed to `getItemProps`

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82078,
-    "minified": 38025,
-    "gzipped": 9601
+    "bundled": 82171,
+    "minified": 38051,
+    "gzipped": 9612
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80787,
-    "minified": 36977,
-    "gzipped": 9500
+    "bundled": 80880,
+    "minified": 37003,
+    "gzipped": 9510
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93847,
-    "minified": 32054,
-    "gzipped": 9859
+    "bundled": 93946,
+    "minified": 32080,
+    "gzipped": 9869
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 107911,
-    "minified": 38110,
-    "gzipped": 11396
+    "bundled": 108010,
+    "minified": 38136,
+    "gzipped": 11406
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98486,
-    "minified": 33372,
-    "gzipped": 10422
+    "bundled": 98585,
+    "minified": 33398,
+    "gzipped": 10431
   },
   "dist/downshift.umd.js": {
-    "bundled": 137071,
-    "minified": 47008,
-    "gzipped": 14011
+    "bundled": 137170,
+    "minified": 47034,
+    "gzipped": 14022
   },
   "dist/downshift.esm.js": {
-    "bundled": 81697,
-    "minified": 37716,
-    "gzipped": 9541,
+    "bundled": 81790,
+    "minified": 37742,
+    "gzipped": 9551,
     "treeshaked": {
       "rollup": {
         "code": 629,
         "import_statements": 303
       },
       "webpack": {
-        "code": 27590
+        "code": 27616
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 80387,
-    "minified": 36649,
-    "gzipped": 9439,
+    "bundled": 80480,
+    "minified": 36675,
+    "gzipped": 9449,
     "treeshaked": {
       "rollup": {
         "code": 630,
         "import_statements": 304
       },
       "webpack": {
-        "code": 27633
+        "code": 27659
       }
     }
   }

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -50,6 +50,16 @@ describe('getItemProps', () => {
 
       expect(itemProps['aria-selected']).toBeUndefined()
     })
+
+    test('omit event handlers when disabled', () => {
+      const {result} = setupHook()
+      const itemProps = result.current.getItemProps({
+        disabled: true,
+      })
+
+      expect(itemProps.onMouseMove).toBeUndefined()
+      expect(itemProps.onClick).toBeUndefined()
+    })
   })
 
   describe('user props', () => {

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -54,6 +54,7 @@ describe('getItemProps', () => {
     test('omit event handlers when disabled', () => {
       const {result} = setupHook()
       const itemProps = result.current.getItemProps({
+        index: 0,
         disabled: true,
       })
 

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -398,7 +398,7 @@ function useSelect(userProps = {}) {
     if (itemIndex < 0) {
       throw new Error('Pass either item or item index in getItemProps!')
     }
-    return {
+    const itemProps = {
       [refKey]: handleRefs(ref, itemNode => {
         if (itemNode) {
           itemRefs.current.push(itemNode)
@@ -407,12 +407,15 @@ function useSelect(userProps = {}) {
       role: 'option',
       ...(itemIndex === highlightedIndex && {'aria-selected': true}),
       id: getItemId(itemIndex),
-      onMouseMove: callAllEventHandlers(onMouseMove, () =>
-        itemHandleMouseMove(itemIndex),
-      ),
-      onClick: callAllEventHandlers(onClick, () => itemHandleClick(itemIndex)),
       ...rest,
+    };
+
+    if (!rest.disabled) {
+      itemProps.onMouseMove = callAllEventHandlers(onMouseMove, () =>itemHandleMouseMove(itemIndex))
+      itemProps.onClick = callAllEventHandlers(onClick, () => itemHandleClick(itemIndex))
     }
+
+    return itemProps;
   }
 
   return {


### PR DESCRIPTION
**What**:
`disabled` property is ignored when passed to `getItemProps`

**Why**:
Not respecting `disabled` property causes unwanted handlers to trigger on hover and click (opposite to the what [docs](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect#getitemprops) says)

**How**:
I followed the convention that @maxmalov used to fix similar bug (#829), but in `getToggleButtonProps`. 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
