### PR TITLE
Migrate to import * as React from 'react'

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ the library treeshaked (pruned) and given only the code you need. Since version
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Installation](#installation)
 - [Usage](#usage)
 - [Basic Props](#basic-props)
@@ -164,8 +163,8 @@ should be installed as one of your project's `dependencies`:
 npm install --save downshift
 ```
 
-> This package also depends on `react`. Please make sure you
-> have it installed as well.
+> This package also depends on `react`. Please make sure you have it installed
+> as well.
 
 > Note also this library supports `preact` out of the box. If you are using
 > `preact` then use the corresponding module in the `preact/dist` folder. You
@@ -176,7 +175,7 @@ npm install --save downshift
 > [Try it out in the browser](https://codesandbox.io/s/simple-downshift-with-getrootprops-example-24s13)
 
 ```jsx
-import React from 'react'
+import * as React from 'react'
 import {render} from 'react-dom'
 import Downshift from 'downshift'
 
@@ -1395,6 +1394,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/docs/tests/combobox.js
+++ b/docs/tests/combobox.js
@@ -1,7 +1,7 @@
-import React, {Component} from 'react'
+import * as React from 'react'
 import Downshift from '../../src'
 
-class Combobox extends Component {
+class Combobox extends React.Component {
   state = {
     selectedColor: '',
   }

--- a/flow-typed/npm/downshift_v2.x.x.js.flow
+++ b/flow-typed/npm/downshift_v2.x.x.js.flow
@@ -6,7 +6,7 @@
  * Repo: http://github.com/joarwilk/flowgen
  */
 
-import React from 'react'
+import * as React from 'react'
 
 declare module downshift {
   declare type StateChangeTypes = {

--- a/other/react-native/__tests__/onBlur-tests.js
+++ b/other/react-native/__tests__/onBlur-tests.js
@@ -1,5 +1,5 @@
 import {Text, TextInput, View} from 'react-native'
-import React from 'react'
+import * as React from 'react'
 
 // Note: test renderer must be required after react-native.
 import TestRenderer from 'react-test-renderer'

--- a/other/react-native/__tests__/onChange-tests.js
+++ b/other/react-native/__tests__/onChange-tests.js
@@ -1,5 +1,5 @@
 import {Text, TextInput, View} from 'react-native'
-import React from 'react'
+import * as React from 'react'
 
 // Note: test renderer must be required after react-native.
 import TestRenderer from 'react-test-renderer'

--- a/other/react-native/__tests__/render-tests.js
+++ b/other/react-native/__tests__/render-tests.js
@@ -1,5 +1,5 @@
 import {Text, TextInput, View} from 'react-native'
-import React from 'react'
+import * as React from 'react'
 
 // Note: test renderer must be required after react-native.
 import TestRenderer from 'react-test-renderer'

--- a/other/ssr/__tests__/index.js
+++ b/other/ssr/__tests__/index.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import ReactDOMServer from 'react-dom/server'
+import * as React from 'react'
+import * as ReactDOMServer from 'react-dom/server'
 import Downshift, {resetIdCounter} from '../../../src'
 
 test('does not throw an error when server rendering', () => {

--- a/src/__tests__/downshift.aria.js
+++ b/src/__tests__/downshift.aria.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render} from '@testing-library/react'
 import Downshift from '../'
 import {resetIdCounter} from '../utils'

--- a/src/__tests__/downshift.focus-restoration.js
+++ b/src/__tests__/downshift.focus-restoration.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import Downshift from '../'
 

--- a/src/__tests__/downshift.get-button-props.js
+++ b/src/__tests__/downshift.get-button-props.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import Downshift from '../'
 
@@ -92,9 +92,7 @@ test(`getToggleButtonProps doesn't include event handlers when disabled is passe
   // eslint-disable-next-line jest/no-if
   if (entry) {
     throw new Error(
-      `getToggleButtonProps should not have any props that are callbacks. It has ${
-        entry[0]
-      }.`,
+      `getToggleButtonProps should not have any props that are callbacks. It has ${entry[0]}.`,
     )
   }
 })

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import Downshift from '../'
 
@@ -577,9 +577,7 @@ test(`getInputProps doesn't include event handlers when disabled is passed (for 
   // eslint-disable-next-line jest/no-if
   if (entry) {
     throw new Error(
-      `getInputProps should not have any props that are callbacks. It has ${
-        entry[0]
-      }.`,
+      `getInputProps should not have any props that are callbacks. It has ${entry[0]}.`,
     )
   }
 })

--- a/src/__tests__/downshift.get-item-props.js
+++ b/src/__tests__/downshift.get-item-props.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import Downshift from '../'
 import {setIdCounter} from '../utils'
@@ -150,9 +150,7 @@ test(`getItemProps doesn't include event handlers when disabled is passed (for I
   // eslint-disable-next-line jest/no-if
   if (entry) {
     throw new Error(
-      `getItemProps should not have any props that are callbacks. It has ${
-        entry[0]
-      }.`,
+      `getItemProps should not have any props that are callbacks. It has ${entry[0]}.`,
     )
   }
 })

--- a/src/__tests__/downshift.get-label-props.js
+++ b/src/__tests__/downshift.get-label-props.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render} from '@testing-library/react'
 import Downshift from '../'
 

--- a/src/__tests__/downshift.get-menu-props.js
+++ b/src/__tests__/downshift.get-menu-props.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render} from '@testing-library/react'
 import Downshift from '../'
 

--- a/src/__tests__/downshift.get-root-props.js
+++ b/src/__tests__/downshift.get-root-props.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render} from '@testing-library/react'
 import Downshift from '../'
 

--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {fireEvent, render} from '@testing-library/react'
 import Downshift from '../'
 import setA11yStatus from '../set-a11y-status'

--- a/src/__tests__/downshift.misc-with-utils-mocked.js
+++ b/src/__tests__/downshift.misc-with-utils-mocked.js
@@ -1,7 +1,7 @@
 // this is stuff that I couldn't think fit anywhere else
 // but we still want to have tested.
 
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import Downshift from '../'
 import {scrollIntoView} from '../utils'

--- a/src/__tests__/downshift.misc.js
+++ b/src/__tests__/downshift.misc.js
@@ -1,8 +1,8 @@
 // this is stuff that I couldn't think fit anywhere else
 // but we still want to have tested.
 
-import React from 'react'
-import ReactDOM from 'react-dom'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
 import {render} from '@testing-library/react'
 import Downshift from '../'
 

--- a/src/__tests__/downshift.props.js
+++ b/src/__tests__/downshift.props.js
@@ -1,7 +1,7 @@
 // this is stuff that I couldn't think fit anywhere else
 // but we still want to have tested.
 
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import Downshift from '../'
 

--- a/src/__tests__/portal-support.js
+++ b/src/__tests__/portal-support.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
 import {render, fireEvent} from '@testing-library/react'
 import Downshift from '../'
 

--- a/src/__tests__/utils.reset-id-counter.js
+++ b/src/__tests__/utils.reset-id-counter.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render} from '@testing-library/react'
 import Downshift from '../'
 import {resetIdCounter} from '../utils'

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -79,7 +79,7 @@ between them, screen reader support, highlight by character keys etc.
 > [Try it out in the browser][sandbox-example]
 
 ```jsx
-import React from 'react'
+import * as React from 'react'
 import {render} from 'react-dom'
 import {useCombobox} from 'downshift'
 // items = ['Neptunium', 'Plutonium', ...]

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-disabled-tests */
-import React from 'react'
+import * as React from 'react'
 import {act} from '@testing-library/react-hooks'
 import {fireEvent, cleanup} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import {renderHook} from '@testing-library/react-hooks'
 import userEvent from '@testing-library/user-event'

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -28,7 +28,6 @@ between them, screen reader support, highlight by character keys etc.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Usage](#usage)
 - [Basic Props](#basic-props)
   - [items](#items)
@@ -74,7 +73,7 @@ between them, screen reader support, highlight by character keys etc.
 > [Try it out in the browser][sandbox-example]
 
 ```jsx
-import React from 'react'
+import * as React from 'react'
 import {render} from 'react-dom'
 import {useSelect} from 'downshift'
 // items = ['Neptunium', 'Plutonium', ...]

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-disabled-tests */
-import React from 'react'
+import * as React from 'react'
 import {act} from '@testing-library/react-hooks'
 import {cleanup, act as reactAct, fireEvent} from '@testing-library/react'
 import {renderUseSelect, renderSelect} from '../testUtils'

--- a/src/hooks/useSelect/testUtils.js
+++ b/src/hooks/useSelect/testUtils.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {render, fireEvent} from '@testing-library/react'
 import {renderHook} from '@testing-library/react-hooks'
 import userEvent from '@testing-library/user-event'

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Downshift, {
   type StateChangeOptions,


### PR DESCRIPTION
**What**:

Migrated to `import * as React from 'react'`

**Why**:

Ref https://github.com/facebook/react/pull/18102

This is the recommended way to import react now.

**How**:

With the help of replace-in-files-cli package

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
