### PR TITLE
fix(hooks): only add aria-activedescendant when menu is open

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,33 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 115982,
-    "minified": 53641,
-    "gzipped": 11578
+    "bundled": 115500,
+    "minified": 53542,
+    "gzipped": 11554
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 114704,
-    "minified": 52607,
-    "gzipped": 11474
-  },
-  "dist/downshift.umd.min.js": {
-    "bundled": 131756,
-    "minified": 43218,
-    "gzipped": 11725
+    "bundled": 114222,
+    "minified": 52508,
+    "gzipped": 11450
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 127525,
-    "minified": 41907,
-    "gzipped": 11172
+    "bundled": 126965,
+    "minified": 41808,
+    "gzipped": 11165
+  },
+  "dist/downshift.umd.min.js": {
+    "bundled": 131196,
+    "minified": 43119,
+    "gzipped": 11713
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 143885,
-    "minified": 51833,
-    "gzipped": 13131
+    "bundled": 143325,
+    "minified": 51734,
+    "gzipped": 13113
+  },
+  "dist/downshift.umd.js": {
+    "bundled": 172946,
+    "minified": 60677,
+    "gzipped": 15664
   },
   "dist/downshift.esm.js": {
-    "bundled": 115479,
-    "minified": 53213,
-    "gzipped": 11510,
+    "bundled": 114997,
+    "minified": 53114,
+    "gzipped": 11488,
     "treeshaked": {
       "rollup": {
         "code": 1970,
@@ -38,15 +43,10 @@
       }
     }
   },
-  "dist/downshift.umd.js": {
-    "bundled": 173506,
-    "minified": 60776,
-    "gzipped": 15677
-  },
   "preact/dist/downshift.esm.js": {
-    "bundled": 114167,
-    "minified": 52145,
-    "gzipped": 11408,
+    "bundled": 113685,
+    "minified": 52046,
+    "gzipped": 11383,
     "treeshaked": {
       "rollup": {
         "code": 1971,

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -60,13 +60,20 @@ describe('getInputProps', () => {
       expect(inputProps['aria-controls']).toEqual(`${props.menuId}`)
     })
 
-    test('assign id of highlighted item to aria-activedescendant if item is highlighted', () => {
-      const {result} = renderUseCombobox({highlightedIndex: 2})
+    test('assign id of highlighted item to aria-activedescendant if item is highlighted and menu is open', () => {
+      const {result} = renderUseCombobox({highlightedIndex: 2, isOpen: true})
       const inputProps = result.current.getInputProps()
 
       expect(inputProps['aria-activedescendant']).toEqual(
         defaultIds.getItemId(2),
       )
+    })
+
+    test('assign no aria-activedescendant if item is highlighted and menu is closed', () => {
+      const {result} = renderUseCombobox({highlightedIndex: 2})
+      const inputProps = result.current.getInputProps()
+
+      expect(inputProps['aria-activedescendant']).toBeUndefined()
     })
 
     test('do not assign aria-activedescendant if no item is highlighted', () => {

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -428,9 +428,12 @@ function useCombobox(userProps = {}) {
       id: elementIds.current.inputId,
       'aria-autocomplete': 'list',
       'aria-controls': elementIds.current.menuId,
-      ...(highlightedIndex > -1 && {
-        'aria-activedescendant': elementIds.current.getItemId(highlightedIndex),
-      }),
+      ...(isOpen &&
+        highlightedIndex > -1 && {
+          'aria-activedescendant': elementIds.current.getItemId(
+            highlightedIndex,
+          ),
+        }),
       'aria-labelledby': elementIds.current.labelId,
       // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
       // revert back since autocomplete="nope" is ignored on latest Chrome and Opera

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -60,13 +60,20 @@ describe('getMenuProps', () => {
       expect(menuProps.tabIndex).toEqual(-1)
     })
 
-    test('assign id of highlighted item to aria-activedescendant if item is highlighted', () => {
-      const {result} = renderUseSelect({highlightedIndex: 2})
+    test('assign id of highlighted item to aria-activedescendant if item is highlighted and menu is open', () => {
+      const {result} = renderUseSelect({highlightedIndex: 2, isOpen: true})
       const menuProps = result.current.getMenuProps()
 
       expect(menuProps['aria-activedescendant']).toEqual(
         defaultIds.getItemId(2),
       )
+    })
+
+    test('do not assign aria-activedescendant if item is highlighted and menu is closed', () => {
+      const {result} = renderUseSelect({highlightedIndex: 2})
+      const menuProps = result.current.getMenuProps()
+
+      expect(menuProps['aria-activedescendant']).toBeUndefined()
     })
 
     test('do not assign aria-activedescendant if no item is highlighted', () => {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -427,9 +427,10 @@ function useSelect(userProps = {}) {
     role: 'listbox',
     'aria-labelledby': elementIds.current.labelId,
     tabIndex: -1,
-    ...(highlightedIndex > -1 && {
-      'aria-activedescendant': elementIds.current.getItemId(highlightedIndex),
-    }),
+    ...(isOpen &&
+      highlightedIndex > -1 && {
+        'aria-activedescendant': elementIds.current.getItemId(highlightedIndex),
+      }),
     onMouseLeave: callAllEventHandlers(onMouseLeave, menuHandleMouseLeave),
     onKeyDown: callAllEventHandlers(onKeyDown, menuHandleKeyDown),
     onBlur: callAllEventHandlers(onBlur, menuHandleBlur),


### PR DESCRIPTION
Based on https://github.com/downshift-js/downshift/pull/926, means to fix the issue where in hooks we can have `aria-activedescendant` with a item value even though the menu is closed and the item does not exist.

Fixes https://github.com/downshift-js/downshift/issues/921.

