### PR TITLE
chore: Add `sideEffects` hint for ESM bundlers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/downshift.cjs.js",
   "react-native": "dist/downshift.native.cjs.js",
   "module": "dist/downshift.esm.js",
+  "sideEffects": false,
   "typings": "typings/index.d.ts",
   "scripts": {
     "build": "npm run build:web --silent && npm run build:native --silent",


### PR DESCRIPTION
See https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free.

**What**: This PR adds the `sideEffects` hint to `package.json`. This assumes that `Downshift` does not introduce any side effects.

**Why**: So that bundlers can tree shake the ESM distribution of `Downshift` more efficiently

**How**: A simple boolean flag was added in `package.json`.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged

I am only assuming `Downshift` has no side effects. We should verify that before merging this.
