### PR TITLE
fix(useCombobox): pass down missing disabled prop in prop getters

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 113146,
-    "minified": 52111,
-    "gzipped": 11538
+    "bundled": 113058,
+    "minified": 52081,
+    "gzipped": 11521
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 111864,
-    "minified": 51073,
-    "gzipped": 11437
+    "bundled": 111776,
+    "minified": 51043,
+    "gzipped": 11421
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 140209,
-    "minified": 48040,
-    "gzipped": 13116
+    "bundled": 140807,
+    "minified": 50220,
+    "gzipped": 13039
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 124057,
-    "minified": 40510,
-    "gzipped": 11333
+    "bundled": 124445,
+    "minified": 40311,
+    "gzipped": 11141
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 128292,
-    "minified": 41826,
-    "gzipped": 11867
+    "bundled": 128680,
+    "minified": 41630,
+    "gzipped": 11599
   },
   "dist/downshift.umd.js": {
-    "bundled": 169834,
-    "minified": 56952,
-    "gzipped": 15717
+    "bundled": 170432,
+    "minified": 59160,
+    "gzipped": 15594
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 111365,
-    "minified": 50648,
-    "gzipped": 11370,
+    "bundled": 111277,
+    "minified": 50618,
+    "gzipped": 11354,
     "treeshaked": {
       "rollup": {
         "code": 1752,

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -98,6 +98,7 @@ describe('getInputProps', () => {
       expect(inputProps.onChange).toBeUndefined()
       expect(inputProps.onKeyDown).toBeUndefined()
       expect(inputProps.onBlur).toBeUndefined()
+      expect(inputProps.disabled).toBe(true)
     })
   })
 

--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -53,12 +53,14 @@ describe('getItemProps', () => {
 
     test("handlers are not called if it's disabled", () => {
       const {result} = setupHook()
-      const inputProps = result.current.getInputProps({
+      const itemProps = result.current.getItemProps({
         disabled: true,
+        index: 0,
       })
 
-      expect(inputProps.onClick).toBeUndefined()
-      expect(inputProps.onMouseMove).toBeUndefined()
+      expect(itemProps.onClick).toBeUndefined()
+      expect(itemProps.onMouseMove).toBeUndefined()
+      expect(itemProps.disabled).toBe(true)
     })
   })
 

--- a/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
@@ -32,6 +32,7 @@ describe('getToggleButtonProps', () => {
       })
 
       expect(toggleButtonProps.onClick).toBeUndefined()
+      expect(toggleButtonProps.disabled).toBe(true)
     })
   })
 

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -262,7 +262,6 @@ function useCombobox(userProps = {}) {
     onMouseMove,
     onClick,
     onPress,
-    disabled,
     ...rest
   } = {}) => {
     const itemIndex = getItemIndex(index, item, items)
@@ -286,7 +285,7 @@ function useCombobox(userProps = {}) {
       role: 'option',
       ...(itemIndex === highlightedIndex && {'aria-selected': true}),
       id: getItemId(itemIndex),
-      ...(!disabled && {
+      ...(!rest.disabled && {
         onMouseMove: callAllEventHandlers(onMouseMove, () => {
           itemHandleMouseMove(itemIndex)
         }),
@@ -302,7 +301,6 @@ function useCombobox(userProps = {}) {
     onPress,
     refKey = 'ref',
     ref,
-    disabled,
     ...rest
   } = {}) => {
     return {
@@ -311,7 +309,7 @@ function useCombobox(userProps = {}) {
       }),
       id: toggleButtonId,
       tabIndex: -1,
-      ...(!disabled && {
+      ...(!rest.disabled && {
         ...(isReactNative
           ? /* istanbul ignore next (react-native) */ {
               onPress: callAllEventHandlers(onPress, toggleButtonHandleClick),

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -60,6 +60,7 @@ describe('getItemProps', () => {
 
       expect(itemProps.onMouseMove).toBeUndefined()
       expect(itemProps.onClick).toBeUndefined()
+      expect(itemProps.disabled).toBe(true)
     })
   })
 

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -85,6 +85,7 @@ describe('getToggleButtonProps', () => {
 
       expect(toggleButtonProps.onClick).toBeUndefined()
       expect(toggleButtonProps.onKeyDown).toBeUndefined()
+      expect(toggleButtonProps.disabled).toBe(true)
     })
   })
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Currently, `getToggleButtonProps` & `getItemProps` accept a `disabled` prop to remove handlers but won't pass that prop down.

<!-- Why are these changes necessary? -->

**Why**:

Allows components to be styled dependent on the `disabled` prop. Accessibility?

<!-- How were these changes implemented? -->

**How**:

Simply pass down the `disabled` prop.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Added tests for both `useSelect` and `useCombobox`.
