### PR TITLE
chore: update node version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - ~/.cache
 notifications:
   email: false
-node_js: '8'
+node_js: '10'
 install: npm install
 before_script:
   - npx cypress verify &


### PR DESCRIPTION
Otherwise semantic-release would not release.

Updating node_js version in travis.yml from 8 to 10.