### PR TITLE
fix(typings): optional options for `getInputProps` and `getComboboxProps`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -489,8 +489,8 @@ export interface UseComboboxPropGetters<Item> {
   getLabelProps: (options?: UseComboboxGetLabelPropsOptions) => any
   getMenuProps: (options?: UseComboboxGetMenuPropsOptions) => any
   getItemProps: (options: UseComboboxGetItemPropsOptions<Item>) => any
-  getInputProps: (options: UseComboboxGetInputPropsOptions) => any
-  getComboboxProps: (options: UseComboboxGetComboboxPropsOptions) => any
+  getInputProps: (options?: UseComboboxGetInputPropsOptions) => any
+  getComboboxProps: (options?: UseComboboxGetComboboxPropsOptions) => any
 }
 
 export interface UseComboboxActions<Item> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Changed `getInputProps` and `getComboboxProps` options parameter to be optional in `useCombobox` hook.

<!-- Why are these changes necessary? -->

**Why**:

They are not required, if I understand it correctly. You can see it in the [Usage documentation](https://github.com/downshift-js/downshift/tree/c9479dc4f508a1a4fd298f69c8f5cdeefa3d4b6f/src/hooks/useCombobox#usage). Also, they are out of sync with `Downshift` component. Only `getItemProps` requires options to pass `item`.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
