### PR TITLE
fix(hooks): replace useReducer with useState

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,59 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 133989,
-    "minified": 62191,
-    "gzipped": 13202
+    "bundled": 135913,
+    "minified": 62673,
+    "gzipped": 13187
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 132722,
-    "minified": 61168,
-    "gzipped": 13101
+    "bundled": 134646,
+    "minified": 61650,
+    "gzipped": 13094
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 144028,
-    "minified": 46749,
-    "gzipped": 12534
+    "bundled": 145933,
+    "minified": 46952,
+    "gzipped": 12498
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 148225,
-    "minified": 48055,
-    "gzipped": 13085
+    "bundled": 150130,
+    "minified": 48259,
+    "gzipped": 13048
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 154141,
-    "minified": 54980,
-    "gzipped": 13850
+    "bundled": 156100,
+    "minified": 55348,
+    "gzipped": 13828
   },
   "dist/downshift.umd.js": {
-    "bundled": 183728,
-    "minified": 63906,
-    "gzipped": 16484
+    "bundled": 185687,
+    "minified": 64274,
+    "gzipped": 16460
   },
   "dist/downshift.esm.js": {
-    "bundled": 133389,
-    "minified": 61668,
-    "gzipped": 13131,
+    "bundled": 135298,
+    "minified": 62136,
+    "gzipped": 13111,
     "treeshaked": {
       "rollup": {
-        "code": 2275,
+        "code": 2281,
         "import_statements": 317
       },
       "webpack": {
-        "code": 4498
+        "code": 4504
       }
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 132077,
-    "minified": 60600,
-    "gzipped": 13029,
+    "bundled": 133986,
+    "minified": 61068,
+    "gzipped": 13014,
     "treeshaked": {
       "rollup": {
-        "code": 2276,
+        "code": 2282,
         "import_statements": 318
       },
       "webpack": {
-        "code": 4497
+        "code": 4503
       }
     }
   }

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -6,10 +6,25 @@ route: /use-combobox
 
 import {useState} from 'react'
 import {Playground} from 'docz'
-import {Input, IconButton, FormLabel, List, ListItem, ListItemText, ListItemAvatar, Avatar } from '@material-ui/core'
+import {
+  Input,
+  IconButton,
+  FormLabel,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemAvatar,
+  Avatar,
+} from '@material-ui/core'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import {useCombobox} from '../../src'
-import {items, useStyles, itemsAsObjects, menuStyles, comboboxStyles} from '../utils'
+import {
+  items,
+  useStyles,
+  itemsAsObjects,
+  menuStyles,
+  comboboxStyles,
+} from '../utils'
 
 # useCombobox
 
@@ -78,7 +93,7 @@ combobox `<div>` and the `<ul>` needs to be at the same level with the combobox
     // import { useCombobox } from 'downshift'
     // import { items, menuStyles, comboboxStyles } from './utils'
     function DropdownCombobox() {
-      const [inputItems, setInputItems] = useState(items);
+      const [inputItems, setInputItems] = useState(items)
       const {
         isOpen,
         getToggleButtonProps,
@@ -87,17 +102,17 @@ combobox `<div>` and the `<ul>` needs to be at the same level with the combobox
         getInputProps,
         getComboboxProps,
         highlightedIndex,
-        getItemProps
+        getItemProps,
       } = useCombobox({
         items: inputItems,
-        onInputValueChange: ({ inputValue }) => {
+        onInputValueChange: ({inputValue}) => {
           setInputItems(
             items.filter(item =>
-              item.toLowerCase().startsWith(inputValue.toLowerCase())
-            )
-          );
-        }
-      });
+              item.toLowerCase().startsWith(inputValue.toLowerCase()),
+            ),
+          )
+        },
+      })
       return (
         <div>
           <label {...getLabelProps()}>Choose an element:</label>
@@ -112,20 +127,22 @@ combobox `<div>` and the `<ul>` needs to be at the same level with the combobox
               inputItems.map((item, index) => (
                 <li
                   style={
-                    highlightedIndex === index ? { backgroundColor: "#bde4ff" } : {}
+                    highlightedIndex === index
+                      ? {backgroundColor: '#bde4ff'}
+                      : {}
                   }
                   key={`${item}${index}`}
-                  {...getItemProps({ item, index })}
+                  {...getItemProps({item, index})}
                 >
                   {item}
                 </li>
               ))}
           </ul>
         </div>
-      );
+      )
     }
     return <DropdownCombobox />
-}}
+  }}
 </Playground>
 
 ## MaterialUI
@@ -196,7 +213,10 @@ to be the string equialent of each item object.
         <div>
           <FormLabel {...getLabelProps()}>Choose an employee:</FormLabel>
           <div style={comboboxStyles} {...getComboboxProps()}>
-            <Input placeholder="Employees" {...getInputProps({refKey: 'inputRef'})} />
+            <Input
+              placeholder="Employees"
+              {...getInputProps({refKey: 'inputRef'})}
+            />
             <IconButton
               color="secondary"
               className={classes.button}
@@ -212,7 +232,9 @@ to be the string equialent of each item object.
                   <ListItem
                     key={`${item.primary}-${index}`}
                     className={
-                      index === highlightedIndex ? classes.highlighted : undefined
+                      index === highlightedIndex
+                        ? classes.highlighted
+                        : undefined
                     }
                     {...getItemProps({
                       item,
@@ -241,10 +263,9 @@ via onChange props (`onHighlightedIndexChange`, `onSelectedItemChange` etc.),
 changing them based on your requirements and passing them back to Downshift via
 props, for instance `highlightedIndex` or `selectedItem`.
 
-The example below shows how to control `selectedItem`. The value computed by
-Downshift is received in `onSelectedItemChange` callback. The user checks it and
-passes back a controlled value via `selectedItem`. Here, for example, it checks
-if `selectedItem` is an element that begings with the letter `C`.
+The example below shows how to control `selectedItem`. Both comboboxes share the
+same `selectedItem` reference, and changing it in one of the dropdowns will update
+the value in the other one as well.
 
 [CodeSandbox](https://codesandbox.io/s/usecombobox-variations-controlling-state-wfr1j)
 
@@ -253,12 +274,8 @@ if `selectedItem` is an element that begings with the letter `C`.
     // import React, { useState } from 'react'
     // import { useCombobox } from 'downshift'
     // import { items, menuStyles, comboboxStyles } from './utils'
-    function DropdownCombobox() {
-      const [selectedItem, setSelectedItem] = useState(null);
-      const selectionMessage = selectedItem
-        ? `Selection is ${selectedItem}! Well done!`
-        : 'Select item starting with the letter C.'
-      const [inputItems, setInputItems] = useState(items);
+    function DropdownCombobox({selectedItem, handleSelectedItemChange}) {
+      const [inputItems, setInputItems] = useState(items)
       const {
         isOpen,
         getToggleButtonProps,
@@ -267,26 +284,21 @@ if `selectedItem` is an element that begings with the letter `C`.
         getInputProps,
         getComboboxProps,
         highlightedIndex,
-        getItemProps
+        getItemProps,
       } = useCombobox({
         items: inputItems,
         selectedItem,
-        onSelectedItemChange: ({ selectedItem }) => {
-          if (!selectedItem || selectedItem.startsWith("C")) {
-            setSelectedItem(selectedItem);
-          }
-        },
-        onInputValueChange: ({ inputValue }) => {
+        onSelectedItemChange: handleSelectedItemChange,
+        onInputValueChange: ({inputValue}) => {
           setInputItems(
             items.filter(item =>
-              item.toLowerCase().startsWith(inputValue.toLowerCase())
-            )
-          );
-        }
-      });
+              item.toLowerCase().startsWith(inputValue.toLowerCase()),
+            ),
+          )
+        },
+      })
       return (
         <div>
-          <div>{selectionMessage}</div>
           <label {...getLabelProps()}>Choose an element:</label>
           <div style={comboboxStyles} {...getComboboxProps()}>
             <input {...getInputProps()} />
@@ -299,19 +311,39 @@ if `selectedItem` is an element that begings with the letter `C`.
               inputItems.map((item, index) => (
                 <li
                   style={
-                    highlightedIndex === index ? { backgroundColor: "#bde4ff" } : {}
+                    highlightedIndex === index
+                      ? {backgroundColor: '#bde4ff'}
+                      : {}
                   }
                   key={`${item}${index}`}
-                  {...getItemProps({ item, index })}
+                  {...getItemProps({item, index})}
                 >
                   {item}
                 </li>
               ))}
           </ul>
         </div>
-      );
+      )
     }
-    return <DropdownCombobox />
+    function ControlledComboboxes() {
+      const [selectedItem, setSelectedItem] = useState(null)
+      function handleSelectedItemChange({selectedItem}) {
+        setSelectedItem(selectedItem)
+      }
+      return (
+        <div>
+          <DropdownCombobox
+            selectedItem={selectedItem}
+            handleSelectedItemChange={handleSelectedItemChange}
+          />
+          <DropdownCombobox
+            selectedItem={selectedItem}
+            handleSelectedItemChange={handleSelectedItemChange}
+          />
+        </div>
+      )
+    }
+    return <ControlledComboboxes />
   }}
 </Playground>
 
@@ -421,5 +453,4 @@ In all other state change types, we return `Downshift` default changes.
   }}
 </Playground>
 
-[combobox-aria]:
-  https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
+[combobox-aria]: https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -7,14 +7,17 @@ route: /use-select
 import {useState} from 'react'
 import {Playground} from 'docz'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import {Button, FormLabel, List, ListItem, ListItemText, ListItemAvatar, Avatar } from '@material-ui/core'
-import {useSelect} from '../../src'
 import {
-  items,
-  menuStyles,
-  itemsAsObjects,
-  useStyles,
-} from '../utils'
+  Button,
+  FormLabel,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemAvatar,
+  Avatar,
+} from '@material-ui/core'
+import {useSelect} from '../../src'
+import {items, menuStyles, itemsAsObjects, useStyles} from '../utils'
 
 # useSelect
 
@@ -150,7 +153,7 @@ chosen to be the string equialent of each item object.
     // import {Button, FormLabel, List, ListItem, ListItemText } from '@material-ui/core'
     function MaterialDropdownSelect() {
       const classes = useStyles()
-      const itemToString = item => item ? item.primary : ''
+      const itemToString = item => (item ? item.primary : '')
       const {
         isOpen,
         selectedItem,
@@ -213,12 +216,9 @@ via onChange props (`onHighlightedIndexChange`, `onSelectedItemChange` etc.),
 changing them based on your requirements and passing them back to Downshift via
 props, for instance `highlightedIndex` or `selectedItem`.
 
-The example below shows how to control `selectedItem`. The value computed by
-Downshift is received in `onSelectedItemChange` callback. The user checks it and
-passes back a controlled value via`selectedChangeProp`. Here, for example, it
-checks if `selectedItem` starts with the letter `C` and only then updates the
-`selectedItem` in the widget. If not updated via prop, then the dropdown behaves
-as if no item was selected.
+The example below shows how to control `selectedItem`. Both selects share the
+same `selectedItem` reference, and changing it in one of the dropdowns will update 
+the value in the other one as well.
 
 [CodeSandbox](https://codesandbox.io/s/useselect-variations-controlling-state-8tvwj)
 
@@ -227,11 +227,7 @@ as if no item was selected.
     // import React, { useState } from 'react'
     // import { useSelect } from 'downshift'
     // import { items, menuStyles } from './utils'
-    function DropdownSelect() {
-      const [selectedItem, setSelectedItem] = useState()
-      const selectionMessage = selectedItem
-        ? `Selection is ${selectedItem}! Well done!`
-        : 'Select item starting with the letter C.'
+    function DropdownSelect({selectedItem, handleSelectedItemChange}) {
       const {
         isOpen,
         getToggleButtonProps,
@@ -242,15 +238,10 @@ as if no item was selected.
       } = useSelect({
         items,
         selectedItem,
-        onSelectedItemChange: ({selectedItem}) => {
-          if (selectedItem.startsWith('C')) {
-            setSelectedItem(selectedItem)
-          }
-        },
+        onSelectedItemChange: handleSelectedItemChange,
       })
       return (
         <div>
-          <div>{selectionMessage}</div>
           <label {...getLabelProps()}>Choose an element:</label>
           <button {...getToggleButtonProps()}>
             {selectedItem || 'Elements'}
@@ -274,7 +265,25 @@ as if no item was selected.
         </div>
       )
     }
-    return <DropdownSelect />
+    function ControlledComboboxes() {
+      const [selectedItem, setSelectedItem] = useState(null)
+      function handleSelectedItemChange({selectedItem}) {
+        setSelectedItem(selectedItem)
+      }
+      return (
+        <div>
+          <DropdownSelect
+            selectedItem={selectedItem}
+            handleSelectedItemChange={handleSelectedItemChange}
+          />
+          <DropdownSelect
+            selectedItem={selectedItem}
+            handleSelectedItemChange={handleSelectedItemChange}
+          />
+        </div>
+      )
+    }
+    return <ControlledComboboxes />
   }}
 </Playground>
 
@@ -357,5 +366,4 @@ In all other state change types, we return `Downshift` default changes.
   }}
 </Playground>
 
-[select-aria]:
-  https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html
+[select-aria]: https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint-plugin-react": "7.19.0",
     "flow-bin": "^0.110.1",
     "flow-coverage-report": "^0.6.1",
-    "kcd-scripts": "^5.6.1",
+    "kcd-scripts": "^5.10.0",
     "npm-run-all": "^4.1.5",
     "preact": "^10.0.1",
     "react": "^16.13.1",

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -100,9 +100,7 @@ describe('props', () => {
       keyDownOnInput('Escape')
       waitForDebouncedA11yStatusUpdate()
 
-      expect(getA11yStatusContainer()).toHaveTextContent(
-        '',
-      )
+      expect(getA11yStatusContainer()).toHaveTextContent('')
     })
 
     test('is called with object that contains specific props', () => {
@@ -301,36 +299,25 @@ describe('props', () => {
   describe('highlightedIndex', () => {
     test('controls the state property if passed', () => {
       const highlightedIndex = 1
+      const expectedItemId = defaultIds.getItemId(highlightedIndex)
       const {keyDownOnInput, input} = renderCombobox({
         isOpen: true,
         highlightedIndex,
       })
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
 
       keyDownOnInput('ArrowDown')
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
 
       keyDownOnInput('End')
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
 
       keyDownOnInput('ArrowUp')
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
     })
   })
 
@@ -360,6 +347,21 @@ describe('props', () => {
       blurInput()
 
       expect(input.value).toBe('Dohn Joe')
+    })
+
+    test('is changed once a new selectedItem comes from props', () => {
+      const initialSelectedItem = 'John Doe'
+      const finalSelectedItem = 'John Wick'
+      const {rerenderWithProps, input} = renderCombobox({
+        isOpen: true,
+        selectedItem: initialSelectedItem,
+      })
+
+      expect(input).toHaveValue(initialSelectedItem)
+
+      rerenderWithProps({selectedItem: finalSelectedItem})
+
+      expect(input).toHaveValue(finalSelectedItem)
     })
   })
 
@@ -392,41 +394,42 @@ describe('props', () => {
     test('controls the state property if passed', () => {
       const highlightedIndex = 2
       const selectedItem = items[highlightedIndex]
-      const {keyDownOnInput, input, clickOnToggleButton} = renderCombobox({
+      const expectedItemId = defaultIds.getItemId(highlightedIndex)
+      const {
+        keyDownOnInput,
+        input,
+        clickOnItemAtIndex,
+        clickOnToggleButton,
+      } = renderCombobox({
         selectedItem,
         initialIsOpen: true,
       })
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
 
+      keyDownOnInput('ArrowDown')
       keyDownOnInput('ArrowDown')
       keyDownOnInput('Enter')
       clickOnToggleButton()
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
 
+      keyDownOnInput('ArrowUp')
       keyDownOnInput('ArrowUp')
       keyDownOnInput('Enter')
       clickOnToggleButton()
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
 
       keyDownOnInput('Escape')
       clickOnToggleButton()
 
-      expect(input).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(highlightedIndex),
-      )
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
+
+      clickOnItemAtIndex(highlightedIndex + 1)
+      clickOnToggleButton()
+
+      expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
     })
   })
 

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -7,13 +7,14 @@ import {
   callAllEventHandlers,
   targetWithinDownshift,
 } from '../../utils'
+import {getItemIndex, getPropTypesValidator, updateA11yStatus} from '../utils'
 import {
-  getItemIndex,
-  getPropTypesValidator,
-  useEnhancedReducer,
-  updateA11yStatus,
-} from '../utils'
-import {getInitialState, propTypes, defaultProps, getElementIds} from './utils'
+  getInitialState,
+  propTypes,
+  defaultProps,
+  getElementIds,
+  useControlledState,
+} from './utils'
 import downshiftUseComboboxReducer from './reducer'
 import * as stateChangeTypes from './stateChangeTypes'
 
@@ -51,7 +52,7 @@ function useCombobox(userProps = {}) {
   const [
     {isOpen, highlightedIndex, selectedItem, inputValue},
     dispatch,
-  ] = useEnhancedReducer(downshiftUseComboboxReducer, initialState, props)
+  ] = useControlledState(downshiftUseComboboxReducer, initialState, props)
 
   /* Refs */
   const menuRef = useRef(null)

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -159,6 +159,7 @@ export default function downshiftUseComboboxReducer(state, action) {
         selectedItem: action.selectedItem,
       }
       break
+    case stateChangeTypes.ControlledPropUpdatedSelectedItem:
     case stateChangeTypes.FunctionSetInputValue:
       changes = {
         inputValue: action.inputValue,

--- a/src/hooks/useCombobox/stateChangeTypes.js
+++ b/src/hooks/useCombobox/stateChangeTypes.js
@@ -30,5 +30,5 @@ export const FunctionSetInputValue = productionEnum(
 )
 export const FunctionReset = productionEnum('__function_reset__')
 export const ControlledPropUpdatedSelectedItem = productionEnum(
-  '__autocomplete_controlled_prop_updated_selected_item__',
+  '__controlled_prop_updated_selected_item__',
 )

--- a/src/hooks/useCombobox/stateChangeTypes.js
+++ b/src/hooks/useCombobox/stateChangeTypes.js
@@ -29,3 +29,6 @@ export const FunctionSetInputValue = productionEnum(
   '__function_set_input_value__',
 )
 export const FunctionReset = productionEnum('__function_reset__')
+export const ControlledPropUpdatedSelectedItem = productionEnum(
+  '__autocomplete_controlled_prop_updated_selected_item__',
+)

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -24,6 +24,8 @@ jest.mock('../../utils', () => {
 const renderCombobox = (props, uiCallback) => {
   const ui = <DropdownCombobox {...props} />
   const wrapper = render(uiCallback ? uiCallback(ui) : ui)
+  const rerenderWithProps = newProps =>
+    wrapper.rerender(<DropdownCombobox {...newProps} />)
   const label = wrapper.getByText(/choose an element/i)
   const menu = wrapper.getByRole('listbox')
   const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
@@ -63,6 +65,7 @@ const renderCombobox = (props, uiCallback) => {
 
   return {
     ...wrapper,
+    rerenderWithProps,
     label,
     menu,
     toggleButton,

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -1,7 +1,7 @@
 import {useRef, useEffect} from 'react'
 import setStatus from '../../set-a11y-status'
 import {handleRefs, callAllEventHandlers, normalizeArrowKey} from '../../utils'
-import {useEnhancedReducer, getItemIndex} from '../utils'
+import {useControlledState, getItemIndex} from '../utils'
 import {
   getInitialState,
   defaultProps,
@@ -27,7 +27,7 @@ function useMultipleSelection(userProps = {}) {
   } = props
 
   // Reducer init.
-  const [{activeIndex, selectedItems}, dispatch] = useEnhancedReducer(
+  const [{activeIndex, selectedItems}, dispatch] = useControlledState(
     downshiftMultipleSelectionReducer,
     getInitialState(props),
     props,

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -5,7 +5,7 @@ import {
   getItemIndex,
   getPropTypesValidator,
   isAcceptedCharacterKey,
-  useEnhancedReducer,
+  useControlledState,
   getInitialState,
   updateA11yStatus,
 } from '../utils'
@@ -51,11 +51,10 @@ function useSelect(userProps = {}) {
   const initialState = getInitialState(props)
 
   // Reducer init.
-  const [{isOpen, highlightedIndex, selectedItem, inputValue}, dispatch] = useEnhancedReducer(
-    downshiftSelectReducer,
-    initialState,
-    props,
-  )
+  const [
+    {isOpen, highlightedIndex, selectedItem, inputValue},
+    dispatch,
+  ] = useControlledState(downshiftSelectReducer, initialState, props)
 
   // Refs
   const toggleButtonRef = useRef(null)

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -124,7 +124,17 @@ export function capitalizeString(string) {
   return `${string.slice(0, 1).toUpperCase()}${string.slice(1)}`
 }
 
-export function useEnhancedReducer(reducer, initialState, props) {
+/**
+ * Computes the controlled state using a the previous state, props,
+ * two reducers, one from downshift and an optional one from the user.
+ * Also calls the onChange handlers for state values that have changed.
+ *
+ * @param {Function} reducer Reducer function from downshift.
+ * @param {Object} initialState Initial state of the hook.
+ * @param {Object} props The hook props.
+ * @returns {Array} An array with the state and an action dispatcher.
+ */
+export function useControlledState(reducer, initialState, props) {
   const [uncontrolledState, setState] = useState(initialState)
   const state = getState(uncontrolledState, props)
 

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import {useCallback, useReducer} from 'react'
+import {useState} from 'react'
 import {
   scrollIntoView,
   getNextWrappingIndex,
@@ -64,7 +64,9 @@ function stateReducer(s, a) {
 function getA11ySelectionMessage(selectionParameters) {
   const {selectedItem, itemToString: itemToStringLocal} = selectionParameters
 
-  return selectedItem ? `${itemToStringLocal(selectedItem)} has been selected.` : ''
+  return selectedItem
+    ? `${itemToStringLocal(selectedItem)} has been selected.`
+    : ''
 }
 
 /**
@@ -123,22 +125,19 @@ export function capitalizeString(string) {
 }
 
 export function useEnhancedReducer(reducer, initialState, props) {
-  const enhancedReducer = useCallback(
-    (state, action) => {
-      state = getState(state, action.props)
+  const [uncontrolledState, setState] = useState(initialState)
+  const state = getState(uncontrolledState, props)
 
-      const {stateReducer: stateReduceLocal} = action.props
-      const changes = reducer(state, action)
-      const newState = stateReduceLocal(state, {...action, changes})
+  const dispatch = action => {
+    const {stateReducer: stateReducerFromProps} = action.props
+    const changes = reducer(state, action)
+    const newState = stateReducerFromProps(state, {...action, changes})
 
-      callOnChangeProps(action, state, newState)
+    callOnChangeProps(action, state, newState)
 
-      return newState
-    },
-    [reducer],
-  )
+    setState(newState)
+  }
 
-  const [state, dispatch] = useReducer(enhancedReducer, initialState)
   const dispatchWithProps = action => dispatch({props, ...action})
 
   return [getState(state, props), dispatchWithProps]

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -398,6 +398,7 @@ export enum UseComboboxStateChangeTypes {
   FunctionSelectItem = '__function_select_item__',
   FunctionSetInputValue = '__function_set_input_value__',
   FunctionReset = '__function_reset__',
+  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__'
 }
 
 export interface UseComboboxProps<Item> {
@@ -511,6 +512,7 @@ export interface UseComboboxInterface {
     FunctionSelectItem: UseComboboxStateChangeTypes.FunctionSelectItem
     FunctionSetInputValue: UseComboboxStateChangeTypes.FunctionSetInputValue
     FunctionReset: UseComboboxStateChangeTypes.FunctionReset
+    ControlledPropUpdatedSelectedItem: UseComboboxStateChangeTypes.ControlledPropUpdatedSelectedItem
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Improving the state management by using a useState approach rather than a useReducer one. Also adding a new state transition similar to the one in `Downshift` which updates `inputValue` if the `selectedItem` is controlled via prop and it gets updated.
<!-- Why are these changes necessary? -->

**Why**:
We had the issue with the reducer that it wasn't a pure function, as we called the onChange handlers inside the callback passed to `useReducer`. This throws a warning in newer versions of React.
We also had the issue of `inputValue` not refreshing properly when a controlled `selectedItem` via props changed its value.

<!-- How were these changes implemented? -->

**How**:
`inputValue` refresh is done in a similar way how it's done in the `Downshift` component.
`useEnhancedReducer` has been replaced with `useControlledState` in which we call onChange handlers from inside the dispatch.
<!-- Have you done all of these things?  -->

Fixes https://github.com/downshift-js/downshift/issues/982
Fixes https://github.com/downshift-js/downshift/issues/962

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation - Update the controlled examples with two widgets, side by side, sharing some common controlled state (for instance `selectedItem`).
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
