### PR TITLE
fix(hooks): call onStateChange with type and only changed props

### DIFF
--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -546,12 +546,14 @@ describe('props', () => {
       const {clickOnToggleButton, input} = renderCombobox({stateReducer})
 
       clickOnToggleButton()
+
       expect(input.value).toBe('Robin Hood')
     })
 
     test('receives a downshift action type', () => {
       const stateReducer = jest.fn((s, a) => {
         expect(a.type).toBe(useCombobox.stateChangeTypes.ToggleButtonClick)
+
         return a.changes
       })
       const {clickOnToggleButton} = renderCombobox({stateReducer})
@@ -627,9 +629,7 @@ describe('props', () => {
       expect(onStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
           isOpen,
-          highlightedIndex,
-          selectedItem,
-          inputValue,
+          type: stateChangeTypes.ToggleButtonClick,
         }),
       )
     })
@@ -741,44 +741,139 @@ describe('props', () => {
   describe('onStateChange', () => {
     test('is called at each state property change', () => {
       const onStateChange = jest.fn()
-      const inputChange = 'test input'
-      const itemClickIndex = 0
       const {
         clickOnToggleButton,
         changeInputValue,
-        keyDownOnInput,
         clickOnItemAtIndex,
+        mouseLeaveMenu,
+        mouseMoveItemAtIndex,
+        keyDownOnInput,
+        blurInput,
       } = renderCombobox({onStateChange})
 
       clickOnToggleButton()
 
-      expect(onStateChange).toHaveBeenCalledWith(
+      expect(onStateChange).toHaveBeenCalledTimes(1)
+      expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
           isOpen: true,
+          type: stateChangeTypes.ToggleButtonClick,
+        }),
+      )
+
+      changeInputValue('t')
+
+      expect(onStateChange).toHaveBeenCalledTimes(2)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          inputValue: 't',
+          type: stateChangeTypes.InputChange,
+        }),
+      )
+
+      mouseMoveItemAtIndex(1)
+
+      expect(onStateChange).toHaveBeenCalledTimes(3)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 1,
+          type: stateChangeTypes.ItemMouseMove,
+        }),
+      )
+
+      clickOnItemAtIndex(2)
+
+      expect(onStateChange).toHaveBeenCalledTimes(4)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          selectedItem: items[2],
+          highlightedIndex: -1,
+          inputValue: items[2],
+          type: stateChangeTypes.ItemClick,
         }),
       )
 
       keyDownOnInput('ArrowDown')
 
-      expect(onStateChange).toHaveBeenCalledWith(
+      expect(onStateChange).toHaveBeenCalledTimes(5)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 3,
+          type: stateChangeTypes.InputKeyDownArrowDown,
+        }),
+      )
+
+      keyDownOnInput('End')
+
+      expect(onStateChange).toHaveBeenCalledTimes(6)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: items.length - 1,
+          type: stateChangeTypes.InputKeyDownEnd,
+        }),
+      )
+
+      keyDownOnInput('Home')
+
+      expect(onStateChange).toHaveBeenCalledTimes(7)
+      expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
           highlightedIndex: 0,
+          type: stateChangeTypes.InputKeyDownHome,
         }),
       )
 
-      changeInputValue(inputChange)
+      keyDownOnInput('Enter')
 
-      expect(onStateChange).toHaveBeenCalledWith(
+      expect(onStateChange).toHaveBeenCalledTimes(8)
+      expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          inputValue: inputChange,
+          highlightedIndex: -1,
+          selectedItem: items[0],
+          inputValue: items[0],
+          type: stateChangeTypes.InputKeyDownEnter,
         }),
       )
 
-      clickOnItemAtIndex(itemClickIndex)
+      keyDownOnInput('Escape')
 
-      expect(onStateChange).toHaveBeenCalledWith(
+      expect(onStateChange).toHaveBeenCalledTimes(9)
+      expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          selectedItem: items[itemClickIndex],
+          selectedItem: null,
+          inputValue: '',
+          type: stateChangeTypes.InputKeyDownEscape,
+        }),
+      )
+
+      keyDownOnInput('ArrowUp')
+
+      expect(onStateChange).toHaveBeenCalledTimes(10)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 25,
+          isOpen: true,
+          type: stateChangeTypes.InputKeyDownArrowUp,
+        }),
+      )
+
+      mouseLeaveMenu()
+
+      expect(onStateChange).toHaveBeenCalledTimes(11)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: -1,
+          type: stateChangeTypes.MenuMouseLeave,
+        }),
+      )
+
+      blurInput()
+
+      expect(onStateChange).toHaveBeenCalledTimes(12)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: false,
+          type: stateChangeTypes.InputBlur,
         }),
       )
     })

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -669,8 +669,7 @@ describe('props', () => {
       expect(onStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
           isOpen,
-          highlightedIndex,
-          selectedItem,
+          type: stateChangeTypes.ToggleButtonClick,
         }),
       )
     })
@@ -775,32 +774,183 @@ describe('props', () => {
   })
 
   describe('onStateChange', () => {
-    test('is called at each state property change', () => {
+    // eslint-disable-next-line max-statements
+    test('is called at each state property change but only with changed props', () => {
       const onStateChange = jest.fn()
       const {
         clickOnToggleButton,
+        blurMenu,
+        mouseLeaveMenu,
         keyDownOnToggleButton,
+        keyDownOnMenu,
+        mouseMoveItemAtIndex,
         clickOnItemAtIndex,
-      } = renderSelect({onStateChange})
+      } = renderSelect({onStateChange, isOpen: true})
 
       clickOnToggleButton()
-      expect(onStateChange).toHaveBeenCalledWith(
+
+      expect(onStateChange).toHaveBeenCalledTimes(1)
+      expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          isOpen: true,
+          isOpen: false,
+          type: stateChangeTypes.ToggleButtonClick,
+        }),
+      )
+
+      keyDownOnMenu('c')
+
+      expect(onStateChange).toHaveBeenCalledTimes(2)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          inputValue: 'c',
+          highlightedIndex: 3, // 4th item starts with C.
+          type: stateChangeTypes.MenuKeyDownCharacter,
+        }),
+      )
+
+      keyDownOnMenu('ArrowDown')
+
+      expect(onStateChange).toHaveBeenCalledTimes(3)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 4,
+          type: stateChangeTypes.MenuKeyDownArrowDown,
+        }),
+      )
+
+      keyDownOnMenu('ArrowUp')
+
+      expect(onStateChange).toHaveBeenCalledTimes(4)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 3,
+          type: stateChangeTypes.MenuKeyDownArrowUp,
+        }),
+      )
+
+      keyDownOnMenu('End')
+
+      expect(onStateChange).toHaveBeenCalledTimes(5)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: items.length - 1,
+          type: stateChangeTypes.MenuKeyDownEnd,
+        }),
+      )
+
+      keyDownOnMenu('Home')
+
+      expect(onStateChange).toHaveBeenCalledTimes(6)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 0,
+          type: stateChangeTypes.MenuKeyDownHome,
+        }),
+      )
+
+      keyDownOnMenu('Enter')
+
+      expect(onStateChange).toHaveBeenCalledTimes(7)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: false,
+          selectedItem: items[0],
+          type: stateChangeTypes.MenuKeyDownEnter,
+        }),
+      )
+
+      mouseMoveItemAtIndex(3)
+
+      expect(onStateChange).toHaveBeenCalledTimes(8)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 3,
+          type: stateChangeTypes.ItemMouseMove,
+        }),
+      )
+
+      mouseLeaveMenu()
+
+      expect(onStateChange).toHaveBeenCalledTimes(9)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: -1,
+          type: stateChangeTypes.MenuMouseLeave,
+        }),
+      )
+
+      keyDownOnMenu('Escape')
+
+      expect(onStateChange).toHaveBeenCalledTimes(10)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: false,
+          type: stateChangeTypes.MenuKeyDownEscape,
         }),
       )
 
       keyDownOnToggleButton('ArrowDown')
-      expect(onStateChange).toHaveBeenCalledWith(
+
+      expect(onStateChange).toHaveBeenCalledTimes(11)
+      expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          highlightedIndex: 0,
+          highlightedIndex: 1,
+          type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
         }),
       )
 
-      clickOnItemAtIndex(0)
-      expect(onStateChange).toHaveBeenCalledWith(
+      keyDownOnMenu(' ')
+
+      expect(onStateChange).toHaveBeenCalledTimes(12)
+      expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          selectedItem: items[0],
+          highlightedIndex: -1,
+          selectedItem: items[1],
+          isOpen: false,
+          type: stateChangeTypes.MenuKeyDownSpaceButton,
+        }),
+      )
+
+      keyDownOnToggleButton('ArrowDown')
+
+      expect(onStateChange).toHaveBeenCalledTimes(13)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: 2,
+          type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
+        }),
+      )
+
+      clickOnItemAtIndex(3)
+
+      expect(onStateChange).toHaveBeenCalledTimes(14)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          selectedItem: items[3],
+          isOpen: false,
+          highlightedIndex: -1,
+          type: stateChangeTypes.ItemClick,
+        }),
+      )
+
+      keyDownOnToggleButton('a')
+
+      expect(onStateChange).toHaveBeenCalledTimes(15)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          inputValue: 'ca',
+          selectedItem: items[5], // 5 item starts with CA.
+          type: stateChangeTypes.ToggleButtonKeyDownCharacter,
+        }),
+      )
+
+      blurMenu()
+
+      expect(onStateChange).toHaveBeenCalledTimes(16)
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: false,
+          type: stateChangeTypes.MenuBlur,
         }),
       )
     })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes https://github.com/downshift-js/downshift/issues/963.
Should call onStateChange with a type now, and also only with props that changed.

<!-- Why are these changes necessary? -->

**Why**:
Previous implementation was not following the API.

<!-- How were these changes implemented? -->

**How**:
Filtered the changes that we call onStateChange with.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
