### PR TITLE
fix(release): manually release a major version

### DIFF
--- a/other/manual-releases.md
+++ b/other/manual-releases.md
@@ -47,4 +47,4 @@ change is to release a new patch version.
 Reference: #<the number of a relevant pull request, issue, or commit>
 ```
 
-The number of times we've had to do a manual release is: 6
+The number of times we've had to do a manual release is: 7


### PR DESCRIPTION
fix(release): manually release a major version

There was an issue with a major release, so this manual-releases.md
change is to release a new major version.

Reference: https://github.com/downshift-js/downshift/pull/907

BREAKING CHANGE: Changes the parameters of a11y status functions and the keysSoFar to inputValue in useSelect. Please see the attached PR.