### PR TITLE
fix(useSelect): don't trigger blur state change after item selection

### DIFF
--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -795,6 +795,33 @@ describe('props', () => {
       clickOnToggleButton()
     })
 
+    // should check that no blur state change occurs after item selection.
+    // https://github.com/downshift-js/downshift/issues/965
+    test('is called only once on item selection', () => {
+      const stateReducer = jest.fn((s, a) => a.changes)
+      const {
+        clickOnToggleButton,
+        keyDownOnMenu,
+        clickOnItemAtIndex,
+      } = renderSelect({stateReducer, initialIsOpen: true})
+
+      clickOnItemAtIndex(0)
+
+      expect(stateReducer).toHaveBeenCalledTimes(1)
+
+      clickOnToggleButton()
+      keyDownOnMenu('ArrowDown')
+      keyDownOnMenu('Enter')
+
+      expect(stateReducer).toHaveBeenCalledTimes(4)
+
+      clickOnToggleButton()
+      keyDownOnMenu('ArrowDown')
+      keyDownOnMenu(' ')
+
+      expect(stateReducer).toHaveBeenCalledTimes(7)
+    })
+
     test('changes are visible in onChange handlers', () => {
       const highlightedIndex = 2
       const selectedItem = {foo: 'bar'}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
MenuBlur state change was triggered after item selection (ItemClick, MenuEnter or MenuSpaceButton).

<!-- Why are these changes necessary? -->

**Why**:
This state change was not needed and it was confusing. Blur change should be triggered only on (Shift)Tab and outside click.

<!-- How were these changes implemented? -->

**How**:
With a ref value. When we blur the menu by programatically focusing the triggerButton, after item selection, we will make that value `false`. This way, when the handler for the menu blur is triggered, it checks this value, and if it's false, it sets it back to true and returns, without triggering the blur action.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Fixes https://github.com/downshift-js/downshift/issues/965.