### PR TITLE
perf(getItemProps): memoize the event handlers for item

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82171,
-    "minified": 38051,
-    "gzipped": 9612
+    "bundled": 83479,
+    "minified": 38653,
+    "gzipped": 9793
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80880,
-    "minified": 37003,
-    "gzipped": 9510
+    "bundled": 82188,
+    "minified": 37605,
+    "gzipped": 9684
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93946,
-    "minified": 32080,
-    "gzipped": 9869
+    "bundled": 113690,
+    "minified": 35968,
+    "gzipped": 11186
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 108010,
-    "minified": 38136,
-    "gzipped": 11406
+    "bundled": 127754,
+    "minified": 42036,
+    "gzipped": 12688
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98585,
-    "minified": 33398,
-    "gzipped": 10431
+    "bundled": 118337,
+    "minified": 37304,
+    "gzipped": 11735
   },
   "dist/downshift.umd.js": {
-    "bundled": 137170,
-    "minified": 47034,
-    "gzipped": 14022
+    "bundled": 156922,
+    "minified": 50939,
+    "gzipped": 15291
   },
   "dist/downshift.esm.js": {
-    "bundled": 81790,
-    "minified": 37742,
-    "gzipped": 9551,
+    "bundled": 83078,
+    "minified": 38329,
+    "gzipped": 9730,
     "treeshaked": {
       "rollup": {
-        "code": 629,
-        "import_statements": 303
+        "code": 652,
+        "import_statements": 326
       },
       "webpack": {
-        "code": 27616
+        "code": 28191
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 80480,
-    "minified": 36675,
-    "gzipped": 9449,
+    "bundled": 81768,
+    "minified": 37262,
+    "gzipped": 9620,
     "treeshaked": {
       "rollup": {
-        "code": 630,
-        "import_statements": 304
+        "code": 653,
+        "import_statements": 327
       },
       "webpack": {
-        "code": 27659
+        "code": 28234
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 83479,
-    "minified": 38653,
-    "gzipped": 9793
+    "bundled": 82820,
+    "minified": 38436,
+    "gzipped": 9717
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 82188,
-    "minified": 37605,
-    "gzipped": 9684
+    "bundled": 81529,
+    "minified": 37388,
+    "gzipped": 9609
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 113690,
-    "minified": 35968,
-    "gzipped": 11186
+    "bundled": 113005,
+    "minified": 35796,
+    "gzipped": 11126
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 127754,
-    "minified": 42036,
-    "gzipped": 12688
+    "bundled": 127069,
+    "minified": 41864,
+    "gzipped": 12627
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 118337,
-    "minified": 37304,
-    "gzipped": 11735
+    "bundled": 117652,
+    "minified": 37132,
+    "gzipped": 11676
   },
   "dist/downshift.umd.js": {
-    "bundled": 156922,
-    "minified": 50939,
-    "gzipped": 15291
+    "bundled": 156237,
+    "minified": 50767,
+    "gzipped": 15231
   },
   "dist/downshift.esm.js": {
-    "bundled": 83078,
-    "minified": 38329,
-    "gzipped": 9730,
+    "bundled": 82419,
+    "minified": 38112,
+    "gzipped": 9651,
     "treeshaked": {
       "rollup": {
         "code": 652,
         "import_statements": 326
       },
       "webpack": {
-        "code": 28191
+        "code": 28019
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 81768,
-    "minified": 37262,
-    "gzipped": 9620,
+    "bundled": 81109,
+    "minified": 37045,
+    "gzipped": 9547,
     "treeshaked": {
       "rollup": {
         "code": 653,
         "import_statements": 327
       },
       "webpack": {
-        "code": 28234
+        "code": 28062
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82820,
-    "minified": 38436,
-    "gzipped": 9717
+    "bundled": 82391,
+    "minified": 38211,
+    "gzipped": 9665
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 81529,
-    "minified": 37388,
-    "gzipped": 9609
+    "bundled": 81100,
+    "minified": 37163,
+    "gzipped": 9564
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 113005,
-    "minified": 35796,
-    "gzipped": 11126
+    "bundled": 96750,
+    "minified": 33202,
+    "gzipped": 10210
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 127069,
-    "minified": 41864,
-    "gzipped": 12627
+    "bundled": 110814,
+    "minified": 39259,
+    "gzipped": 11755
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 117652,
-    "minified": 37132,
-    "gzipped": 11676
+    "bundled": 101389,
+    "minified": 34520,
+    "gzipped": 10797
   },
   "dist/downshift.umd.js": {
-    "bundled": 156237,
-    "minified": 50767,
-    "gzipped": 15231
+    "bundled": 139974,
+    "minified": 48161,
+    "gzipped": 14354
   },
   "dist/downshift.esm.js": {
-    "bundled": 82419,
-    "minified": 38112,
-    "gzipped": 9651,
+    "bundled": 81990,
+    "minified": 37887,
+    "gzipped": 9604,
     "treeshaked": {
       "rollup": {
-        "code": 652,
-        "import_statements": 326
+        "code": 650,
+        "import_statements": 324
       },
       "webpack": {
-        "code": 28019
+        "code": 27794
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 81109,
-    "minified": 37045,
-    "gzipped": 9547,
+    "bundled": 80680,
+    "minified": 36820,
+    "gzipped": 9503,
     "treeshaked": {
       "rollup": {
-        "code": 653,
-        "import_statements": 327
+        "code": 651,
+        "import_statements": 325
       },
       "webpack": {
-        "code": 28062
+        "code": 27837
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "compute-scroll-into-view": "^1.0.9",
+    "lodash.memoize": "^4.1.2",
     "prop-types": "^15.7.2",
     "react-is": "^16.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "compute-scroll-into-view": "^1.0.9",
-    "lodash.memoize": "^4.1.2",
+    "fast-memoize": "^2.5.1",
     "prop-types": "^15.7.2",
     "react-is": "^16.9.0"
   },

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -3,7 +3,7 @@
 import PropTypes from 'prop-types'
 import {Component, cloneElement} from 'react'
 import {isForwardRef} from 'react-is'
-import memoize from 'lodash.memoize'
+import memoize from 'fast-memoize'
 import {isPreact, isReactNative} from './is.macro'
 import setA11yStatus from './set-a11y-status'
 import * as stateChangeTypes from './stateChangeTypes'
@@ -868,56 +868,47 @@ class Downshift extends Component {
   }
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ MENU
 
-  getItemPropsEventHandlers = ({
-    onClick,
-    onPress,
-    onMouseMove,
-    onMouseDown,
-    index,
-  }) => {
-    const onSelectKey = isReactNative
-      ? /* istanbul ignore next (react-native) */ 'onPress'
-      : 'onClick'
-    const customClickHandler = isReactNative
-      ? /* istanbul ignore next (react-native) */ onPress
-      : onClick
+  getItemPropsEventHandlers = memoize(
+    (index, item, onClick, onPress, onMouseMove, onMouseDown) => {
+      const onSelectKey = isReactNative
+        ? /* istanbul ignore next (react-native) */ 'onPress'
+        : 'onClick'
+      const customClickHandler = isReactNative
+        ? /* istanbul ignore next (react-native) */ onPress
+        : onClick
 
-    return {
-      // onMouseMove is used over onMouseEnter here. onMouseMove
-      // is only triggered on actual mouse movement while onMouseEnter
-      // can fire on DOM changes, interrupting keyboard navigation
-      onMouseMove: callAllEventHandlers(onMouseMove, () => {
-        if (index === this.getState().highlightedIndex) {
-          return
-        }
-        this.setHighlightedIndex(index, {
-          type: stateChangeTypes.itemMouseEnter,
-        })
+      return {
+        // onMouseMove is used over onMouseEnter here. onMouseMove
+        // is only triggered on actual mouse movement while onMouseEnter
+        // can fire on DOM changes, interrupting keyboard navigation
+        onMouseMove: callAllEventHandlers(onMouseMove, () => {
+          if (index === this.getState().highlightedIndex) {
+            return
+          }
+          this.setHighlightedIndex(index, {
+            type: stateChangeTypes.itemMouseEnter,
+          })
 
-        // We never want to manually scroll when changing state based
-        // on `onMouseMove` because we will be moving the element out
-        // from under the user which is currently scrolling/moving the
-        // cursor
-        this.avoidScrolling = true
-        this.internalSetTimeout(() => (this.avoidScrolling = false), 250)
-      }),
-      onMouseDown: callAllEventHandlers(onMouseDown, event => {
-        // This prevents the activeElement from being changed
-        // to the item so it can remain with the current activeElement
-        // which is a more common use case.
-        event.preventDefault()
-      }),
-      [onSelectKey]: callAllEventHandlers(customClickHandler, () => {
-        this.selectItemAtIndex(index, {
-          type: stateChangeTypes.clickItem,
-        })
-      }),
-    }
-  }
-
-  getItemPropsEventHandlersMemoized = memoize(
-    this.getItemPropsEventHandlers,
-    ({index}) => this.getItemId(index),
+          // We never want to manually scroll when changing state based
+          // on `onMouseMove` because we will be moving the element out
+          // from under the user which is currently scrolling/moving the
+          // cursor
+          this.avoidScrolling = true
+          this.internalSetTimeout(() => (this.avoidScrolling = false), 250)
+        }),
+        onMouseDown: callAllEventHandlers(onMouseDown, event => {
+          // This prevents the activeElement from being changed
+          // to the item so it can remain with the current activeElement
+          // which is a more common use case.
+          event.preventDefault()
+        }),
+        [onSelectKey]: callAllEventHandlers(customClickHandler, () => {
+          this.selectItemAtIndex(index, {
+            type: stateChangeTypes.clickItem,
+          })
+        }),
+      }
+    },
   )
 
   /////////////////////////////// ITEM
@@ -939,13 +930,14 @@ class Downshift extends Component {
       this.items[index] = item
     }
 
-    const enabledEventHandlers = this.getItemPropsEventHandlersMemoized({
+    const enabledEventHandlers = this.getItemPropsEventHandlers(
+      index,
+      item,
       onClick,
       onMouseDown,
       onMouseMove,
       onPress,
-      index,
-    })
+    )
 
     // Passing down the onMouseDown handler to prevent redirect
     // of the activeElement if clicking on disabled items

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -917,7 +917,7 @@ class Downshift extends Component {
 
   getItemPropsEventHandlersMemoized = memoize(
     this.getItemPropsEventHandlers,
-    ({item, index}) => `${this.props.itemToString(item)}-${index}`,
+    ({index}) => this.getItemId(index),
   )
 
   /////////////////////////////// ITEM
@@ -945,7 +945,6 @@ class Downshift extends Component {
       onMouseMove,
       onPress,
       index,
-      item,
     })
 
     // Passing down the onMouseDown handler to prevent redirect


### PR DESCRIPTION
The main reason for doing this is because we are calling `getItemProps` to apply attributes / handlers and also to supply Downshift with items. If we want to avoid calling it so that we don't re-render the item, Downshift on re-render will throw away the items references and will not know about them anymore.

Since there is no way to avoid calling this with current `Downshift` implementation, we should at least provide the event handlers as memoized functions, so if your item is a pure component and it does not have to change, it will not.

Probably we should use this approach with the rest of the handlers as well, will need to look into it soon.