### PR TITLE
docs: combobox HTML correct structure in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ npm install --save downshift
 
 Usage examples are on the [docsite](https://downshift.netlify.com/) or in the
 [examples section](#examples). This example has been changed to encourage the
-use of a correct HTML structure for the autocomplete.
+use of a correct HTML structure for the autocomplete. It uses `getRootProps` on
+an element that wraps the `<input>` and optionally the `trigger button`. Check
+also the `getRootProps` in the getter props [section](#prop-getters).
 
 > [Try it out in the browser](https://codesandbox.io/s/simple-downshift-with-getrootprops-example-24s13)
 
@@ -247,10 +249,10 @@ render(
 )
 ```
 
-The old example without `getRootProps` is
+The previous example without `getRootProps` is
 [here](https://codesandbox.io/s/n9095).
 
-> Warning: It is not fully accessible using screen readers.
+> Warning: The previous example is not fully accessible using screen readers.
 
 `<Downshift />` is the only component exposed by this package. It doesn't render
 anything itself, it just calls the render function and renders that. ["Use a

--- a/README.md
+++ b/README.md
@@ -173,7 +173,11 @@ npm install --save downshift
 
 ## Usage
 
-> [Try it out in the browser](https://codesandbox.io/s/n9095)
+Usage examples are on the [docsite](https://downshift.netlify.com/) or in the
+[examples section](#examples). This example has been changed to encourage the
+use of a correct HTML structure for the autocomplete.
+
+> [Try it out in the browser](https://codesandbox.io/s/simple-downshift-with-getrootprops-example-24s13)
 
 ```jsx
 import React from 'react'
@@ -204,10 +208,16 @@ render(
       inputValue,
       highlightedIndex,
       selectedItem,
+      getRootProps,
     }) => (
       <div>
         <label {...getLabelProps()}>Enter a fruit</label>
-        <input {...getInputProps()} />
+        <div
+          style={{display: 'inline-block'}}
+          {...getRootProps({}, {suppressRefError: true})}
+        >
+          <input {...getInputProps()} />
+        </div>
         <ul {...getMenuProps()}>
           {isOpen
             ? items
@@ -236,6 +246,11 @@ render(
   document.getElementById('root'),
 )
 ```
+
+The old example without `getRootProps` is
+[here](https://codesandbox.io/s/n9095).
+
+> Warning: It is not fully accessible using screen readers.
 
 `<Downshift />` is the only component exposed by this package. It doesn't render
 anything itself, it just calls the render function and renders that. ["Use a

--- a/README.md
+++ b/README.md
@@ -173,12 +173,6 @@ npm install --save downshift
 
 ## Usage
 
-Usage examples are on the [docsite](https://downshift.netlify.com/) or in the
-[examples section](#examples). This example has been changed to encourage the
-use of a correct HTML structure for the autocomplete. It uses `getRootProps` on
-an element that wraps the `<input>` and optionally the `trigger button`. Check
-also the `getRootProps` in the getter props [section](#prop-getters).
-
 > [Try it out in the browser](https://codesandbox.io/s/simple-downshift-with-getrootprops-example-24s13)
 
 ```jsx
@@ -252,7 +246,10 @@ render(
 The previous example without `getRootProps` is
 [here](https://codesandbox.io/s/n9095).
 
-> Warning: The previous example is not fully accessible using screen readers.
+> Warning: The example without `getRootProps` is not fully accessible with
+> screen readers as it's not possible to achieve a correct HTML structure for
+> the combobox. Examples on how to use `Downshift` component with and without
+> `getRootProps` are on the [docsite](https://downshift.netlify.com/).
 
 `<Downshift />` is the only component exposed by this package. It doesn't render
 anything itself, it just calls the render function and renders that. ["Use a

--- a/docs/downshift/downshift.mdx
+++ b/docs/downshift/downshift.mdx
@@ -1,0 +1,201 @@
+---
+name: Component
+menu: Downshift
+route: /downshift/component
+---
+
+import {useState} from 'react'
+import {Playground} from 'docz'
+import Downshift from '../../src'
+import {items, menuStyles, comboboxStyles, playgroundStyles} from '../utils'
+
+# Downshift
+
+## Introduction
+
+The `Downshift` component has been developed in order to provide accessibility
+and functionality to a `combobox` component, described by the corresponding
+[ARIA docs](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html).
+
+In the examples below, we use the `Downshift` hook and destructure from its
+result the getter props and state variables. The hooks also has the
+`onInputValueChange` prop passed in order to filter the items in the list
+according to the input value. The getter props are used as follows:
+
+| Returned prop          | Element    | Comments                                                                  |
+| ---------------------- | ---------- | ------------------------------------------------------------------------- |
+| `getLabelProps`        | `<label>`  | Adds an `id` attribute to be used for `menu` and `toggleButton`           |
+| `getToggleButtonProps` | `<button>` | Controls the open state of the list.                                      |
+| `getRootProps`         | `<div>`    | Container for `input` and `toggleButton`.                                 |
+| `getInputProps`        | `<input>`  | Can be used to filter the options. Also displays the selected item.       |
+| `getMenuProps`         | `<ul>`     | Makes list focusable, adds ARIA attributes and event handlers.            |
+| `getItemProps`         | `<li>`     | Called with `index` and `item`, adds ARIA attributes and event listeners. |
+| `isOpen`               |            | Only when it's true we render the `<li>` elements.                        |
+| `highlightedIndex`     | `<li>`     | Used to style the highlighted item.                                       |
+| `selectedItem`         | `<button>` | Used to render text equivalent of selected item on the button.            |
+
+For a complete documentation on all the returned props, component props and more
+information check out the
+[Github Page](https://github.com/downshift-js/downshift).
+
+## Important
+
+If you are new to `Downshift` then maybe you should fist check `useCombobox`
+which should provide the same functionality but as a hook. If it's not suiting
+your use case then come back here. Also, if you need just a `select` dropdown
+without a text input, then check `useSelect`.
+
+As far as the component is concerned, you can use it in two ways, both of them
+illustrated below.
+
+There is an _straightforward_ way, which allows you to wrap your whole
+`combobox` HTML in `<Downshift>`. The drawback of this way is that the
+`combobox` HTML structure is not correct, and screen readers will not widely
+support it.
+
+There is also the _not-so-straightforward-way_ which allows you to respect the
+`combobox` HTML structure and you should aim for this one. Here you will use
+`getRootProps` on the element that wraps your `<input>` and then you will add
+the `<ul>` on the same level with the wrapper. More details on each of these
+examples below.
+
+A `combobox` element can be created with HTML elements such as: `<label>`,
+`<ul>`, `<li>`, `<button>`, `<input>` and a `<div>` or something similar to
+contain the input and the toggle button. It is absolutely important to follow
+the HTML structure below, as it will allow all screen readers to properly work
+with the widget. Most importantly, the `<input>` needs to be contained by the
+combobox `<div>` and the `<ul>` needs to be at the same level with the combobox
+`<div>`.
+
+## Usage with `getRootProps`
+
+It is possible to achieve the correct HTML structure only if you use
+`getRootProps` getter prop from `Downshift`. You apply `getRootProps` on the
+wrapper element that contains the `<input>` and optionally the trigger button.
+
+[CodeSandbox](https://codesandbox.io/s/simple-downshift-with-getrootprops-example-24s13)
+
+<Playground style={playgroundStyles}>
+  {() => {
+    const DropdownCombobox = () => {
+      const [inputItems, setInputItems] = useState(items)
+
+      return (
+        <Downshift onInputValueChange={inputValue => {
+          setInputItems(
+            items.filter(item =>
+              item.toLowerCase().startsWith(inputValue.toLowerCase()),
+            )
+          )
+        }}>
+          {({
+            getInputProps,
+            getItemProps,
+            getMenuProps,
+            getLabelProps,
+            getRootProps,
+            getToggleButtonProps,
+            highlightedIndex,
+            isOpen,
+          }) => (
+        <>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <div style={comboboxStyles} {...getRootProps({}, {suppressRefError: true})}>
+            <input {...getInputProps()} />
+            <button {...getToggleButtonProps()} aria-label={'toggle menu'}>
+              &#8595;
+            </button>
+          </div>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              inputItems.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index
+                      ? {backgroundColor: '#bde4ff'}
+                      : {}
+                  }
+                  key={`${item}${index}`}
+                  {...getItemProps({item, index})}
+                >
+                  {item}
+                </li>
+              ))}
+          </ul>
+        </>
+      )}
+      </Downshift>
+    )}
+
+    return <DropdownCombobox />
+
+}}
+
+</Playground>
+
+## Usage without `getRootProps`
+
+Using `Downshift` without the `getRootProps` will add the `combobox` role to the
+child element rendered. This way you are forced into having all elements (menu,
+input, button, label) as children of the `combobox` which is not compatible with
+the widget HTML structure. It will still work, and you can style it to look as a
+normal combobox, but this structure is not supported by screen readers.
+Accessibility will not be achieved in this case, so please migrate to either the
+example above or to `useCombobox` hook.
+
+[CodeSandbox](https://codesandbox.io/s/usecombobox-usage-evufg)
+
+<Playground style={playgroundStyles}>
+  {() => {
+    const DropdownCombobox = () => {
+      const [inputItems, setInputItems] = useState(items)
+
+      return (
+        <Downshift onInputValueChange={inputValue => {
+          setInputItems(
+            items.filter(item =>
+              item.toLowerCase().startsWith(inputValue.toLowerCase()),
+            )
+          )
+        }}>
+          {({
+            getInputProps,
+            getItemProps,
+            getMenuProps,
+            getLabelProps,
+            getToggleButtonProps,
+            highlightedIndex,
+            isOpen,
+          }) => (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <input {...getInputProps()} />
+          <button {...getToggleButtonProps()} aria-label={'toggle menu'}>
+            &#8595;
+          </button>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              inputItems.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index
+                      ? {backgroundColor: '#bde4ff'}
+                      : {}
+                  }
+                  key={`${item}${index}`}
+                  {...getItemProps({item, index})}
+                >
+                  {item}
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+      </Downshift>
+    )}
+
+    return <DropdownCombobox />
+
+}}
+
+</Playground>

--- a/docs/downshift/downshift.mdx
+++ b/docs/downshift/downshift.mdx
@@ -40,10 +40,11 @@ information check out the
 
 ## Important
 
-If you are new to `Downshift` then maybe you should fist check `useCombobox`
-which should provide the same functionality but as a hook. If it's not suiting
-your use case then come back here. Also, if you need just a `select` dropdown
-without a text input, then check `useSelect`.
+If you are new to `Downshift` then maybe you should fist check
+[useCombobox](/hooks/use-combobox) which should provide the same functionality
+but as a hook. If it's not suiting your use case then come back here. Also, if
+you need just a `select` dropdown without a text input, then check
+[useSelect](/hooks/use-select).
 
 As far as the component is concerned, you can use it in two ways, both of them
 illustrated below.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,10 +6,14 @@ order: 1
 
 # Downshift
 
-Work in progress for the docsite. Looking to centralize Downshift examples here. Also using it for Cypress tests.
+Work in progress for the docsite. Looking to centralize Downshift examples here.
+Also using it for Cypress tests.
 
-For `docs` see the repo: [github.com/downshift-js/downshift](https://github.com/downshift-js/downshift)
+For `docs` see the repo:
+[github.com/downshift-js/downshift](https://github.com/downshift-js/downshift)
 
-For `Downshift` examples see: [github.com/kentcdodds/downshift-examples](https://github.com/kentcdodds/downshift-examples)
+For `Downshift` examples see [component section](/downshift/component) or
+[github.com/kentcdodds/downshift-examples](https://github.com/kentcdodds/downshift-examples)
 
-For `useSelect` examples see: [the docsite](/hooks/use-select/usage).
+For `Downshift` hooks examples see [useSelect](/hooks/use-select) or
+[useCombobox](/hooks/use-combobox).

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,5 +1,10 @@
 export default {
   port: 6006,
   files: './docs/**/*.{md,markdown,mdx}',
-  menu: ['Home', {name: 'Hooks', menu: ['useSelect', 'useCombobox']}, 'Tests'],
+  menu: [
+    'Home',
+    'Downshift',
+    {name: 'Hooks', menu: ['useSelect', 'useCombobox']},
+    'Tests',
+  ],
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Fixes https://github.com/downshift-js/downshift/issues/779.

**Why**:

The main `Downshift` use example is not accessible with screen readers. The HTML structure for a `combobox` is not achievable without using getRootProps.

**How**:

Change main Downshift usage example. Added more information on why is it important to use that instead of the previous one. Also added a docs page for both these usages.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
