### PR TITLE
fix: only add aria-activedescendant when menu is open

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 115938,
-    "minified": 53222,
-    "gzipped": 11708
+    "bundled": 116483,
+    "minified": 53342,
+    "gzipped": 11738
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 114661,
-    "minified": 52189,
-    "gzipped": 11606
+    "bundled": 115206,
+    "minified": 52309,
+    "gzipped": 11633
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 143824,
-    "minified": 51110,
-    "gzipped": 13253
+    "bundled": 144453,
+    "minified": 51230,
+    "gzipped": 13279
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 127462,
-    "minified": 41220,
-    "gzipped": 11303
+    "bundled": 128091,
+    "minified": 41340,
+    "gzipped": 11322
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 131692,
-    "minified": 42541,
-    "gzipped": 11806
+    "bundled": 132321,
+    "minified": 42661,
+    "gzipped": 11827
   },
   "dist/downshift.umd.js": {
-    "bundled": 173444,
-    "minified": 60053,
-    "gzipped": 15770
+    "bundled": 174073,
+    "minified": 60173,
+    "gzipped": 15789
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 114127,
-    "minified": 51729,
-    "gzipped": 11539,
+    "bundled": 114672,
+    "minified": 51849,
+    "gzipped": 11566,
     "treeshaked": {
       "rollup": {
         "code": 1752,
@@ -44,9 +44,9 @@
     }
   },
   "dist/downshift.esm.js": {
-    "bundled": 115439,
-    "minified": 52797,
-    "gzipped": 11642,
+    "bundled": 115984,
+    "minified": 52917,
+    "gzipped": 11670,
     "treeshaked": {
       "rollup": {
         "code": 1751,

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -57,13 +57,20 @@ describe('getInputProps', () => {
       expect(inputProps['aria-controls']).toEqual(`${props.menuId}`)
     })
 
-    test('assign id of highlighted item to aria-activedescendant if item is highlighted', () => {
+    test('assign id of highlighted item to aria-activedescendant if item is highlighted and menu is open', () => {
+      const wrapper = setup({highlightedIndex: 2, isOpen: true})
+      const input = wrapper.getByTestId(dataTestIds.input)
+
+      expect(input.getAttribute('aria-activedescendant')).toEqual(
+        defaultIds.getItemId(2),
+      )
+    })
+
+    test('do not assign aria-activedescendant if menu is closed', () => {
       const {result} = setupHook({highlightedIndex: 2})
       const inputProps = result.current.getInputProps()
 
-      expect(inputProps['aria-activedescendant']).toEqual(
-        defaultIds.getItemId(2),
-      )
+      expect(inputProps['aria-activedescendant']).toBeUndefined()
     })
 
     test('do not assign aria-activedescendant if no item is highlighted', () => {

--- a/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
@@ -208,6 +208,8 @@ describe('getToggleButtonProps', () => {
         )
 
         fireEvent.click(toggleButton)
+        // fireEvent.blur(input)
+        input.blur() // the code above does not blur.
         fireEvent.click(toggleButton)
 
         expect(input.getAttribute('aria-activedescendant')).toBe(

--- a/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
@@ -208,8 +208,7 @@ describe('getToggleButtonProps', () => {
         )
 
         fireEvent.click(toggleButton)
-        // fireEvent.blur(input)
-        input.blur() // the code above does not blur.
+        input.blur()
         fireEvent.click(toggleButton)
 
         expect(input.getAttribute('aria-activedescendant')).toBe(

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -442,9 +442,10 @@ function useCombobox(userProps = {}) {
       id: inputId,
       'aria-autocomplete': 'list',
       'aria-controls': menuId,
-      ...(highlightedIndex > -1 && {
-        'aria-activedescendant': getItemId(highlightedIndex),
-      }),
+      ...(isOpen &&
+        highlightedIndex > -1 && {
+          'aria-activedescendant': getItemId(highlightedIndex),
+        }),
       'aria-labelledby': labelId,
       // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
       // revert back since autocomplete="nope" is ignored on latest Chrome and Opera

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -56,13 +56,20 @@ describe('getMenuProps', () => {
       expect(menuProps.tabIndex).toEqual(-1)
     })
 
-    test('assign id of highlighted item to aria-activedescendant if item is highlighted', () => {
+    test('assign id of highlighted item to aria-activedescendant if item is highlighted and menu is open', () => {
+      const wrapper = setup({highlightedIndex: 2, isOpen: true})
+      const menu = wrapper.getByTestId(dataTestIds.menu)
+
+      expect(menu.getAttribute('aria-activedescendant')).toEqual(
+        defaultIds.getItemId(2),
+      )
+    })
+
+    test('do not assign aria-activedescendant if menu is closed', () => {
       const {result} = setupHook({highlightedIndex: 2})
       const menuProps = result.current.getMenuProps()
 
-      expect(menuProps['aria-activedescendant']).toEqual(
-        defaultIds.getItemId(2),
-      )
+      expect(menuProps['aria-activedescendant']).toBeUndefined()
     })
 
     test('do not assign aria-activedescendant if no item is highlighted', () => {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -351,9 +351,10 @@ function useSelect(userProps = {}) {
     role: 'listbox',
     'aria-labelledby': labelId,
     tabIndex: -1,
-    ...(highlightedIndex > -1 && {
-      'aria-activedescendant': getItemId(highlightedIndex),
-    }),
+    ...(isOpen &&
+      highlightedIndex > -1 && {
+        'aria-activedescendant': getItemId(highlightedIndex),
+      }),
     onKeyDown: callAllEventHandlers(onKeyDown, menuHandleKeyDown),
     onBlur: callAllEventHandlers(onBlur, menuHandleBlur),
     onMouseLeave: callAllEventHandlers(onMouseLeave, menuHandleMouseLeave),


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: in `useSelect`/`useCombobox` only add `aria-activedescendant` attribute when menu is open to avoid pointing to non-existing id.

<!-- Why are these changes necessary? -->

**Why**: Fixes #921

<!-- How were these changes implemented? -->

**How**: check if `isOpen` is `true` before adding `aria-activedescendant`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
