### PR TITLE
fix(hooks): add type to on change handler params

### DIFF
--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -917,6 +917,7 @@ describe('props', () => {
       expect(onSelectedItemChange).toHaveBeenCalledWith(
         expect.objectContaining({
           selectedItem: items[itemIndex],
+          type: stateChangeTypes.ItemClick,
         }),
       )
     })
@@ -981,6 +982,7 @@ describe('props', () => {
       expect(onHighlightedIndexChange).toHaveBeenCalledWith(
         expect.objectContaining({
           highlightedIndex: 0,
+          type: stateChangeTypes.InputKeyDownArrowDown,
         }),
       )
     })
@@ -1058,6 +1060,7 @@ describe('props', () => {
       expect(onIsOpenChange).toHaveBeenCalledWith(
         expect.objectContaining({
           isOpen: false,
+          type: stateChangeTypes.InputKeyDownEscape,
         }),
       )
     })

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -930,6 +930,7 @@ describe('props', () => {
       expect(onSelectedItemChange).toHaveBeenCalledWith(
         expect.objectContaining({
           selectedItem: items[index],
+          type: stateChangeTypes.ItemClick,
         }),
       )
     })
@@ -994,6 +995,7 @@ describe('props', () => {
       expect(onHighlightedIndexChange).toHaveBeenCalledWith(
         expect.objectContaining({
           highlightedIndex: 0,
+          type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
         }),
       )
     })
@@ -1066,6 +1068,7 @@ describe('props', () => {
       expect(onIsOpenChange).toHaveBeenCalledWith(
         expect.objectContaining({
           isOpen: false,
+          type: stateChangeTypes.MenuKeyDownEscape,
         }),
       )
     })

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -22,7 +22,7 @@ function callOnChangeProps(action, state, newState) {
   const changes = {}
 
   Object.keys(state).forEach(key => {
-    invokeOnChangeHandler(key, props, state, newState)
+    invokeOnChangeHandler(key, action, state, newState)
 
     if (newState[key] !== state[key]) {
       changes[key] = newState[key]
@@ -34,14 +34,15 @@ function callOnChangeProps(action, state, newState) {
   }
 }
 
-function invokeOnChangeHandler(key, props, state, newState) {
+function invokeOnChangeHandler(key, action, state, newState) {
+  const {props, type} = action
   const handler = `on${capitalizeString(key)}Change`
   if (
     props[handler] &&
     newState[key] !== undefined &&
     newState[key] !== state[key]
   ) {
-    props[handler](newState)
+    props[handler]({type, ...newState})
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -299,19 +299,19 @@ export interface UseSelectProps<Item> {
   environment?: Environment
 }
 
-export interface UseSelectStateChangeOptions<Item> {
+export interface UseSelectStateChangeOptions<Item>
+  extends UseSelectDispatchAction {
   changes: Partial<UseSelectState<Item>>
-  action: UseSelectDispatchAction
-  props: UseSelectProps<Item>
-}
-export interface UseSelectStateChange<Item>
-  extends Partial<UseSelectState<Item>> {
-  type: UseSelectStateChangeTypes
 }
 
 export interface UseSelectDispatchAction {
   type: UseSelectStateChangeTypes
   [data: string]: any
+}
+
+export interface UseSelectStateChange<Item>
+  extends Partial<UseSelectState<Item>> {
+  type: UseSelectStateChangeTypes
 }
 
 export interface UseSelectGetMenuPropsOptions
@@ -448,20 +448,19 @@ export interface UseComboboxProps<Item> {
   environment?: Environment
 }
 
-export interface UseComboboxStateChangeOptions<Item> {
+export interface UseComboboxStateChangeOptions<Item>
+  extends UseComboboxDispatchAction {
   changes: Partial<UseComboboxState<Item>>
-  action: UseComboboxDispatchAction
-  props: UseComboboxProps<Item>
-}
-
-export interface UseComboboxStateChange<Item>
-  extends Partial<UseComboboxState<Item>> {
-  type: UseComboboxStateChangeTypes
 }
 
 export interface UseComboboxDispatchAction {
   type: UseSelectStateChangeTypes
   [data: string]: any
+}
+
+export interface UseComboboxStateChange<Item>
+  extends Partial<UseComboboxState<Item>> {
+  type: UseComboboxStateChangeTypes
 }
 
 export interface UseComboboxGetMenuPropsOptions

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -292,17 +292,26 @@ export interface UseSelectProps<Item> {
     state: UseSelectState<Item>,
     actionAndChanges: UseSelectStateChangeOptions<Item>,
   ) => UseSelectState<Item>
-  onSelectedItemChange?: (changes: Partial<UseSelectState<Item>>) => void
-  onIsOpenChange?: (changes: Partial<UseSelectState<Item>>) => void
-  onHighlightedIndexChange?: (changes: Partial<UseSelectState<Item>>) => void
-  onStateChange?: (changes: Partial<UseSelectState<Item>>) => void
+  onSelectedItemChange?: (changes: UseSelectStateChange<Item>) => void
+  onIsOpenChange?: (changes: UseSelectStateChange<Item>) => void
+  onHighlightedIndexChange?: (changes: UseSelectStateChange<Item>) => void
+  onStateChange?: (changes: UseSelectStateChange<Item>) => void
   environment?: Environment
 }
 
 export interface UseSelectStateChangeOptions<Item> {
-  type: UseSelectStateChangeTypes
-  changes: UseSelectState<Item>
+  changes: Partial<UseSelectState<Item>>
+  action: UseSelectDispatchAction
   props: UseSelectProps<Item>
+}
+export interface UseSelectStateChange<Item>
+  extends Partial<UseSelectState<Item>> {
+  type: UseSelectStateChangeTypes
+}
+
+export interface UseSelectDispatchAction {
+  type: UseSelectStateChangeTypes
+  [data: string]: any
 }
 
 export interface UseSelectGetMenuPropsOptions
@@ -431,18 +440,28 @@ export interface UseComboboxProps<Item> {
     state: UseComboboxState<Item>,
     actionAndChanges: UseComboboxStateChangeOptions<Item>,
   ) => UseComboboxState<Item>
-  onSelectedItemChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onIsOpenChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onHighlightedIndexChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onStateChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onInputValueChange?: (changes: Partial<UseComboboxState<Item>>) => void
+  onSelectedItemChange?: (changes: UseComboboxStateChange<Item>) => void
+  onIsOpenChange?: (changes: UseComboboxStateChange<Item>) => void
+  onHighlightedIndexChange?: (changes: UseComboboxStateChange<Item>) => void
+  onStateChange?: (changes: UseComboboxStateChange<Item>) => void
+  onInputValueChange?: (changes: UseComboboxStateChange<Item>) => void
   environment?: Environment
 }
 
 export interface UseComboboxStateChangeOptions<Item> {
-  type: UseComboboxStateChangeTypes
-  changes: UseComboboxState<Item>
+  changes: Partial<UseComboboxState<Item>>
+  action: UseComboboxDispatchAction
   props: UseComboboxProps<Item>
+}
+
+export interface UseComboboxStateChange<Item>
+  extends Partial<UseComboboxState<Item>> {
+  type: UseComboboxStateChangeTypes
+}
+
+export interface UseComboboxDispatchAction {
+  type: UseSelectStateChangeTypes
+  [data: string]: any
 }
 
 export interface UseComboboxGetMenuPropsOptions

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -300,13 +300,19 @@ export interface UseSelectProps<Item> {
 }
 
 export interface UseSelectStateChangeOptions<Item>
-  extends UseSelectDispatchAction {
+  extends UseSelectDispatchAction<Item> {
   changes: Partial<UseSelectState<Item>>
 }
 
-export interface UseSelectDispatchAction {
+export interface UseSelectDispatchAction<Item> {
   type: UseSelectStateChangeTypes
-  [data: string]: any
+  getItemNodeFromIndex?: (index: number) => HTMLElement
+  shiftKey?: boolean
+  key?: string
+  index?: number
+  highlightedIndex?: number
+  selectedItem?: Item | null
+  inputValue?: string
 }
 
 export interface UseSelectStateChange<Item>
@@ -449,13 +455,18 @@ export interface UseComboboxProps<Item> {
 }
 
 export interface UseComboboxStateChangeOptions<Item>
-  extends UseComboboxDispatchAction {
+  extends UseComboboxDispatchAction<Item> {
   changes: Partial<UseComboboxState<Item>>
 }
 
-export interface UseComboboxDispatchAction {
+export interface UseComboboxDispatchAction<Item> {
   type: UseSelectStateChangeTypes
-  [data: string]: any
+  shiftKey?: boolean
+  getItemNodeFromIndex?: (index: number) => HTMLElement
+  inputValue?: string
+  index?: number
+  highlightedIndex?: number
+  selectedItem?: Item | null
 }
 
 export interface UseComboboxStateChange<Item>
@@ -584,13 +595,16 @@ export interface UseMultipleSelectionProps<Item> {
 }
 
 export interface UseMultipleSelectionStateChangeOptions<Item>
-  extends UseMultipleSelectionDispatchAction {
+  extends UseMultipleSelectionDispatchAction<Item> {
   changes: Partial<UseMultipleSelectionState<Item>>
 }
 
-export interface UseMultipleSelectionDispatchAction {
+export interface UseMultipleSelectionDispatchAction<Item> {
   type: UseMultipleSelectionStateChangeTypes
-  [data: string]: any
+  index?: number
+  selectedItem?: Item | null
+  selectedItems?: Item[]
+  activeIndex?: number
 }
 
 export interface UseMultipleSelectionStateChange<Item>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
As discussed [here](https://github.com/downshift-js/downshift/issues/879#issuecomment-608349780) we are adding `type` to other handlers as we claim to support this already in the docs.

<!-- Why are these changes necessary? -->

**Why**:

We already claim to support these. We already pass `type` in `onStateChange`.
Fixes https://github.com/downshift-js/downshift/issues/1015.

<!-- How were these changes implemented? -->

**How**:

- Add `type` in other chance handlers as well (`onIsOpenChange`, `onSelectedItemChange` etc.)
- Fix TS typings for these handlers to reflect they can have partial state + type.
- Remove `props` from the `stateReducer` call param `actionAndChanges`. Now it should be called with `{...action, changes}`, where `action` has a `type` and other data passed by the hook in dispatch.
- Also fix typings for `stateReducer` in both hooks to reflect it's being called with `{...action, changes}`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
