### PR TITLE
feat: add `selectedItemChanged` prop to useCombobox

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -35,6 +35,7 @@ function useCombobox(userProps = {}) {
     ...defaultProps,
     ...userProps,
   }
+
   const {
     initialIsOpen,
     defaultIsOpen,

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -35,7 +35,6 @@ function useCombobox(userProps = {}) {
     ...defaultProps,
     ...userProps,
   }
-
   const {
     initialIsOpen,
     defaultIsOpen,

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -68,6 +68,7 @@ export const propTypes = {
   getItemId: PropTypes.func,
   inputId: PropTypes.string,
   toggleButtonId: PropTypes.string,
+  selectedItemChanged: PropTypes.func,
   stateReducer: PropTypes.func,
   onSelectedItemChange: PropTypes.func,
   onHighlightedIndexChange: PropTypes.func,
@@ -101,9 +102,13 @@ export function useControlledReducer(reducer, initialState, props) {
   const previousSelectedItemRef = useRef()
   const [state, dispatch] = useEnhancedReducer(reducer, initialState, props)
 
-  // ToDo: if needed, make same approach as selectedItemChanged from Downshift.
   if (isControlledProp(props, 'selectedItem')) {
-    if (previousSelectedItemRef.current !== props.selectedItem) {
+    if (
+      props.selectedItemChanged(
+        previousSelectedItemRef.current,
+        props.selectedItem,
+      )
+    ) {
       dispatch({
         type: ControlledPropUpdatedSelectedItem,
         inputValue: props.itemToString(props.selectedItem),
@@ -121,6 +126,7 @@ export function useControlledReducer(reducer, initialState, props) {
 
 export const defaultProps = {
   ...defaultPropsCommon,
+  selectedItemChanged: (prevItem, item) => prevItem !== item,
   getA11yStatusMessage,
   circularNavigation: true,
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -398,7 +398,7 @@ export enum UseComboboxStateChangeTypes {
   FunctionSelectItem = '__function_select_item__',
   FunctionSetInputValue = '__function_set_input_value__',
   FunctionReset = '__function_reset__',
-  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__',
+  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__'
 }
 
 export interface UseComboboxProps<Item> {
@@ -589,8 +589,7 @@ export interface A11yRemovalMessage<Item> {
 }
 
 export interface UseMultipleSelectionGetSelectedItemPropsOptions<Item>
-  extends React.HTMLProps<HTMLElement>,
-    GetPropsWithRefKey {
+  extends React.HTMLProps<HTMLElement>, GetPropsWithRefKey {
   index?: number
   selectedItem: Item
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -398,7 +398,7 @@ export enum UseComboboxStateChangeTypes {
   FunctionSelectItem = '__function_select_item__',
   FunctionSetInputValue = '__function_set_input_value__',
   FunctionReset = '__function_reset__',
-  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__'
+  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__',
 }
 
 export interface UseComboboxProps<Item> {
@@ -417,6 +417,7 @@ export interface UseComboboxProps<Item> {
   initialSelectedItem?: Item
   defaultSelectedItem?: Item
   inputValue?: string
+  selectedItemChanged?: (prevItem: Item, item: Item) => boolean
   initialInputValue?: string
   defaultInputValue?: string
   id?: string
@@ -588,7 +589,8 @@ export interface A11yRemovalMessage<Item> {
 }
 
 export interface UseMultipleSelectionGetSelectedItemPropsOptions<Item>
-  extends React.HTMLProps<HTMLElement>, GetPropsWithRefKey {
+  extends React.HTMLProps<HTMLElement>,
+    GetPropsWithRefKey {
   index?: number
   selectedItem: Item
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

While working with `useCombobox`, I found a re-rendering bug I was not able to solve. While looking at Downshift, and the code for `useCombobox`, I realized that while downshift supports the prop `selectedItemChanged`, useCombobox does not.

In my project, I had to migrate my code from using useCombobox to using vanilla downshift. 

<!-- Why are these changes necessary? -->

**Why**:

If you are dealing with objects as values, `useCombobox` will fire act as if the selectedItem changed, when it in fact did not.

<!-- How were these changes implemented? -->

**How**:

Added the same `selectedItemChanged` prop that downshift supports.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
