### PR TITLE
docs: Add null-check note for itemToString (#975)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,13 @@ the section "[Children Function](#children-function)".
 
 ### itemToString
 
-> `function(item: any)` | defaults to: `i => (i == null ? '' : String(i))`
+> `function(item: any)` | defaults to: `item => (item ? String(item) : '')`
 
-Used to determine the string value for the selected item (which is used to
-compute the `inputValue`).
+If your items are stored as, say, objects instead of strings, downshift still
+needs a string representation for each one (e.g., to set `inputValue`).
+
+**Note:** This callback _must_ include a null check: it is invoked with `null`
+whenever the user abandons input via `<Esc>`.
 
 ### onChange
 
@@ -437,7 +440,7 @@ Called with the item that was selected and the new state of `downshift`. (see
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or
-all of the state (e.g. isOpen, selectedItem, highlightedIndex, etc) and then
+all of the state (e.g., isOpen, selectedItem, highlightedIndex, etc) and then
 pass it as props, rather than letting downshift control all its state itself.
 The parameters both take the shape of internal state
 (`{highlightedIndex: number, inputValue: string, isOpen: boolean, selectedItem: any}`)

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -156,12 +156,14 @@ index, like in `Downshift`.
 
 ### itemToString
 
-> `function(item: any)` | defaults to: `i => (i == null ? '' : String(i))`
+> `function(item: any)` | defaults to: `item => (item ? String(item) : '')`
 
-Used to determine the string value for the selected item. It is used to compute
-the accessibility message that occurs after selecting the item. It is also used
-to allow highlighting by typing character keys, when downshift looks for the
-items whose string version start with the keys typed.
+If your items are stored as, say, objects instead of strings, downshift still
+needs a string representation for each one. This is required for accessibility
+messages (e.g., after making a selection).
+
+**Note:** This callback _must_ include a null check: it is invoked with `null`
+whenever the user abandons input via `<Esc>`.
 
 ### onSelectedItemChange
 
@@ -381,7 +383,7 @@ change like any input of type text, at any character key press, `Space`,
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or
-all of the state (e.g. isOpen, selectedItem, highlightedIndex, etc) and then
+all of the state (e.g., isOpen, selectedItem, highlightedIndex, etc) and then
 pass it as props, rather than letting downshift control all its state itself.
 
 - `changes`: These are the properties that actually have changed since the last

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -132,12 +132,15 @@ index, like in `Downshift`.
 
 ### itemToString
 
-> `function(item: any)` | defaults to: `i => (i == null ? '' : String(i))`
+> `function(item: any)` | defaults to: `item => (item ? String(item) : '')`
 
-Used to determine the string value for the selected item. It is used to compute
-the accessibility message that occurs after selecting the item. It is also used
-to allow highlighting by typing character keys, when downshift looks for the
-items whose string version start with the keys typed.
+If your items are stored as, say, objects instead of strings, downshift still
+needs a string representation for each one. This is required for accessibility
+messages (e.g., after making a selection) and keyboard interaction features
+(e.g., highlighting an item by typing its first few characters).
+
+**Note:** This callback _must_ include a null check: it is invoked with `null`
+whenever the user abandons input via `<Esc>`.
 
 ### onSelectedItemChange
 
@@ -327,7 +330,7 @@ again or hitting Escape key.
 
 This function is called anytime the internal state changes. This can be useful
 if you're using downshift as a "controlled" component, where you manage some or
-all of the state (e.g. isOpen, selectedItem, highlightedIndex, etc) and then
+all of the state (e.g., isOpen, selectedItem, highlightedIndex, etc) and then
 pass it as props, rather than letting downshift control all its state itself.
 
 - `changes`: These are the properties that actually have changed since the last


### PR DESCRIPTION
This commit includes one small, overall style change, as well: [most U.S. style guides recommend that "e.g." be followed by a comma][0], whereas the downshift docs leave it bare.

The core changes in this commit use the phrase "e.g." in a few places, so in the interest of consistency, this commit applies the comma both in new additions and existing instances of "e.g." throughout the docs.

[0]: https://www.dailywritingtips.com/comma-after-i-e-and-e-g/

### Notes

1. I did not run pre-commit hooks because `kcd-scripts test --findRelatedTests` just hung forever. Let me know if I need to make this work.

2. I removed the following point in the `useCombobox` docs:

   > It is also used to allow highlighting by typing character keys, when downshift looks for the items whose string version start with the keys typed.

   I might be wrong, but I believe this only applies to `useSelect`. (Any time I typed extra characters on the combobox, they went directly into the input field.)

3. For consistency, I also updated the "defaults to" code sample to reflect [the actual default callback definition](https://github.com/downshift-js/downshift/blob/master/src/hooks/utils.js#L39) (in `src/hooks/utils.js`).

4. From a package-usability perspective, I would have preferred to put the null checks directly into downshift in the first place; e.g.,

   ```javascript
   // src/hooks/useCombobox/utils.js
   - inputValue = props.itemToString(selectedItem)
   + inputValue = selectedItem ? props.itemToString(selectedItem) : ''
   ```

   but I get the impression that downshift errs on the side of letting users make their own decisions about things. Would you have preferred that, too, or is the current PR better?

Thanks.