### PR TITLE
fix(scrollIntoView): do not scroll falsy node

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,7 @@ function noop() {}
  * @param {HTMLElement} menuNode the menu element of the component
  */
 function scrollIntoView(node, menuNode) {
-  if (node === null) {
+  if (!node) {
     return
   }
 


### PR DESCRIPTION
**What**: fix(scrollIntoView): do not scroll falsy node

**Why**: Ref: https://github.com/downshift-js/downshift/pull/1045#issuecomment-628682162

<!-- How were these changes implemented? -->

**How**: swap `if (node === null) return` with `if (!node) return`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
