### PR TITLE
docs(useCombobox): change stateReducer codesandbox link

### DIFF
--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -136,7 +136,7 @@ After that, we will return the uppercased input value.
 
 In all other state change types, we return `Downshift` default changes.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-variations-state-reducer-ysc2r)
+[CodeSandbox](https://codesandbox.io/s/usecombobox-variations-state-reducer-x7feb)
 
 <Playground style={playgroundStyles}>
   {() => {


### PR DESCRIPTION
Changes the codesandbox link of the `useCombobox` example with `stateReducer`.