### PR TITLE
fix(useSelect): correct typings for toggleButton and menu getter props

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -44,9 +44,9 @@
     }
   },
   "dist/downshift.esm.js": {
-    "bundled": 112677,
-    "minified": 51716,
-    "gzipped": 11470,
+    "bundled": 112589,
+    "minified": 51686,
+    "gzipped": 11454,
     "treeshaked": {
       "rollup": {
         "code": 1751,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -328,9 +328,9 @@ export interface UseSelectGetItemPropsOptions<Item>
     GetPropsWithRefKey {}
 
 export interface UseSelectPropGetters<Item> {
-  getToggleButtonProps: (options?: UseSelectGetMenuPropsOptions) => any
+  getToggleButtonProps: (options?: UseSelectGetToggleButtonPropsOptions) => any
   getLabelProps: (options?: UseSelectGetLabelPropsOptions) => any
-  getMenuProps: (options?: UseSelectGetToggleButtonPropsOptions) => any
+  getMenuProps: (options?: UseSelectGetMenuPropsOptions) => any
   getItemProps: (options: UseSelectGetItemPropsOptions<Item>) => any
 }
 


### PR DESCRIPTION
**What**:

`UseSelectPropGetters` interface has some wrong types used. This PR fixes the issue.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] TypeScript Types
- [ ] Flow Types N/A
- [x] Ready to be merged
