### PR TITLE
fix(hooks): replace Object.entries with Object.keys to support > IE 9

### DIFF
--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -42,7 +42,7 @@ function itemToString(item) {
 function getPropTypesValidator(caller, propTypes) {
   // istanbul ignore next
   return function validate(options = {}) {
-    Object.entries(propTypes).forEach(([key]) => {
+    Object.keys(propTypes).forEach(key => {
       PropTypes.checkPropTypes(propTypes, options, key, caller.name)
     })
   }
@@ -79,7 +79,7 @@ function callOnChangeProps(action, state, newState) {
     }
   })
 
-  if (props.onStateChange && Object.entries(changes).length) {
+  if (props.onStateChange && Object.keys(changes).length) {
     props.onStateChange({type, ...changes})
   }
 }


### PR DESCRIPTION
Object.entries is not required because the value in the object is not being used. Replaced with Object.keys as at least it is supported on IE 9 and later.

See https://github.com/downshift-js/downshift/issues/970

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged

