### PR TITLE
fix(useCombobox): allow to submit form on pressing Enter

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,74 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-<<<<<<< HEAD
-    "bundled": 137464,
-    "minified": 63123,
-    "gzipped": 13314
+    "bundled": 137466,
+    "minified": 63088,
+    "gzipped": 13305
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 136201,
-    "minified": 62104,
-    "gzipped": 13212
+    "bundled": 136204,
+    "minified": 62070,
+    "gzipped": 13203
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 147577,
-    "minified": 47315,
-    "gzipped": 12623
+    "bundled": 147582,
+    "minified": 47311,
+    "gzipped": 12616
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 151770,
-    "minified": 48622,
-    "gzipped": 13175
+    "bundled": 151774,
+    "minified": 48618,
+    "gzipped": 13173
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 157731,
-    "minified": 55673,
-    "gzipped": 13956
+    "bundled": 157736,
+    "minified": 55669,
+    "gzipped": 13943
   },
   "dist/downshift.umd.js": {
-    "bundled": 187314,
-    "minified": 64598,
-    "gzipped": 16588
+    "bundled": 187318,
+    "minified": 64594,
+    "gzipped": 16582
   },
   "dist/downshift.esm.js": {
-    "bundled": 136840,
-    "minified": 62576,
-    "gzipped": 13240,
-=======
-    "bundled": 136444,
-    "minified": 62731,
-    "gzipped": 13205
-  },
-  "preact/dist/downshift.cjs.js": {
-    "bundled": 135178,
-    "minified": 61709,
-    "gzipped": 13110
-  },
-  "preact/dist/downshift.umd.min.js": {
-    "bundled": 146510,
-    "minified": 47019,
-    "gzipped": 12526
-  },
-  "dist/downshift.umd.min.js": {
-    "bundled": 150706,
-    "minified": 48326,
-    "gzipped": 13075
-  },
-  "preact/dist/downshift.umd.js": {
-    "bundled": 156664,
-    "minified": 55376,
-    "gzipped": 13860
-  },
-  "dist/downshift.umd.js": {
-    "bundled": 186250,
-    "minified": 64302,
-    "gzipped": 16492
-  },
-  "dist/downshift.esm.js": {
-    "bundled": 135823,
-    "minified": 62188,
-    "gzipped": 13124,
->>>>>>> fix(useCombobox): allow to submit form on pressing Enter
+    "bundled": 136836,
+    "minified": 62535,
+    "gzipped": 13230,
     "treeshaked": {
       "rollup": {
         "code": 2281,
@@ -80,15 +44,9 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-<<<<<<< HEAD
-    "bundled": 135528,
-    "minified": 61508,
-    "gzipped": 13135,
-=======
-    "bundled": 134511,
-    "minified": 61120,
-    "gzipped": 13028,
->>>>>>> fix(useCombobox): allow to submit form on pressing Enter
+    "bundled": 135524,
+    "minified": 61467,
+    "gzipped": 13124,
     "treeshaked": {
       "rollup": {
         "code": 2282,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,5 +1,6 @@
 {
   "dist/downshift.cjs.js": {
+<<<<<<< HEAD
     "bundled": 137464,
     "minified": 63123,
     "gzipped": 13314
@@ -33,6 +34,41 @@
     "bundled": 136840,
     "minified": 62576,
     "gzipped": 13240,
+=======
+    "bundled": 136444,
+    "minified": 62731,
+    "gzipped": 13205
+  },
+  "preact/dist/downshift.cjs.js": {
+    "bundled": 135178,
+    "minified": 61709,
+    "gzipped": 13110
+  },
+  "preact/dist/downshift.umd.min.js": {
+    "bundled": 146510,
+    "minified": 47019,
+    "gzipped": 12526
+  },
+  "dist/downshift.umd.min.js": {
+    "bundled": 150706,
+    "minified": 48326,
+    "gzipped": 13075
+  },
+  "preact/dist/downshift.umd.js": {
+    "bundled": 156664,
+    "minified": 55376,
+    "gzipped": 13860
+  },
+  "dist/downshift.umd.js": {
+    "bundled": 186250,
+    "minified": 64302,
+    "gzipped": 16492
+  },
+  "dist/downshift.esm.js": {
+    "bundled": 135823,
+    "minified": 62188,
+    "gzipped": 13124,
+>>>>>>> fix(useCombobox): allow to submit form on pressing Enter
     "treeshaked": {
       "rollup": {
         "code": 2281,
@@ -44,9 +80,15 @@
     }
   },
   "preact/dist/downshift.esm.js": {
+<<<<<<< HEAD
     "bundled": 135528,
     "minified": 61508,
     "gzipped": 13135,
+=======
+    "bundled": 134511,
+    "minified": 61120,
+    "gzipped": 13028,
+>>>>>>> fix(useCombobox): allow to submit form on pressing Enter
     "treeshaked": {
       "rollup": {
         "code": 2282,

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -687,6 +687,25 @@ describe('getInputProps', () => {
         expect(input).not.toHaveAttribute('aria-activedescendant')
       })
 
+      test('enter on an input with a closed menu does nothing', () => {
+        const {keyDownOnInput, renderSpy} = renderCombobox({
+          initialHighlightedIndex: 2,
+          initialIsOpen: false,
+        })
+        expect(renderSpy).toHaveBeenCalledTimes(1)
+        keyDownOnInput('Enter')
+        expect(renderSpy).toHaveBeenCalledTimes(1)
+      })
+
+      test('enter on an input with an open menu does nothing without a highlightedIndex', () => {
+        const {keyDownOnInput, renderSpy} = renderCombobox({
+          initialIsOpen: true,
+        })
+        expect(renderSpy).toHaveBeenCalledTimes(1)
+        keyDownOnInput('Enter')
+        expect(renderSpy).toHaveBeenCalledTimes(1)
+      })
+
       test('tab it closes the menu and selects highlighted item', () => {
         const initialHighlightedIndex = 2
         const {input, getItems} = renderCombobox(

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -260,11 +260,13 @@ function useCombobox(userProps = {}) {
         return
       }
 
-      event.preventDefault()
-      dispatch({
-        type: stateChangeTypes.InputKeyDownEnter,
-        getItemNodeFromIndex,
-      })
+      if (isOpen && highlightedIndex > -1) {
+        event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.InputKeyDownEnter,
+          getItemNodeFromIndex,
+        })
+      }
     },
   }
 

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -100,9 +100,7 @@ const DropdownCombobox = ({renderSpy, ...props}) => {
   } = useCombobox({items, ...props})
   const {itemToString} = props.itemToString ? props : defaultProps
 
-  if (renderSpy) {
-    renderSpy()
-  }
+  renderSpy()
 
   return (
     <div>
@@ -143,4 +141,4 @@ const renderUseCombobox = props => {
   return renderHook(() => useCombobox({items, ...props}))
 }
 
-export {renderUseCombobox, dataTestIds, renderCombobox, DropdownCombobox}
+export {renderUseCombobox, dataTestIds, renderCombobox}

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -22,10 +22,11 @@ jest.mock('../../utils', () => {
 })
 
 const renderCombobox = (props, uiCallback) => {
-  const ui = <DropdownCombobox {...props} />
+  const renderSpy = jest.fn()
+  const ui = <DropdownCombobox renderSpy={renderSpy} {...props} />
   const wrapper = render(uiCallback ? uiCallback(ui) : ui)
   const rerender = newProps =>
-    wrapper.rerender(<DropdownCombobox {...newProps} />)
+    wrapper.rerender(<DropdownCombobox renderSpy={renderSpy} {...newProps} />)
   const label = wrapper.getByText(/choose an element/i)
   const menu = wrapper.getByRole('listbox')
   const toggleButton = wrapper.getByTestId(dataTestIds.toggleButton)
@@ -65,6 +66,7 @@ const renderCombobox = (props, uiCallback) => {
 
   return {
     ...wrapper,
+    renderSpy,
     rerender,
     label,
     menu,
@@ -85,7 +87,7 @@ const renderCombobox = (props, uiCallback) => {
   }
 }
 
-const DropdownCombobox = props => {
+const DropdownCombobox = ({renderSpy, ...props}) => {
   const {
     isOpen,
     getToggleButtonProps,
@@ -97,6 +99,10 @@ const DropdownCombobox = props => {
     getItemProps,
   } = useCombobox({items, ...props})
   const {itemToString} = props.itemToString ? props : defaultProps
+
+  if (renderSpy) {
+    renderSpy()
+  }
 
   return (
     <div>


### PR DESCRIPTION
**What**:

Ref https://github.com/downshift-js/downshift/issues/1019


**How**:

Allow to submit form on pressing Enter when menu is closed or
no item is selected.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
