### PR TITLE
fix(useSelect): add support for space button on menu

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 107604,
-    "minified": 50106,
-    "gzipped": 11240
+    "bundled": 107924,
+    "minified": 50343,
+    "gzipped": 11289
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 106322,
-    "minified": 49068,
-    "gzipped": 11125
+    "bundled": 106642,
+    "minified": 49305,
+    "gzipped": 11176
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 118383,
-    "minified": 38903,
-    "gzipped": 11087
+    "bundled": 118734,
+    "minified": 39044,
+    "gzipped": 11127
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 134506,
-    "minified": 46407,
-    "gzipped": 12880
+    "bundled": 135096,
+    "minified": 46649,
+    "gzipped": 12928
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 122618,
-    "minified": 40223,
-    "gzipped": 11625
+    "bundled": 122969,
+    "minified": 40364,
+    "gzipped": 11664
   },
   "dist/downshift.umd.js": {
-    "bundled": 164131,
-    "minified": 55319,
-    "gzipped": 15457
+    "bundled": 164721,
+    "minified": 55561,
+    "gzipped": 15510
   },
   "dist/downshift.esm.js": {
-    "bundled": 107135,
-    "minified": 49711,
-    "gzipped": 11172,
+    "bundled": 107455,
+    "minified": 49948,
+    "gzipped": 11222,
     "treeshaked": {
       "rollup": {
         "code": 998,
@@ -44,9 +44,9 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 105823,
-    "minified": 48643,
-    "gzipped": 11057,
+    "bundled": 106143,
+    "minified": 48880,
+    "gzipped": 11107,
     "treeshaked": {
       "rollup": {
         "code": 999,

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -28,6 +28,7 @@ between them, screen reader support, highlight by character keys etc.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Usage](#usage)
 - [Basic Props](#basic-props)
   - [items](#items)
@@ -441,6 +442,7 @@ The list of all possible values this `type` property can take is defined in
 - `useSelect.stateChangeTypes.MenuKeyDownHome`
 - `useSelect.stateChangeTypes.MenuKeyDownEnd`
 - `useSelect.stateChangeTypes.MenuKeyDownEnter`
+- `useSelect.stateChangeTypes.MenuKeyDownSpaceButton`
 - `useSelect.stateChangeTypes.MenuKeyDownCharacter`
 - `useSelect.stateChangeTypes.MenuBlur`
 - `useSelect.stateChangeTypes.MenuMouseLeave`

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -627,6 +627,50 @@ describe('getMenuProps', () => {
         expect(document.activeElement).toBe(toggleButton)
       })
 
+      test('space it closes the menu and selects highlighted item', () => {
+        const initialHighlightedIndex = 2
+        const wrapper = setup({
+          initialIsOpen: true,
+          initialHighlightedIndex,
+        })
+        const menu = wrapper.getByTestId(dataTestIds.menu)
+        const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
+
+        fireEvent.keyDown(menu, {key: ' '})
+
+        expect(menu.childNodes).toHaveLength(0)
+        expect(toggleButton.textContent).toEqual(items[initialHighlightedIndex])
+      })
+
+      test('space it selects highlighted item and resets to user defaults', () => {
+        const defaultHighlightedIndex = 2
+        const wrapper = setup({
+          defaultHighlightedIndex,
+          defaultIsOpen: true,
+        })
+        const menu = wrapper.getByTestId(dataTestIds.menu)
+        const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
+
+        fireEvent.keyDown(menu, {key: ' '})
+
+        expect(toggleButton.textContent).toEqual(items[defaultHighlightedIndex])
+        expect(menu.childNodes).toHaveLength(items.length)
+        expect(menu.getAttribute('aria-activedescendant')).toBe(
+          defaultIds.getItemId(defaultHighlightedIndex),
+        )
+      })
+
+      test('space it has the focus moved to toggleButton', () => {
+        const wrapper = setup({initialIsOpen: true})
+        const menu = wrapper.getByTestId(dataTestIds.menu)
+        const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
+
+        menu.focus()
+        fireEvent.keyDown(menu, {key: ' '})
+
+        expect(document.activeElement).toBe(toggleButton)
+      })
+
       test.skip('tab it closes the menu and selects highlighted item', () => {
         const initialHighlightedIndex = 2
         const wrapper = setup({

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -198,6 +198,12 @@ function useSelect(userProps = {}) {
         type: stateChangeTypes.MenuKeyDownEnter,
       })
     },
+    ' '(event) {
+      event.preventDefault()
+      dispatch({
+        type: stateChangeTypes.MenuKeyDownSpaceButton,
+      })
+    },
     Tab(event) {
       // The exception that calls MenuBlur.
       // istanbul ignore next

--- a/src/hooks/useSelect/reducer.js
+++ b/src/hooks/useSelect/reducer.js
@@ -63,6 +63,7 @@ export default function downshiftSelectReducer(state, action) {
       }
       break
     case stateChangeTypes.MenuKeyDownEnter:
+    case stateChangeTypes.MenuKeyDownSpaceButton:
       changes = {
         isOpen: getDefaultValue(props, 'isOpen'),
         highlightedIndex: getDefaultValue(props, 'highlightedIndex'),

--- a/src/hooks/useSelect/stateChangeTypes.js
+++ b/src/hooks/useSelect/stateChangeTypes.js
@@ -8,6 +8,9 @@ export const MenuKeyDownEscape = productionEnum('__menu_keydown_escape__')
 export const MenuKeyDownHome = productionEnum('__menu_keydown_home__')
 export const MenuKeyDownEnd = productionEnum('__menu_keydown_end__')
 export const MenuKeyDownEnter = productionEnum('__menu_keydown_enter__')
+export const MenuKeyDownSpaceButton = productionEnum(
+  '__menu_keydown_space_button__',
+)
 export const MenuKeyDownCharacter = productionEnum('__menu_keydown_character__')
 export const MenuBlur = productionEnum('__menu_blur__')
 export const MenuMouseLeave = productionEnum('__menu_mouse_leave__')

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -248,6 +248,7 @@ export enum UseSelectStateChangeTypes {
   MenuKeyDownHome = '__menu_keydown_home__',
   MenuKeyDownEnd = '__menu_keydown_end__',
   MenuKeyDownEnter = '__menu_keydown_enter__',
+  MenuKeyDownSpaceButton = '__menu_keydown_space_button__',
   MenuKeyDownCharacter = '__menu_keydown_character__',
   MenuBlur = '__menu_blur__',
   MenuMouseLeave = '__menu_mouse_leave__',
@@ -355,6 +356,7 @@ export interface UseSelectInterface {
     MenuKeyDownHome: UseSelectStateChangeTypes.MenuKeyDownHome
     MenuKeyDownEnd: UseSelectStateChangeTypes.MenuKeyDownEnd
     MenuKeyDownEnter: UseSelectStateChangeTypes.MenuKeyDownEnter
+    MenuKeyDownSpaceButton: UseSelectStateChangeTypes.MenuKeyDownSpaceButton
     MenuKeyDownCharacter: UseSelectStateChangeTypes.MenuKeyDownCharacter
     MenuBlur: UseSelectStateChangeTypes.MenuBlur
     MenuMouseLeave: UseSelectStateChangeTypes.MenuMouseLeave


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Making the menu on `useSelect` behave the same way when pressing spacebar or enter.

<!-- Why are these changes necessary? -->

**Why**:

`<select>` also behave like that. See https://github.com/downshift-js/downshift/issues/853 for more detail.

<!-- How were these changes implemented? -->

**How**:

- Add a new `stateChangeTypes`, `MenuKeyDownSpaceButton`
- Dispatch it when receiving `' '` key on menu
- Handle that action in the reducer the same way `MenuKeyDownEnter` is handling.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
