### PR TITLE
fix(useCombobox): pass down disabled prop in getItemProps

### DIFF
--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -53,12 +53,14 @@ describe('getItemProps', () => {
 
     test("handlers are not called if it's disabled", () => {
       const {result} = setupHook()
-      const inputProps = result.current.getInputProps({
+      const itemProps = result.current.getItemProps({
         disabled: true,
+        index: 0,
       })
 
-      expect(inputProps.onClick).toBeUndefined()
-      expect(inputProps.onMouseMove).toBeUndefined()
+      expect(itemProps.onClick).toBeUndefined()
+      expect(itemProps.onMouseMove).toBeUndefined()
+      expect(itemProps.disabled).toBeDefined()
     })
   })
 

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -283,6 +283,7 @@ function useCombobox(userProps = {}) {
           itemRefs.current.push(itemNode)
         }
       }),
+      disabled,
       role: 'option',
       ...(itemIndex === highlightedIndex && {'aria-selected': true}),
       id: getItemId(itemIndex),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Currently, `getItemProps` accepts a `disabled` prop to remove handlers but won't pass that prop down to the `component`.

<!-- Why are these changes necessary? -->

**Why**:

Allows component to be styled dependent on the `disabled` prop. Accessibility?

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->
Simply pass down the `disabled` prop.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Wasn't sure if I need to add a new test or if it's okay to expand the existing one. I believe the existing test was incorrect and fixed it.
