### PR TITLE
fix(ts): fix useSelect typings for stateReducer and stateChangeTypes

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82171,
-    "minified": 38051,
-    "gzipped": 9612
+    "bundled": 82763,
+    "minified": 38226,
+    "gzipped": 9667
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 80880,
-    "minified": 37003,
-    "gzipped": 9510
+    "bundled": 81472,
+    "minified": 37178,
+    "gzipped": 9567
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 93946,
-    "minified": 32080,
-    "gzipped": 9869
+    "bundled": 94473,
+    "minified": 32166,
+    "gzipped": 9899
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 108010,
-    "minified": 38136,
-    "gzipped": 11406
+    "bundled": 108329,
+    "minified": 38150,
+    "gzipped": 11424
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 98585,
-    "minified": 33398,
-    "gzipped": 10431
+    "bundled": 99112,
+    "minified": 33484,
+    "gzipped": 10477
   },
   "dist/downshift.umd.js": {
-    "bundled": 137170,
-    "minified": 47034,
-    "gzipped": 14022
+    "bundled": 137489,
+    "minified": 47048,
+    "gzipped": 14044
   },
   "dist/downshift.esm.js": {
-    "bundled": 81790,
-    "minified": 37742,
-    "gzipped": 9551,
+    "bundled": 82382,
+    "minified": 37917,
+    "gzipped": 9607,
     "treeshaked": {
       "rollup": {
         "code": 629,
         "import_statements": 303
       },
       "webpack": {
-        "code": 27616
+        "code": 27754
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 80480,
-    "minified": 36675,
-    "gzipped": 9449,
+    "bundled": 81072,
+    "minified": 36850,
+    "gzipped": 9506,
     "treeshaked": {
       "rollup": {
         "code": 630,
         "import_statements": 304
       },
       "webpack": {
-        "code": 27659
+        "code": 27797
       }
     }
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -287,8 +287,8 @@ export interface UseSelectProps<Item> {
   getItemId?: (index: number) => string
   stateReducer?: (
     state: UseSelectState<Item>,
-    changes: UseSelectStateChangeOptions<Item>,
-  ) => Partial<UseSelectStateChangeOptions<Item>>
+    actionAndChanges: UseSelectStateChangeOptions<Item>,
+  ) => UseSelectState<Item>
   onSelectedItemChange?: (changes: Partial<UseSelectState<Item>>) => void
   onIsOpenChange?: (changes: Partial<UseSelectState<Item>>) => void
   onHighlightedIndexChange?: (changes: Partial<UseSelectState<Item>>) => void
@@ -303,9 +303,10 @@ export interface UseSelectA11yMessageOptions<Item> {
   itemToString: (item: Item) => string
 }
 
-export interface UseSelectStateChangeOptions<Item>
-  extends Partial<UseSelectState<Item>> {
+export interface UseSelectStateChangeOptions<Item> {
   type: UseSelectStateChangeTypes
+  changes: UseSelectState<Item>
+  props: UseSelectProps<Item>
 }
 
 export interface UseSelectPropGetters<Item> {
@@ -331,9 +332,8 @@ export type UseSelectReturnValue<Item> = UseSelectState<Item> &
   UseSelectPropGetters<Item> &
   UseSelectActions<Item>
 
-export type UseSelectInterface<Item> = (
-  props: UseSelectProps<Item>,
-) => UseSelectReturnValue<Item> & {
+export interface UseSelectInterface {
+  <Item>(props: UseSelectProps<Item>): UseSelectReturnValue<Item>
   stateChangeTypes: {
     MenuKeyDownArrowDown: UseSelectStateChangeTypes.MenuKeyDownArrowDown
     MenuKeyDownArrowUp: UseSelectStateChangeTypes.MenuKeyDownArrowUp
@@ -360,6 +360,4 @@ export type UseSelectInterface<Item> = (
   }
 }
 
-export function useSelect<Item>(
-  props: UseSelectProps<Item>,
-): UseSelectReturnValue<Item>
+export const useSelect: UseSelectInterface


### PR DESCRIPTION
Bundling https://github.com/downshift-js/downshift/pull/839/ and https://github.com/downshift-js/downshift/pull/840/ together. Fixes https://github.com/downshift-js/downshift/issues/836 and https://github.com/downshift-js/downshift/issues/838.

Many thanks to @saitonakamura for these fixes! @all-contributors please add @saitonakamura for bug and code!