### PR TITLE
docs: fix incorrect link to useCombobox

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -12,7 +12,7 @@ For a `<select>` custom dropdown [click here][select-readme].
 
 ### useCombobox
 
-For a `combobox autocomplete` dropdown [click here][select-readme].
+For a `combobox autocomplete` dropdown [click here][combobox-readme].
 
 ## Roadmap and contributions
 


### PR DESCRIPTION
**What**:

README link for useCombobox incorrectly linked to useSelect README; should have been the useSelect README

**Why**:

Issue makes docs harder to read.

**How**:

Simple text change

**Checklist**:


- [X] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
