### PR TITLE
fix(input): handle IME events on input Enter keydown

### DIFF
--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -385,6 +385,32 @@ test('enter on an input with an open menu does nothing without a highlightedInde
   expect(childrenSpy).not.toHaveBeenCalled()
 })
 
+test('enter on an input with an open menu and a highlightedIndex but with IME composing will not select that item', () => {
+  const {enterOnInput, childrenSpy} = renderDownshift({
+    props: {initialIsOpen: true, initialHighlightedIndex: 0},
+  })
+  const extraEventProps = {keyCode: 229}
+  childrenSpy.mockClear()
+
+  // Enter but for IME
+  enterOnInput(extraEventProps)
+
+  // does not even rerender
+  expect(childrenSpy).not.toHaveBeenCalled()
+
+  // Enter without IME
+  enterOnInput()
+
+  // now it behaves normally
+  expect(childrenSpy).toHaveBeenCalledTimes(1)
+  expect(childrenSpy).toHaveBeenCalledWith(expect.objectContaining({
+    selectedItem: colors[0],
+    inputValue: colors[0],
+    isOpen: false,
+    highlightedIndex: null,
+  }))
+})
+
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
   const onChange = jest.fn()
   const isOpen = true

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -574,6 +574,10 @@ class Downshift extends Component {
     },
 
     Enter(event) {
+      if (event.which === 229) {
+        return
+      }
+
       const {isOpen, highlightedIndex} = this.getState()
       if (isOpen && highlightedIndex != null) {
         event.preventDefault()

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -664,6 +664,29 @@ describe('getInputProps', () => {
         )
       })
 
+      test('enter while IME composing will not select highlighted item', () => {
+        const initialHighlightedIndex = 2
+        const {keyDownOnInput, input, getItems} = renderCombobox({
+          initialHighlightedIndex,
+          initialIsOpen: true,
+        })
+
+        keyDownOnInput('Enter', {keyCode: 229})
+
+        expect(input.value).toEqual('')
+        expect(getItems()).toHaveLength(items.length)
+        expect(input).toHaveAttribute(
+          'aria-activedescendant',
+          defaultIds.getItemId(initialHighlightedIndex),
+        )
+
+        keyDownOnInput('Enter')
+
+        expect(input.value).toEqual(items[2])
+        expect(getItems()).toHaveLength(0)
+        expect(input).not.toHaveAttribute('aria-activedescendant')
+      })
+
       test('tab it closes the menu and selects highlighted item', () => {
         const initialHighlightedIndex = 2
         const {input, getItems} = renderCombobox(

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -235,6 +235,11 @@ function useCombobox(userProps = {}) {
       })
     },
     Enter(event) {
+      // if IME composing, wait for next Enter keydown event.
+      if (event.which === 229) {
+        return
+      }
+
       event.preventDefault()
       dispatch({
         type: stateChangeTypes.InputKeyDownEnter,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Recreating the fix from https://github.com/downshift-js/downshift/pull/671.

<!-- Why are these changes necessary? -->

**Why**:

Handle this case by default in Downshift without users having to create boiler plate handling.

Handle IME composing events.

<!-- How were these changes implemented? -->

**How**:

Check for `event.which === 229`. If true, then will wait for a subsequent event without composing.

More info on:
https://github.com/mui-org/material-ui/issues/19435
https://github.com/zendeskgarden/react-components/issues/598

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
