### PR TITLE
fix(typescript): add missing `scrollIntoView` definitions to hooks

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -287,6 +287,7 @@ export interface UseSelectProps<Item> {
   menuId?: string
   toggleButtonId?: string
   getItemId?: (index: number) => string
+  scrollIntoView?: (node: HTMLElement, menuNode: HTMLElement) => void
   stateReducer?: (
     state: UseSelectState<Item>,
     actionAndChanges: UseSelectStateChangeOptions<Item>,
@@ -423,6 +424,7 @@ export interface UseComboboxProps<Item> {
   toggleButtonId?: string
   inputId?: string
   getItemId?: (index: number) => string
+  scrollIntoView?: (node: HTMLElement, menuNode: HTMLElement) => void
   stateReducer?: (
     state: UseComboboxState<Item>,
     actionAndChanges: UseComboboxStateChangeOptions<Item>,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added missing `scrollIntoView` type definitions for `useSelect` and `useCombobox` hooks.

**Why**:

Was getting Typescript error while trying to pass `scrollIntoView` prop to `useCombobox`:
```
Object literal may only specify known properties, and 'scrollIntoView' does not exist in type 'UseComboboxProps<string>'
```

**How**:

A small edit to the `typings/index.d.ts` file

**Checklist**:

- [x] TypeScript Types
- [ ] Ready to be merged