### PR TITLE
docs(useSelect): change the docsite stateReducer example

### DIFF
--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -293,19 +293,18 @@ For even more granular state change control, you can add your own reducer on top
 of the default one. When the `stateReducer` is called, it will receive the
 previous `state` and the `actionAndChanges` object as parameters.
 `actionAndChanges` contains the change `type`, which explains why the state is
-bein g changed. It also contains the `changes` proposed by `Downshift` that
+being changed. It also contains the `changes` proposed by `useSelect` that
 should occur as a consequence of that change type. You are supposed to return
 the new state according to your needs.
 
-In the example below, we are catching the selection event types,
-`MenuKeyDownEnter` and `ItemClick`. To keep the menu open, we override `isOpen`
-with `state.isOpen` and `highlightedIndex` with `state.highlightedIndex` to keep
-the same appearance to the user (menu open with same item highlighted) after
-selection. But selection is still performed, since we are also returning the
-destructured `actionAndChanges.changes` which contains the `selectedItem` given
-to us by the `Downshift` default reducer.
+In the example below, we are implementing a Windows-specific behavior for the
+select. While menu is closed, using `ArrowUp` and `ArrowDown` should keep the
+menu closed and change `selectedItem` incrementally or decrementally. In the
+`stateReducer` we capture the `ToggleButtonKeyDownArrowDown` and
+`ToggleButtonKeyDownArrowUp` events, compute the next `selectedItem` based on
+index, and return it without any other changes.
 
-In all other state change types, we return `Downshift` default changes.
+In all other state change types, we return `useSelect` default changes.
 
 [CodeSandbox](https://codesandbox.io/s/useselect-variations-state-reducer-ysc2r)
 
@@ -316,15 +315,19 @@ In all other state change types, we return `Downshift` default changes.
     // import { items, menuStyles } from './utils'
     function stateReducer(state, actionAndChanges) {
       const {type, changes} = actionAndChanges
-      // this prevents the menu from being closed when the user selects an item.
       switch (type) {
-        case useSelect.stateChangeTypes.MenuKeyDownEnter:
-        case useSelect.stateChangeTypes.ItemClick:
-          return {
-            ...changes, // default Downshift new state changes on item selection.
-            isOpen: state.isOpen, // but keep menu open.
-            highlightedIndex: state.highlightedIndex, // with the item highlighted.
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowDown:
+          const nextItemIndex = items.indexOf(state.selectedItem)
+          if (nextItemIndex === items.length - 1) {
+            return {selectedItem: items[0]}
           }
+          return {selectedItem: items[nextItemIndex + 1]}
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowUp:
+          const previousItemIndex = items.indexOf(state.selectedItem)
+          if (previousItemIndex === 0) {
+            return {selectedItem: items[items.length - 1]}
+          }
+          return {selectedItem: items[previousItemIndex - 1]}
         default:
           return changes // otherwise business as usual.
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Showcase the Windows-specific behavior of a select on ArrowUp/ArrowDown with menu closed.
Instead of opening the menu with a highlightedIndex, we just select the previous/next item.
<!-- Why are these changes necessary? -->

**Why**:
Better use case to illustrate.
<!-- How were these changes implemented? -->

**How**:
Change the stateReducer.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Closes https://github.com/downshift-js/downshift/issues/792.