### PR TITLE
docs(useCombobox): fix stateReducer example to use correct stateChangeType

### DIFF
--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -208,7 +208,7 @@ const {getMenuProps, getItemProps, ...rest} = useCombobox({
 function stateReducer(state, actionAndChanges) {
   // this prevents the menu from being closed when the user selects an item with 'Enter' or mouse
   switch (actionAndChanges.type) {
-    case useCombobox.stateChangeTypes.MenuKeyDownEnter:
+    case useCombobox.stateChangeTypes.InputKeyDownEnter:
     case useCombobox.stateChangeTypes.ItemClick:
       return {
         ...actionAndChanges.changes, // default Downshift new state changes on item selection.


### PR DESCRIPTION
**What**:

The `useCombobox` readme refers to `useCombobox.stateChangeTypes.MenuKeyDownEnter`, which doesn't exist.

**Why**:

Makes it possible to follow the docs without digging into the code to find the type.

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged