### PR TITLE
perf(getItemProps): getMemoizedItemHandlers prop to return memoized handlers

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,45 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 113603,
-    "minified": 52349,
-    "gzipped": 11598
+    "bundled": 114798,
+    "minified": 52655,
+    "gzipped": 11620
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 112278,
-    "minified": 51272,
-    "gzipped": 11492
+    "bundled": 113473,
+    "minified": 51578,
+    "gzipped": 11512
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 124483,
-    "minified": 40709,
-    "gzipped": 11379
+    "bundled": 125720,
+    "minified": 40951,
+    "gzipped": 11395
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 128718,
-    "minified": 42025,
-    "gzipped": 11915
+    "bundled": 129955,
+    "minified": 42267,
+    "gzipped": 11921
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 140635,
-    "minified": 48239,
-    "gzipped": 13164
+    "bundled": 141872,
+    "minified": 48529,
+    "gzipped": 13213
   },
   "dist/downshift.umd.js": {
-    "bundled": 170305,
-    "minified": 57182,
-    "gzipped": 15768
+    "bundled": 171542,
+    "minified": 57472,
+    "gzipped": 15780
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 111779,
-    "minified": 50847,
-    "gzipped": 11423,
+    "bundled": 112974,
+    "minified": 51153,
+    "gzipped": 11444,
     "treeshaked": {
       "rollup": {
-        "code": 1752,
+        "code": 1766,
         "import_statements": 318
       },
       "webpack": {
-        "code": 3837
+        "code": 3855
+      }
+    }
+  },
+  "dist/downshift.esm.js": {
+    "bundled": 114329,
+    "minified": 52260,
+    "gzipped": 11553,
+    "treeshaked": {
+      "rollup": {
+        "code": 1765,
+        "import_statements": 317
+      },
+      "webpack": {
+        "code": 3856
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 113146,
-    "minified": 52111,
-    "gzipped": 11538
+    "bundled": 113603,
+    "minified": 52349,
+    "gzipped": 11598
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 111864,
-    "minified": 51073,
-    "gzipped": 11437
-  },
-  "preact/dist/downshift.umd.js": {
-    "bundled": 140209,
-    "minified": 48040,
-    "gzipped": 13116
+    "bundled": 112278,
+    "minified": 51272,
+    "gzipped": 11492
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 124057,
-    "minified": 40510,
-    "gzipped": 11333
+    "bundled": 124483,
+    "minified": 40709,
+    "gzipped": 11379
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 128292,
-    "minified": 41826,
-    "gzipped": 11867
+    "bundled": 128718,
+    "minified": 42025,
+    "gzipped": 11915
+  },
+  "preact/dist/downshift.umd.js": {
+    "bundled": 140635,
+    "minified": 48239,
+    "gzipped": 13164
   },
   "dist/downshift.umd.js": {
-    "bundled": 169834,
-    "minified": 56952,
-    "gzipped": 15717
+    "bundled": 170305,
+    "minified": 57182,
+    "gzipped": 15768
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 111365,
-    "minified": 50648,
-    "gzipped": 11370,
+    "bundled": 111779,
+    "minified": 50847,
+    "gzipped": 11423,
     "treeshaked": {
       "rollup": {
         "code": 1752,
@@ -40,20 +40,6 @@
       },
       "webpack": {
         "code": 3837
-      }
-    }
-  },
-  "dist/downshift.esm.js": {
-    "bundled": 112677,
-    "minified": 51716,
-    "gzipped": 11470,
-    "treeshaked": {
-      "rollup": {
-        "code": 1751,
-        "import_statements": 317
-      },
-      "webpack": {
-        "code": 3838
       }
     }
   }

--- a/docs/downshift/downshift.mdx
+++ b/docs/downshift/downshift.mdx
@@ -5,6 +5,7 @@ route: /downshift/component
 ---
 
 import {useState} from 'react'
+import memoize from 'fast-memoize'
 import {Playground} from 'docz'
 import Downshift from '../../src'
 import {items, menuStyles, comboboxStyles, playgroundStyles} from '../utils'
@@ -194,6 +195,80 @@ example above or to `useCombobox` hook.
       )}
       </Downshift>
     )}
+
+    return <DropdownCombobox />
+
+}}
+
+</Playground>
+
+## Memoization of the `getItemProps` handlers
+
+<Playground style={playgroundStyles}>
+  {() => {
+    const DropdownCombobox = () => {
+      const [inputItems, setInputItems] = useState(items)
+      const getMemoizedItemHandlers = memoize(
+        (getHandlers, item, index) => {
+          return getHandlers()
+        },
+        {
+          serializer: args => {
+            return `${args[1]}${args[2]}`
+          },
+        },
+      )
+
+      return (
+        <Downshift
+          getMemoizedItemHandlers={getMemoizedItemHandlers}
+          onInputValueChange={inputValue => {
+            setInputItems(
+              items.filter(item =>
+                item.toLowerCase().startsWith(inputValue.toLowerCase()),
+              ),
+            )
+          }}
+        >
+          {({
+            getInputProps,
+            getItemProps,
+            getMenuProps,
+            getLabelProps,
+            getToggleButtonProps,
+            highlightedIndex,
+            isOpen,
+          }) => (
+            <div>
+              <label {...getLabelProps()}>Choose an element:</label>
+              <input {...getInputProps()} />
+              <button
+                {...getToggleButtonProps()}
+                aria-label={'toggle menu'}
+              >
+                &#8595;
+              </button>
+              <ul {...getMenuProps()} style={menuStyles}>
+                {isOpen &&
+                  inputItems.map((item, index) => (
+                    <li
+                      style={
+                        highlightedIndex === index
+                          ? {backgroundColor: '#bde4ff'}
+                          : {}
+                      }
+                      key={`${item}${index}`}
+                      {...getItemProps({item, index})}
+                    >
+                      {item}
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          )}
+        </Downshift>
+      )
+    }
 
     return <DropdownCombobox />
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "docz-theme-default": "^1.2.0",
     "eslint-plugin-cypress": "^2.7.0",
     "eslint-plugin-react": "7.16.0",
+    "fast-memoize": "^2.5.1",
     "flow-bin": "^0.110.1",
     "flow-coverage-report": "^0.6.0",
     "kcd-scripts": "^1.9.0",

--- a/src/__tests__/downshift.get-item-props.js
+++ b/src/__tests__/downshift.get-item-props.js
@@ -322,7 +322,7 @@ test(`highlight wrapping works with disabled items downwards`, () => {
   expect(input.value).toBe('Chess')
 })
 
-test('getMemoizedItemHandlers used if provided', () => {
+test('getMemoizedItemHandlers is called if provided', () => {
   const getMemoizedItemHandlers = jest.fn().mockImplementation(getHandlers => {
     return getHandlers()
   })

--- a/src/__tests__/downshift.get-item-props.js
+++ b/src/__tests__/downshift.get-item-props.js
@@ -322,6 +322,25 @@ test(`highlight wrapping works with disabled items downwards`, () => {
   expect(input.value).toBe('Chess')
 })
 
+test('getMemoizedItemHandlers used if provided', () => {
+  const getMemoizedItemHandlers = jest.fn().mockImplementation(getHandlers => {
+    return getHandlers()
+  })
+  const items = ['Chess', 'Dominion', 'Checkers']
+  const {arrowDownInput} = renderDownshift({
+    items,
+    props: {getMemoizedItemHandlers},
+  })
+
+  // rendered downshift is open, should be called.
+  expect(getMemoizedItemHandlers).toHaveBeenCalledTimes(items.length)
+
+  arrowDownInput()
+
+  // should be called each time it re-renders.
+  expect(getMemoizedItemHandlers).toHaveBeenCalledTimes(items.length * 2)
+})
+
 function renderDownshift({
   items = [{item: 'Chess'}, {item: 'Dominion'}, {item: 'Checkers'}],
   props,

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -58,7 +58,7 @@ test('onChange only called when the selection changes', () => {
   expect(handleChange).toHaveBeenCalledTimes(0)
 })
 
-test('onSelect called whenever selection happens, even if the item is the same ', () => {
+test('onSelect called whenever selection happens, even if the item is the same', () => {
   const handleSelect = jest.fn()
   const {selectItem} = setup({
     onSelect: handleSelect,

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -59,6 +59,7 @@ class Downshift extends Component {
     }),
     suppressRefError: PropTypes.bool,
     scrollIntoView: PropTypes.func,
+    getMemoizedItemHandlers: PropTypes.func,
     // things we keep in state for uncontrolled components
     // but can accept as props for controlled components
     /* eslint-disable react/no-unused-prop-types */
@@ -901,24 +902,13 @@ class Downshift extends Component {
   //\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ MENU
 
   /////////////////////////////// ITEM
-  getItemProps = ({
-    onMouseMove,
-    onMouseDown,
+  getItemPropsEventHandlers = (
+    index,
     onClick,
     onPress,
-    index,
-    item = process.env.NODE_ENV === 'production'
-      ? /* istanbul ignore next */ undefined
-      : requiredProp('getItemProps', 'item'),
-    ...rest
-  } = {}) => {
-    if (index === undefined) {
-      this.items.push(item)
-      index = this.items.indexOf(item)
-    } else {
-      this.items[index] = item
-    }
-
+    onMouseMove,
+    onMouseDown,
+  ) => {
     const onSelectKey = isReactNative
       ? /* istanbul ignore next (react-native) */ 'onPress'
       : 'onClick'
@@ -926,7 +916,7 @@ class Downshift extends Component {
       ? /* istanbul ignore next (react-native) */ onPress
       : onClick
 
-    const enabledEventHandlers = {
+    return {
       // onMouseMove is used over onMouseEnter here. onMouseMove
       // is only triggered on actual mouse movement while onMouseEnter
       // can fire on DOM changes, interrupting keyboard navigation
@@ -957,6 +947,47 @@ class Downshift extends Component {
         })
       }),
     }
+  }
+
+  getItemProps = ({
+    onMouseMove,
+    onMouseDown,
+    onClick,
+    onPress,
+    index,
+    item = process.env.NODE_ENV === 'production'
+      ? /* istanbul ignore next */ undefined
+      : requiredProp('getItemProps', 'item'),
+    ...rest
+  } = {}) => {
+    if (index === undefined) {
+      this.items.push(item)
+      index = this.items.indexOf(item)
+    } else {
+      this.items[index] = item
+    }
+
+    const {getMemoizedItemHandlers} = this.props
+    const enabledEventHandlers = getMemoizedItemHandlers
+      ? getMemoizedItemHandlers(
+          () =>
+            this.getItemPropsEventHandlers(
+              index,
+              onClick,
+              onPress,
+              onMouseMove,
+              onMouseDown,
+            ),
+          item,
+          index,
+        )
+      : this.getItemPropsEventHandlers(
+          index,
+          onClick,
+          onPress,
+          onMouseMove,
+          onMouseDown,
+        )
 
     // Passing down the onMouseDown handler to prevent redirect
     // of the activeElement if clicking on disabled items

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -788,7 +788,7 @@ class Downshift extends Component {
     let onChangeKey
     let eventHandlers = {}
 
-    /* istanbul ignore next (preact) */
+    /* istanbul ignore if (preact) */
     if (isPreact) {
       onChangeKey = 'onInput'
     } else {

--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -53,12 +53,13 @@ describe('getItemProps', () => {
 
     test("handlers are not called if it's disabled", () => {
       const {result} = setupHook()
-      const inputProps = result.current.getInputProps({
+      const itemProps = result.current.getItemProps({
+        index: 0,
         disabled: true,
       })
 
-      expect(inputProps.onClick).toBeUndefined()
-      expect(inputProps.onMouseMove).toBeUndefined()
+      expect(itemProps.onMouseMove).toBeUndefined()
+      expect(itemProps.onClick).toBeUndefined()
     })
   })
 
@@ -257,5 +258,21 @@ describe('getItemProps', () => {
       fireEvent.keyDown(input, {key: 'End'})
       expect(scrollIntoView).toHaveBeenCalledTimes(1)
     })
+  })
+
+  test('getMemoizedItemHandlers is called at each render if provided', () => {
+    const getMemoizedItemHandlers = jest
+      .fn()
+      .mockImplementation(getHandlers => {
+        return getHandlers()
+      })
+    const wrapper = setup({isOpen: true, getMemoizedItemHandlers})
+    const input = wrapper.getByTestId(dataTestIds.input)
+
+    expect(getMemoizedItemHandlers).toHaveBeenCalledTimes(items.length)
+
+    fireEvent.keyDown(input, {key: 'ArrowDown'})
+
+    expect(getMemoizedItemHandlers).toHaveBeenCalledTimes(items.length * 2)
   })
 })

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -93,6 +93,7 @@ const propTypes = {
       body: PropTypes.any,
     }),
   }),
+  getMemoizedItemHandlers: PropTypes.func,
 }
 
 const defaultProps = {

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -259,4 +259,20 @@ describe('getItemProps', () => {
       expect(scrollIntoView).toHaveBeenCalledTimes(1)
     })
   })
+
+  test('getMemoizedItemHandlers is called at each render if provided', () => {
+    const getMemoizedItemHandlers = jest
+      .fn()
+      .mockImplementation(getHandlers => {
+        return getHandlers()
+      })
+    const wrapper = setup({isOpen: true, getMemoizedItemHandlers})
+    const menu = wrapper.getByTestId(dataTestIds.menu)
+
+    expect(getMemoizedItemHandlers).toHaveBeenCalledTimes(items.length)
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'})
+
+    expect(getMemoizedItemHandlers).toHaveBeenCalledTimes(items.length * 2)
+  })
 })

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -363,6 +363,7 @@ function useSelect(userProps = {}) {
   })
   const getToggleButtonProps = ({
     onClick,
+    onPress,
     onKeyDown,
     refKey = 'ref',
     ref,
@@ -376,18 +377,19 @@ function useSelect(userProps = {}) {
       'aria-haspopup': 'listbox',
       'aria-expanded': isOpen,
       'aria-labelledby': `${labelId} ${toggleButtonId}`,
+      ...(!rest.disabled &&
+        (isReactNative
+          ? /* istanbul ignore next (react-native) */ {
+              onPress: callAllEventHandlers(onPress, toggleButtonHandleClick),
+            }
+          : {
+              onClick: callAllEventHandlers(onClick, toggleButtonHandleClick),
+              onKeyDown: callAllEventHandlers(
+                onKeyDown,
+                toggleButtonHandleKeyDown,
+              ),
+            })),
       ...rest,
-    }
-
-    if (!rest.disabled) {
-      toggleProps.onClick = callAllEventHandlers(
-        onClick,
-        toggleButtonHandleClick,
-      )
-      toggleProps.onKeyDown = callAllEventHandlers(
-        onKeyDown,
-        toggleButtonHandleKeyDown,
-      )
     }
 
     return toggleProps
@@ -398,9 +400,8 @@ function useSelect(userProps = {}) {
     onPress,
     itemIndex,
   ) => {
-    /* istanbul ignore next (react-native) */
     const [onSelectKey, customClickHandler] = isReactNative
-      ? ['onPress', onPress]
+      ? /* istanbul ignore next (react-native) */ ['onPress', onPress]
       : ['onClick', onClick]
 
     return {

--- a/src/hooks/useSelect/utils.js
+++ b/src/hooks/useSelect/utils.js
@@ -110,6 +110,7 @@ const propTypes = {
       body: PropTypes.any,
     }),
   }),
+  getMemoizedItemHandlers: PropTypes.func,
 }
 
 export {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Prop `getMemoizedItemHandlers` that should be used to memoize the event handlers returned by `getItemProps`.

<!-- Why are these changes necessary? -->

**Why**:
`getItemProps` should be called at each re-render, but receiving new event handlers means that the items themselves need to re-render all the time. If the item is a PureComponent and its position in the list has not changed, then it makes sense for it not to re-render, so providing a memoized version of those handlers makes sense.

Having many items as React components that are expensive to render will make Downshift appear as a slow library. We are not giving any choice so far in this matter, as we always return new callbacks and the items will always be re-rendered. But not anymore.
<!-- How were these changes implemented? -->

**How**:
`getMemoizedItemHandlers` is a prop that is called with a callback to get the handlers, with the item itself and its index in the list. The last two items are enough to make a decision on whether to return the handlers memoized or new ones. The serializer can be `${item.id}${index}` as it is important for both the item itself and its position in the list to be the same in order to return a memoized version of the handlers.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] useSelect
- [ ] useCombobox
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Fixes https://github.com/downshift-js/downshift/issues/845
Closes https://github.com/downshift-js/downshift/issues/827