### PR TITLE
chore(hooks): improve use of react act in tests

### DIFF
--- a/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
@@ -1,5 +1,5 @@
 import {cleanup} from '@testing-library/react'
-import {act as rtlAct} from '@testing-library/react-hooks'
+import {act} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'
 import {setupHook, defaultIds} from '../testUtils'
 
@@ -48,7 +48,7 @@ describe('getComboboxProps', () => {
     test("assign 'true' value to aria-expanded when menu is open", () => {
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef} = result.current.getInputProps()
 
         inputRef({focus: noop})

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-disabled-tests */
-import {act as rtlAct} from '@testing-library/react-hooks'
+import {act} from '@testing-library/react-hooks'
 import {fireEvent, cleanup} from '@testing-library/react'
 import * as stateChangeTypes from '../stateChangeTypes'
 import {noop} from '../../../utils'
@@ -117,7 +117,7 @@ describe('getInputProps', () => {
       const {result} = setupHook()
       const focus = jest.fn()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef} = result.current.getInputProps()
         inputRef({focus})
         result.current.toggleMenu()
@@ -130,7 +130,7 @@ describe('getInputProps', () => {
       const {result} = setupHook()
       const focus = jest.fn()
 
-      rtlAct(() => {
+      act(() => {
         const {blablaRef} = result.current.getInputProps({refKey: 'blablaRef'})
         blablaRef({focus})
         result.current.toggleMenu()
@@ -143,7 +143,7 @@ describe('getInputProps', () => {
       const userOnKeyDown = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onKeyDown} = result.current.getInputProps({
           onKeyDown: userOnKeyDown,
         })
@@ -163,7 +163,7 @@ describe('getInputProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onKeyDown} = result.current.getInputProps({
           onKeyDown: userOnKeyDown,
         })
@@ -181,7 +181,7 @@ describe('getInputProps', () => {
       const userOnBlur = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onBlur} = result.current.getInputProps({
           onBlur: userOnBlur,
         })
@@ -201,7 +201,7 @@ describe('getInputProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onBlur} = result.current.getInputProps({
           onBlur: userOnBlur,
         })
@@ -219,7 +219,7 @@ describe('getInputProps', () => {
       const userOnChange = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onChange} = result.current.getInputProps({
           onChange: userOnChange,
         })
@@ -239,7 +239,7 @@ describe('getInputProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onChange} = result.current.getInputProps({
           onChange: userOnChange,
         })
@@ -257,7 +257,7 @@ describe('getInputProps', () => {
       const userOnInput = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onChange} = result.current.getInputProps({
           onChange: userOnInput,
         })
@@ -277,7 +277,7 @@ describe('getInputProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef, onChange} = result.current.getInputProps({
           onChange: userOnInput,
         })

--- a/src/hooks/useCombobox/__tests__/getMenuProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getMenuProps.test.js
@@ -1,4 +1,4 @@
-import {act as rtlAct} from '@testing-library/react-hooks'
+import {act} from '@testing-library/react-hooks'
 import {fireEvent, cleanup} from '@testing-library/react'
 import {noop} from '../../../utils'
 import {setup, setupHook, defaultIds, dataTestIds} from '../testUtils'
@@ -63,7 +63,7 @@ describe('getMenuProps', () => {
       const userOnMouseLeave = jest.fn()
       const {result} = setupHook({initialHighlightedIndex: 2})
 
-      rtlAct(() => {
+      act(() => {
         const {onMouseLeave} = result.current.getMenuProps({
           onMouseLeave: userOnMouseLeave,
         })
@@ -84,7 +84,7 @@ describe('getMenuProps', () => {
       })
       const {result} = setupHook({initialHighlightedIndex: 2})
 
-      rtlAct(() => {
+      act(() => {
         const {onMouseLeave} = result.current.getMenuProps({
           onMouseLeave: userOnMouseLeave,
         })

--- a/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-disabled-tests */
 import {fireEvent, cleanup} from '@testing-library/react'
-import {act as rtlAct} from '@testing-library/react-hooks'
+import {act} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'
 import {setup, dataTestIds, items, setupHook, defaultIds} from '../testUtils'
 
@@ -50,7 +50,7 @@ describe('getToggleButtonProps', () => {
       const userOnClick = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef} = result.current.getInputProps()
         const {
           ref: toggleButtonRef,
@@ -72,7 +72,7 @@ describe('getToggleButtonProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      act(() => {
         const {ref: inputRef} = result.current.getInputProps()
         const {
           ref: toggleButtonRef,

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -1,7 +1,6 @@
-import {act} from 'react-dom/test-utils'
 import React from 'react'
 import {renderHook} from '@testing-library/react-hooks'
-import {fireEvent, cleanup, render} from '@testing-library/react'
+import {fireEvent, cleanup, render, act} from '@testing-library/react'
 import {defaultProps} from '../../utils'
 import {setup, dataTestIds, items, defaultIds} from '../testUtils'
 import * as stateChangeTypes from '../stateChangeTypes'

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -1,7 +1,6 @@
 /* eslint-disable jest/no-disabled-tests */
-import {act as rtlAct} from '@testing-library/react-hooks'
-import {act} from 'react-dom/test-utils'
-import {fireEvent, cleanup} from '@testing-library/react'
+import {act as reactHooksAct} from '@testing-library/react-hooks'
+import {fireEvent, cleanup, act as reactAct} from '@testing-library/react'
 import {noop} from '../../../utils'
 import {setup, dataTestIds, items, setupHook, defaultIds} from '../testUtils'
 
@@ -88,7 +87,7 @@ describe('getMenuProps', () => {
       const {result} = setupHook()
       const focus = jest.fn()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef} = result.current.getMenuProps()
         menuRef({focus})
         result.current.toggleMenu()
@@ -101,7 +100,7 @@ describe('getMenuProps', () => {
       const {result} = setupHook()
       const focus = jest.fn()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {blablaRef} = result.current.getMenuProps({refKey: 'blablaRef'})
         blablaRef({focus})
         result.current.toggleMenu()
@@ -114,7 +113,7 @@ describe('getMenuProps', () => {
       const userOnMouseLeave = jest.fn()
       const {result} = setupHook({initialHighlightedIndex: 2})
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {onMouseLeave, ref: menuRef} = result.current.getMenuProps({
           onMouseLeave: userOnMouseLeave,
         })
@@ -134,7 +133,7 @@ describe('getMenuProps', () => {
       })
       const {result} = setupHook({initialHighlightedIndex: 2})
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {onMouseLeave, ref: menuRef} = result.current.getMenuProps({
           onMouseLeave: userOnMouseLeave,
         })
@@ -152,7 +151,7 @@ describe('getMenuProps', () => {
       const userOnKeyDown = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef, onKeyDown} = result.current.getMenuProps({
           onKeyDown: userOnKeyDown,
         })
@@ -172,7 +171,7 @@ describe('getMenuProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef, onKeyDown} = result.current.getMenuProps({
           onKeyDown: userOnKeyDown,
         })
@@ -190,7 +189,7 @@ describe('getMenuProps', () => {
       const userOnBlur = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef, onBlur} = result.current.getMenuProps({
           onBlur: userOnBlur,
         })
@@ -210,7 +209,7 @@ describe('getMenuProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef, onBlur} = result.current.getMenuProps({
           onBlur: userOnBlur,
         })
@@ -258,10 +257,18 @@ describe('getMenuProps', () => {
   describe('event handlers', () => {
     describe('on key down', () => {
       describe('character key', () => {
-        jest.useFakeTimers()
+        beforeAll(() => {
+          jest.useFakeTimers()
+        })
+
+        afterAll(() => {
+          jest.useRealTimers()
+        })
 
         afterEach(() => {
-          act(() => jest.runAllTimers())
+          reactAct(() => {
+            jest.runOnlyPendingTimers()
+          })
         })
 
         const startsWithCharacter = (option, character) => {
@@ -289,7 +296,9 @@ describe('getMenuProps', () => {
           )
 
           fireEvent.keyDown(menu, {key: 'c'})
-          act(() => jest.runAllTimers())
+          reactAct(() => {
+            jest.runOnlyPendingTimers()
+          })
           fireEvent.keyDown(menu, {key: 'c'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
@@ -308,9 +317,13 @@ describe('getMenuProps', () => {
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
           fireEvent.keyDown(menu, {key: 'b'})
-          act(() => jest.runAllTimers())
+          reactAct(() => {
+            jest.runOnlyPendingTimers()
+          })
           fireEvent.keyDown(menu, {key: 'b'})
-          act(() => jest.runAllTimers())
+          reactAct(() => {
+            jest.runOnlyPendingTimers()
+          })
           fireEvent.keyDown(menu, {key: 'b'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
@@ -349,7 +362,9 @@ describe('getMenuProps', () => {
 
           fireEvent.keyDown(menu, {key: 'c'})
           fireEvent.keyDown(menu, {key: 'a'})
-          act(() => jest.runAllTimers())
+          reactAct(() => {
+            jest.runOnlyPendingTimers()
+          })
           fireEvent.keyDown(menu, {key: 'l'})
 
           expect(menu.getAttribute('aria-activedescendant')).toBe(
@@ -365,7 +380,7 @@ describe('getMenuProps', () => {
           const menu = wrapper.getByTestId(dataTestIds.menu)
 
           fireEvent.keyDown(menu, {key: 'c'})
-          act(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
+          reactAct(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
           fireEvent.keyDown(menu, {key: 'c'})
 
           // highlight should stay on the first item starting with 'C'

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -1,7 +1,6 @@
 /* eslint-disable jest/no-disabled-tests */
-import {fireEvent, cleanup} from '@testing-library/react'
-import {act as rtlAct} from '@testing-library/react-hooks'
-import {act} from 'react-dom/test-utils'
+import {fireEvent, cleanup, act as reactAct} from '@testing-library/react'
+import {act as reactHooksAct} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'
 import {setup, dataTestIds, items, setupHook, defaultIds} from '../testUtils'
 
@@ -65,7 +64,7 @@ describe('getToggleButtonProps', () => {
     test("assign 'true' value to aria-expanded when menu is open", () => {
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef} = result.current.getMenuProps()
 
         menuRef({focus: noop})
@@ -103,7 +102,7 @@ describe('getToggleButtonProps', () => {
       const userOnClick = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef} = result.current.getMenuProps()
         const {
           ref: toggleButtonRef,
@@ -123,7 +122,7 @@ describe('getToggleButtonProps', () => {
       const userOnKeyDown = jest.fn()
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef} = result.current.getMenuProps()
         const {
           ref: toggleButtonRef,
@@ -145,7 +144,7 @@ describe('getToggleButtonProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef} = result.current.getMenuProps()
         const {
           ref: toggleButtonRef,
@@ -167,7 +166,7 @@ describe('getToggleButtonProps', () => {
       })
       const {result} = setupHook()
 
-      rtlAct(() => {
+      reactHooksAct(() => {
         const {ref: menuRef} = result.current.getMenuProps()
         const {
           ref: toggleButtonRef,
@@ -333,7 +332,7 @@ describe('getToggleButtonProps', () => {
         jest.useFakeTimers()
 
         afterEach(() => {
-          act(() => jest.runAllTimers())
+          reactAct(() => jest.runAllTimers())
         })
 
         const startsWithCharacter = (option, character) => {
@@ -359,7 +358,7 @@ describe('getToggleButtonProps', () => {
           )
 
           fireEvent.keyDown(toggleButton, {key: 'c'})
-          act(() => jest.runAllTimers())
+          reactAct(() => jest.runAllTimers())
           fireEvent.keyDown(toggleButton, {key: 'c'})
 
           expect(toggleButton.textContent).toEqual(
@@ -378,9 +377,9 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
           fireEvent.keyDown(toggleButton, {key: 'b'})
-          act(() => jest.runAllTimers())
+          reactAct(() => jest.runAllTimers())
           fireEvent.keyDown(toggleButton, {key: 'b'})
-          act(() => jest.runAllTimers())
+          reactAct(() => jest.runAllTimers())
           fireEvent.keyDown(toggleButton, {key: 'b'})
 
           expect(toggleButton.textContent).toEqual(
@@ -415,7 +414,7 @@ describe('getToggleButtonProps', () => {
 
           fireEvent.keyDown(toggleButton, {key: 'c'})
           fireEvent.keyDown(toggleButton, {key: 'a'})
-          act(() => jest.runAllTimers())
+          reactAct(() => jest.runAllTimers())
           fireEvent.keyDown(toggleButton, {key: 'l'})
 
           expect(toggleButton.textContent).toEqual(
@@ -429,11 +428,11 @@ describe('getToggleButtonProps', () => {
           const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
           fireEvent.keyDown(toggleButton, {key: 'l'})
-          act(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
+          reactAct(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
           fireEvent.keyDown(toggleButton, {key: 'l'})
-          act(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
+          reactAct(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
           fireEvent.keyDown(toggleButton, {key: 'l'})
-          act(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
+          reactAct(() => jest.advanceTimersByTime(200)) // wait some time but not enough to trigger debounce.
           fireEvent.keyDown(toggleButton, {key: 'l'})
 
           // highlight should stay on the first item starting with 'L'

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -1,6 +1,5 @@
-import {act} from 'react-dom/test-utils'
 import {renderHook} from '@testing-library/react-hooks'
-import {fireEvent, cleanup} from '@testing-library/react'
+import {fireEvent, cleanup, act as reactAct} from '@testing-library/react'
 import {setup, dataTestIds, items, defaultIds} from '../testUtils'
 import * as stateChangeTypes from '../stateChangeTypes'
 import useSelect from '..'
@@ -50,7 +49,7 @@ describe('props', () => {
     jest.useFakeTimers()
 
     afterEach(() => {
-      act(() => jest.runAllTimers())
+      reactAct(() => jest.runAllTimers())
     })
 
     test('should provide string version to a11y status message', () => {
@@ -70,7 +69,7 @@ describe('props', () => {
 
   describe('getA11ySelectionMessage', () => {
     afterEach(() => {
-      act(() => jest.runAllTimers())
+      reactAct(() => jest.runAllTimers())
     })
 
     test('is called with isOpen, items, itemToString and selectedItem at selection', () => {
@@ -99,7 +98,7 @@ describe('props', () => {
 
       fireEvent.click(toggleButton)
       const item = wrapper.getByTestId(dataTestIds.item(3))
-      act(() => jest.runAllTimers())
+      reactAct(() => jest.runAllTimers())
       fireEvent.click(item)
       expect(
         document.getElementById('a11y-status-message').textContent,
@@ -111,7 +110,7 @@ describe('props', () => {
     jest.useFakeTimers()
 
     afterEach(() => {
-      act(() => jest.runAllTimers())
+      reactAct(() => jest.runAllTimers())
     })
 
     test('reports that no results are available if items list is empty', () => {
@@ -151,7 +150,7 @@ describe('props', () => {
     test('is empty on menu close', () => {
       const wrapper = setup({items: ['bla', 'blabla'], initialIsOpen: true})
       const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
-      act(() => jest.runAllTimers())
+      reactAct(() => jest.runAllTimers())
 
       fireEvent.click(toggleButton)
       expect(
@@ -164,7 +163,7 @@ describe('props', () => {
       const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
 
       fireEvent.click(toggleButton)
-      act(() => jest.runAllTimers())
+      reactAct(() => jest.runAllTimers())
 
       expect(
         document.getElementById('a11y-status-message').textContent,


### PR DESCRIPTION
Using `act` either from testing-library/react or react-hooks.