### PR TITLE
Fix of useSelect stateReducer typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -287,8 +287,8 @@ export interface UseSelectProps<Item> {
   getItemId?: (index: number) => string
   stateReducer?: (
     state: UseSelectState<Item>,
-    changes: UseSelectStateChangeOptions<Item>,
-  ) => Partial<UseSelectStateChangeOptions<Item>>
+    actionAndChanges: UseSelectStateChangeOptions<Item>,
+  ) => UseSelectState<Item>
   onSelectedItemChange?: (changes: Partial<UseSelectState<Item>>) => void
   onIsOpenChange?: (changes: Partial<UseSelectState<Item>>) => void
   onHighlightedIndexChange?: (changes: Partial<UseSelectState<Item>>) => void
@@ -303,9 +303,10 @@ export interface UseSelectA11yMessageOptions<Item> {
   itemToString: (item: Item) => string
 }
 
-export interface UseSelectStateChangeOptions<Item>
-  extends Partial<UseSelectState<Item>> {
+export interface UseSelectStateChangeOptions<Item> {
   type: UseSelectStateChangeTypes
+  changes: UseSelectState<Item>
+  props: UseSelectProps<Item>
 }
 
 export interface UseSelectPropGetters<Item> {


### PR DESCRIPTION
**What**:

Fixed wrong ts typings of useSelect stateReducer

**Why**:

Fixes #838 

**How**:

Fixed `typings/index.d.ts`

**Checklist**:
- [x] Documentation: N/A
- [x] Tests
- [x] Ready to be merged