### PR TITLE
perf(hooks): improve mouse and touch tracking

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 137466,
-    "minified": 63088,
-    "gzipped": 13305
+    "bundled": 136546,
+    "minified": 62424,
+    "gzipped": 13264
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 136204,
-    "minified": 62070,
-    "gzipped": 13203
+    "bundled": 135282,
+    "minified": 61404,
+    "gzipped": 13162
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 147582,
-    "minified": 47311,
-    "gzipped": 12616
+    "bundled": 146614,
+    "minified": 46647,
+    "gzipped": 12560
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 151774,
-    "minified": 48618,
-    "gzipped": 13173
+    "bundled": 150808,
+    "minified": 47952,
+    "gzipped": 13114
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 157736,
-    "minified": 55669,
-    "gzipped": 13943
+    "bundled": 156768,
+    "minified": 55003,
+    "gzipped": 13886
   },
   "dist/downshift.umd.js": {
-    "bundled": 187318,
-    "minified": 64594,
-    "gzipped": 16582
+    "bundled": 186352,
+    "minified": 63928,
+    "gzipped": 16505
   },
   "dist/downshift.esm.js": {
-    "bundled": 136836,
-    "minified": 62535,
-    "gzipped": 13230,
+    "bundled": 135928,
+    "minified": 61883,
+    "gzipped": 13187,
     "treeshaked": {
       "rollup": {
         "code": 2281,
@@ -44,9 +44,9 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 135524,
-    "minified": 61467,
-    "gzipped": 13124,
+    "bundled": 134616,
+    "minified": 60815,
+    "gzipped": 13081,
     "treeshaked": {
       "rollup": {
         "code": 2282,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -6,6 +6,7 @@ import {
   getState,
   generateId,
   debounce,
+  targetWithinDownshift,
 } from '../utils'
 import setStatus from '../set-a11y-status'
 
@@ -149,12 +150,8 @@ export function useEnhancedReducer(reducer, initialState, props) {
     },
     [reducer],
   )
-  const [state, dispatch] = useReducer(
-    enhancedReducer,
-    initialState,
-  )
-  const dispatchWithProps = action =>
-    dispatch({props, ...action})
+  const [state, dispatch] = useReducer(enhancedReducer, initialState)
+  const dispatchWithProps = action => dispatch({props, ...action})
   const action = actionRef.current
 
   useEffect(() => {
@@ -278,4 +275,83 @@ export function getHighlightedIndexOnOpen(
     return -1
   }
   return offset < 0 ? items.length - 1 : 0
+}
+
+/**
+ * Reuse the movement tracking of mouse and touch events.
+ *
+ * @param {boolean} isOpen Whether the dropdown is open or not.
+ * @param {Array<Object>} downshiftElementRefs Downshift element refs to track movement (toggleButton, menu etc.)
+ * @param {Object} environment Environment where component/hook exists.
+ * @param {Function} handleBlur Handler on blur from mouse or touch.
+ * @returns {Object} Whether the mouseDown event occurred.
+ */
+export function useMouseAndTouchTracker(
+  isOpen,
+  downshiftElementRefs,
+  environment,
+  handleBlur,
+) {
+  const mouseAndTouchTrackersRef = useRef({
+    isMouseDown: false,
+    isTouchMove: false,
+  })
+
+  useEffect(() => {
+    // The same strategy for checking if a click occurred inside or outside downsift
+    // as in downshift.js.
+    const onMouseDown = () => {
+      mouseAndTouchTrackersRef.current.isMouseDown = true
+    }
+    const onMouseUp = event => {
+      mouseAndTouchTrackersRef.current.isMouseDown = false
+      if (
+        isOpen &&
+        !targetWithinDownshift(
+          event.target,
+          downshiftElementRefs.map(ref => ref.current),
+          environment.document,
+        )
+      ) {
+        handleBlur()
+      }
+    }
+    const onTouchStart = () => {
+      mouseAndTouchTrackersRef.current.isTouchMove = false
+    }
+    const onTouchMove = () => {
+      mouseAndTouchTrackersRef.current.isTouchMove = true
+    }
+    const onTouchEnd = event => {
+      if (
+        isOpen &&
+        !mouseAndTouchTrackersRef.current.isTouchMove &&
+        !targetWithinDownshift(
+          event.target,
+          downshiftElementRefs.map(ref => ref.current),
+          environment.document,
+          false,
+        )
+      ) {
+        handleBlur()
+      }
+    }
+
+    environment.addEventListener('mousedown', onMouseDown)
+    environment.addEventListener('mouseup', onMouseUp)
+    environment.addEventListener('touchstart', onTouchStart)
+    environment.addEventListener('touchmove', onTouchMove)
+    environment.addEventListener('touchend', onTouchEnd)
+
+    return function cleanup() {
+      environment.removeEventListener('mousedown', onMouseDown)
+      environment.removeEventListener('mouseup', onMouseUp)
+      environment.removeEventListener('touchstart', onTouchStart)
+      environment.removeEventListener('touchmove', onTouchMove)
+      environment.removeEventListener('touchend', onTouchEnd)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, environment])
+
+  return mouseAndTouchTrackersRef.current.isMouseDown
 }

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -284,7 +284,7 @@ export function getHighlightedIndexOnOpen(
  * @param {Array<Object>} downshiftElementRefs Downshift element refs to track movement (toggleButton, menu etc.)
  * @param {Object} environment Environment where component/hook exists.
  * @param {Function} handleBlur Handler on blur from mouse or touch.
- * @returns {Object} Whether the mouseDown event occurred.
+ * @returns {boolean} Whether the mouseDown event occurred.
  */
 export function useMouseAndTouchTracker(
   isOpen,

--- a/src/utils.js
+++ b/src/utils.js
@@ -155,7 +155,7 @@ function getA11yStatusMessage({isOpen, resultCount, previousResultCount}) {
       resultCount === 1 ? ' is' : 's are'
     } available, use up and down arrow keys to navigate. Press Enter key to select.`
   }
-  
+
   return ''
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Moves the tracker for mouse and touch events to a separate hook and call it only when isOpen changes.
<!-- Why are these changes necessary? -->

**Why**:
Avoid duplication and prevent it from running at every render.
<!-- How were these changes implemented? -->

**How**:
Moved the whole `useEffect` and the refs for the touch and mouse events to a separate hook. Calling that hook from useCombobox and useSelect, so no more duplication.

There is also no need to call this effect unless the isOpen or environment change.

Can probably be further improved. Ideally it should be re-called when any variable in useEffect changes. Will happily accept further improvements here.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Closes https://github.com/downshift-js/downshift/issues/1031