### PR TITLE
fix(getState): revert the controlled prop check

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 115803,
-    "minified": 53212,
-    "gzipped": 11705
+    "bundled": 115780,
+    "minified": 53146,
+    "gzipped": 11693
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 114524,
-    "minified": 52177,
-    "gzipped": 11602
+    "bundled": 114501,
+    "minified": 52111,
+    "gzipped": 11589
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 142983,
-    "minified": 48987,
-    "gzipped": 13309
+    "bundled": 142962,
+    "minified": 48856,
+    "gzipped": 13285
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 126831,
-    "minified": 41458,
-    "gzipped": 11505
+    "bundled": 126810,
+    "minified": 41328,
+    "gzipped": 11504
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 131063,
-    "minified": 42774,
-    "gzipped": 12065
+    "bundled": 131042,
+    "minified": 42644,
+    "gzipped": 12035
   },
   "dist/downshift.umd.js": {
-    "bundled": 172605,
-    "minified": 57900,
-    "gzipped": 15877
+    "bundled": 172584,
+    "minified": 57773,
+    "gzipped": 15853
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 114004,
-    "minified": 51731,
-    "gzipped": 11532,
+    "bundled": 113981,
+    "minified": 51665,
+    "gzipped": 11520,
     "treeshaked": {
       "rollup": {
         "code": 1752,
@@ -44,9 +44,9 @@
     }
   },
   "dist/downshift.esm.js": {
-    "bundled": 115316,
-    "minified": 52799,
-    "gzipped": 11635,
+    "bundled": 115293,
+    "minified": 52733,
+    "gzipped": 11626,
     "treeshaked": {
       "rollup": {
         "code": 1751,

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -25,6 +25,8 @@ import {
   unwrapArray,
   getNextWrappingIndex,
   getNextNonDisabledIndex,
+  getState,
+  isControlledProp,
 } from './utils'
 
 class Downshift extends Component {
@@ -189,33 +191,11 @@ class Downshift extends Component {
    * is the value given, otherwise it's retrieved from
    * stateToMerge
    *
-   * This will perform a shallow merge of the given state object
-   * with the state coming from props
-   * (for the controlled component scenario)
-   * This is used in state updater functions so they're referencing
-   * the right state regardless of where it comes from.
-   *
    * @param {Object} stateToMerge defaults to this.state
    * @return {Object} the state
    */
   getState(stateToMerge = this.state) {
-    return Object.keys(stateToMerge).reduce((state, key) => {
-      state[key] = this.isControlledProp(key)
-        ? this.props[key]
-        : stateToMerge[key]
-      return state
-    }, {})
-  }
-
-  /**
-   * This determines whether a prop is a "controlled prop" meaning it is
-   * state which is controlled by the outside of this component rather
-   * than within this component.
-   * @param {String} key the key to check
-   * @return {Boolean} whether it is a controlled controlled prop
-   */
-  isControlledProp(key) {
-    return this.props[key] !== undefined
+    return getState(stateToMerge, this.props)
   }
 
   getItemCount() {
@@ -387,7 +367,7 @@ class Downshift extends Component {
           }
           nextFullState[key] = newStateToSet[key]
           // if it's coming from props, then we don't care to set it internally
-          if (!this.isControlledProp(key)) {
+          if (!isControlledProp(this.props, key)) {
             nextState[key] = newStateToSet[key]
           }
         })
@@ -1159,7 +1139,7 @@ class Downshift extends Component {
     }
 
     if (
-      this.isControlledProp('selectedItem') &&
+      isControlledProp(this.props, 'selectedItem') &&
       this.props.selectedItemChanged(
         prevProps.selectedItem,
         this.props.selectedItem,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import {useState, useEffect, useCallback, useReducer} from 'react'
-import {scrollIntoView, getNextWrappingIndex} from '../utils'
+import {scrollIntoView, getNextWrappingIndex, getState} from '../utils'
 
 const defaultStateValues = {
   highlightedIndex: -1,
@@ -20,14 +20,6 @@ function getElementIds(
     getItemId: getItemId || (index => `${uniqueId}-item-${index}`),
     toggleButtonId: toggleButtonId || `${uniqueId}-toggle-button`,
   }
-}
-
-function getState(state, props) {
-  return Object.keys(state).reduce((prevState, key) => {
-    // eslint-disable-next-line no-param-reassign
-    prevState[key] = key in props ? props[key] : state[key]
-    return prevState
-  }, {})
 }
 
 function getItemIndex(index, item, items) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -239,6 +239,38 @@ function pickState(state = {}) {
 }
 
 /**
+ * This will perform a shallow merge of the given state object
+ * with the state coming from props
+ * (for the controlled component scenario)
+ * This is used in state updater functions so they're referencing
+ * the right state regardless of where it comes from.
+ *
+ * @param {Object} state The state of the component/hook.
+ * @param {Object} props The props that may contain controlled values.
+ * @returns {Object} The merged controlled state.
+ */
+function getState(state, props) {
+  return Object.keys(state).reduce((prevState, key) => {
+    prevState[key] = isControlledProp(props, key) ? props[key] : state[key]
+
+    return prevState
+  }, {})
+}
+
+/**
+ * This determines whether a prop is a "controlled prop" meaning it is
+ * state which is controlled by the outside of this component rather
+ * than within this component.
+ *
+ * @param {Object} props The props that may contain controlled values.
+ * @param {String} key the key to check
+ * @return {Boolean} whether it is a controlled controlled prop
+ */
+function isControlledProp(props, key) {
+  return props[key] !== undefined
+}
+
+/**
  * Normalizes the 'key' property of a KeyboardEvent in IE/Edge
  * @param {Object} event a keyboardEvent object
  * @return {String} keyboard key
@@ -407,4 +439,6 @@ export {
   getNextWrappingIndex,
   getNextNonDisabledIndex,
   targetWithinDownshift,
+  getState,
+  isControlledProp,
 }


### PR DESCRIPTION
In the hooks, the function was checking initially if the prop is undefined, then it was changed to `prop in props` in 3.3.2. Since in Downshift it's checking for undefined as it was initially in the hooks, I moved the function in the utils so it can be used for both the hooks and the component. Behaviour should be unified now.