### PR TITLE
fix: treeshake Downshift and useSelect

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,14 @@
+const originalPreset = require('kcd-scripts/babel')
+const customPreset = api => {
+  api.cache(true)
+  const evaluatedPreset = originalPreset(api)
+  const plugins = [
+    ['no-side-effect-class-properties'],
+    ...evaluatedPreset.plugins,
+  ]
+  return {
+    ...evaluatedPreset,
+    plugins,
+  }
+}
+module.exports = customPreset

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,16 +1,16 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 84638,
-    "minified": 38280,
-    "gzipped": 9685
+    "bundled": 84692,
+    "minified": 38317,
+    "gzipped": 9688
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 83346,
-    "minified": 37232,
-    "gzipped": 9579
+    "bundled": 83400,
+    "minified": 37269,
+    "gzipped": 9582
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 95780,
+    "bundled": 95821,
     "minified": 31665,
     "gzipped": 9759
   },
@@ -20,7 +20,7 @@
     "gzipped": 11495
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 100025,
+    "bundled": 100066,
     "minified": 32983,
     "gzipped": 10333
   },
@@ -30,9 +30,9 @@
     "gzipped": 14120
   },
   "dist/downshift.esm.js": {
-    "bundled": 84257,
-    "minified": 37971,
-    "gzipped": 9624,
+    "bundled": 84311,
+    "minified": 38008,
+    "gzipped": 9627,
     "treeshaked": {
       "rollup": {
         "code": 629,
@@ -44,9 +44,9 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 82946,
-    "minified": 36904,
-    "gzipped": 9517,
+    "bundled": 83000,
+    "minified": 36941,
+    "gzipped": 9520,
     "treeshaked": {
       "rollup": {
         "code": 630,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 82763,
-    "minified": 38226,
-    "gzipped": 9667
+    "bundled": 84591,
+    "minified": 38239,
+    "gzipped": 9676
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 81472,
-    "minified": 37178,
-    "gzipped": 9567
+    "bundled": 83299,
+    "minified": 37191,
+    "gzipped": 9572
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 94473,
-    "minified": 32166,
-    "gzipped": 9899
+    "bundled": 96281,
+    "minified": 32203,
+    "gzipped": 9910
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 108329,
-    "minified": 38150,
-    "gzipped": 11424
+    "bundled": 111340,
+    "minified": 38242,
+    "gzipped": 11495
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 99112,
-    "minified": 33484,
-    "gzipped": 10477
+    "bundled": 100534,
+    "minified": 33521,
+    "gzipped": 10489
   },
   "dist/downshift.umd.js": {
-    "bundled": 137489,
-    "minified": 47048,
-    "gzipped": 14044
+    "bundled": 140975,
+    "minified": 47153,
+    "gzipped": 14120
   },
   "dist/downshift.esm.js": {
-    "bundled": 82382,
-    "minified": 37917,
-    "gzipped": 9607,
+    "bundled": 84210,
+    "minified": 37930,
+    "gzipped": 9617,
     "treeshaked": {
       "rollup": {
         "code": 629,
         "import_statements": 303
       },
       "webpack": {
-        "code": 27754
+        "code": 12805
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 81072,
-    "minified": 36850,
-    "gzipped": 9506,
+    "bundled": 82899,
+    "minified": 36863,
+    "gzipped": 9510,
     "treeshaked": {
       "rollup": {
         "code": 630,
         "import_statements": 304
       },
       "webpack": {
-        "code": 27797
+        "code": 12806
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 84591,
-    "minified": 38239,
-    "gzipped": 9676
+    "bundled": 84638,
+    "minified": 38280,
+    "gzipped": 9685
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 83299,
-    "minified": 37191,
-    "gzipped": 9572
+    "bundled": 83346,
+    "minified": 37232,
+    "gzipped": 9579
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 96281,
-    "minified": 32203,
-    "gzipped": 9910
+    "bundled": 95780,
+    "minified": 31665,
+    "gzipped": 9759
   },
   "preact/dist/downshift.umd.js": {
     "bundled": 111340,
@@ -20,9 +20,9 @@
     "gzipped": 11495
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 100534,
-    "minified": 33521,
-    "gzipped": 10489
+    "bundled": 100025,
+    "minified": 32983,
+    "gzipped": 10333
   },
   "dist/downshift.umd.js": {
     "bundled": 140975,
@@ -30,30 +30,30 @@
     "gzipped": 14120
   },
   "dist/downshift.esm.js": {
-    "bundled": 84210,
-    "minified": 37930,
-    "gzipped": 9617,
+    "bundled": 84257,
+    "minified": 37971,
+    "gzipped": 9624,
     "treeshaked": {
       "rollup": {
         "code": 629,
         "import_statements": 303
       },
       "webpack": {
-        "code": 12805
+        "code": 2839
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 82899,
-    "minified": 36863,
-    "gzipped": 9510,
+    "bundled": 82946,
+    "minified": 36904,
+    "gzipped": 9517,
     "treeshaked": {
       "rollup": {
         "code": 630,
         "import_statements": 304
       },
       "webpack": {
-        "code": 12806
+        "code": 2838
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "react-native": "dist/downshift.native.cjs.js",
   "module": "dist/downshift.esm.js",
   "typings": "typings/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "npm run build:web --silent && npm run build:native --silent",
     "build:web": "kcd-scripts build --bundle --p-react --no-clean --size-snapshot",
@@ -80,6 +81,7 @@
     "@types/jest": "^24.0.15",
     "@types/react": "^16.9.2",
     "babel-plugin-macros": "^2.6.1",
+    "babel-plugin-no-side-effect-class-properties": "0.0.7",
     "babel-preset-react-native": "^4.0.1",
     "buble": "^0.19.6",
     "cpy-cli": "^2.0.0",
@@ -98,6 +100,7 @@
     "react-dom": "^16.9.0",
     "react-native": "^0.60.5",
     "react-test-renderer": "^16.9.0",
+    "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
     "serve": "^11.0.2",
     "start-server-and-test": "^1.10.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,19 @@
+const babel = require('rollup-plugin-babel')
 const commonjs = require('rollup-plugin-commonjs')
 const config = require('kcd-scripts/dist/config/rollup.config.js')
-
+const babelPluginIndex = config.plugins.findIndex(
+  plugin => plugin.name === 'babel',
+)
 const cjsPluginIndex = config.plugins.findIndex(
   plugin => plugin.name === 'commonjs',
 )
+config.plugins[babelPluginIndex] = babel({
+  runtimeHelpers: true,
+})
 config.plugins[cjsPluginIndex] = commonjs({
   include: 'node_modules/**',
   namedExports: {
     'react-is': ['isForwardRef'],
   },
 })
-
 module.exports = config

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -17,6 +17,7 @@ import {
   debounce,
   scrollIntoView as defaultScrollIntoView,
   normalizeArrowKey,
+  noop,
 } from '../../utils'
 import downshiftSelectReducer from './reducer'
 import {
@@ -27,7 +28,10 @@ import {
 } from './utils'
 import * as stateChangeTypes from './stateChangeTypes'
 
-const validatePropTypes = getPropTypesValidator(useSelect, propTypes)
+const validatePropTypes =
+  process.env.NODE_ENV === 'production'
+    ? noop
+    : getPropTypesValidator(useSelect, propTypes)
 const defaultProps = {
   itemToString: defaultItemToString,
   stateReducer: (s, a) => a.changes,

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -17,7 +17,6 @@ import {
   debounce,
   scrollIntoView as defaultScrollIntoView,
   normalizeArrowKey,
-  noop,
 } from '../../utils'
 import downshiftSelectReducer from './reducer'
 import {
@@ -30,7 +29,7 @@ import * as stateChangeTypes from './stateChangeTypes'
 
 const validatePropTypes =
   process.env.NODE_ENV === 'production'
-    ? noop
+    ? null
     : getPropTypesValidator(useSelect, propTypes)
 const defaultProps = {
   itemToString: defaultItemToString,
@@ -47,7 +46,9 @@ const defaultProps = {
 useSelect.stateChangeTypes = stateChangeTypes
 
 function useSelect(userProps = {}) {
-  validatePropTypes(userProps)
+  if (process.env.NODE_ENV !== 'production') {
+    validatePropTypes(userProps)
+  }
   // Props defaults and destructuring.
   const props = {
     ...defaultProps,

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -29,7 +29,7 @@ import * as stateChangeTypes from './stateChangeTypes'
 
 const validatePropTypes =
   process.env.NODE_ENV === 'production'
-    ? null
+    ? /* istanbul ignore next */ null
     : getPropTypesValidator(useSelect, propTypes)
 const defaultProps = {
   itemToString: defaultItemToString,
@@ -46,6 +46,7 @@ const defaultProps = {
 useSelect.stateChangeTypes = stateChangeTypes
 
 function useSelect(userProps = {}) {
+  /* istanbul ignore else */
   if (process.env.NODE_ENV !== 'production') {
     validatePropTypes(userProps)
   }


### PR DESCRIPTION
`defaultProps` and `stateChangeTypes` prevent Downshift from being tree-shakeable. Also the prop type checks in `useSelect`.

Use `no-side-effect-class-properties` in `.babelrc.js` along with the original configs from `kcd-scripts`. https://github.com/naver/babel-plugin-no-side-effect-class-properties @kentcdodds maybe you want to include this as well or mark it to be added once a more official version is released.

Updated `rollup.config.js` to use the babel config file.

Only check hook prop-types if not on production.

Result: treeshakeable Downshift.

Most grateful to @layershifter for contributing with this.

https://github.com/babel/babel/issues/8592
https://github.com/babel/babel/pull/6963