### PR TITLE
feat(hooks): memoize all callbacks

### DIFF
--- a/src/__mocks__/utils.js
+++ b/src/__mocks__/utils.js
@@ -1,4 +1,4 @@
-const actualUtils = require.requireActual('../utils')
+const actualUtils = jest.requireActual('../utils')
 module.exports = Object.assign(actualUtils, {
   scrollIntoView: jest.fn(), // hard to write tests for this thing...
 })

--- a/src/__tests__/downshift.lifecycle.js
+++ b/src/__tests__/downshift.lifecycle.js
@@ -7,7 +7,7 @@ import * as utils from '../utils'
 jest.useFakeTimers()
 jest.mock('../set-a11y-status')
 jest.mock('../utils', () => {
-  const realUtils = require.requireActual('../utils')
+  const realUtils = jest.requireActual('../utils')
   return {
     ...realUtils,
     scrollIntoView: jest.fn(),

--- a/src/hooks/useCombobox/__tests__/memo.test.js
+++ b/src/hooks/useCombobox/__tests__/memo.test.js
@@ -1,0 +1,9 @@
+import {renderUseCombobox} from '../testUtils'
+
+test('functions are memoized', () => {
+  const {result, rerender} = renderUseCombobox()
+  const firstRenderResult = result.current
+  rerender()
+  const secondRenderResult = result.current
+  expect(firstRenderResult).toEqual(secondRenderResult)
+})

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -13,7 +13,7 @@ const dataTestIds = {
 }
 
 jest.mock('../../utils', () => {
-  const utils = require.requireActual('../../utils')
+  const utils = jest.requireActual('../../utils')
 
   return {
     ...utils,

--- a/src/hooks/useMultipleSelection/__tests__/memo.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/memo.test.js
@@ -1,0 +1,9 @@
+import {renderUseMultipleSelection} from '../testUtils'
+
+test('functions are memoized', () => {
+  const {result, rerender} = renderUseMultipleSelection()
+  const firstRenderResult = result.current
+  rerender()
+  const secondRenderResult = result.current
+  expect(firstRenderResult).toEqual(secondRenderResult)
+})

--- a/src/hooks/useMultipleSelection/testUtils.js
+++ b/src/hooks/useMultipleSelection/testUtils.js
@@ -8,7 +8,7 @@ import useCombobox from '../useCombobox'
 import useMultipleSelection from '.'
 
 jest.mock('../../utils', () => {
-  const utils = require.requireActual('../../utils')
+  const utils = jest.requireActual('../../utils')
 
   return {
     ...utils,

--- a/src/hooks/useSelect/__tests__/memo.test.js
+++ b/src/hooks/useSelect/__tests__/memo.test.js
@@ -1,0 +1,9 @@
+import {renderUseSelect} from '../testUtils'
+
+test('functions are memoized', () => {
+  const {result, rerender} = renderUseSelect()
+  const firstRenderResult = result.current
+  rerender()
+  const secondRenderResult = result.current
+  expect(firstRenderResult).toEqual(secondRenderResult)
+})

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-statements */
-import {useRef, useEffect} from 'react'
+import {useRef, useEffect, useCallback, useMemo} from 'react'
 import {
   getElementIds,
   getItemIndex,
@@ -9,6 +9,7 @@ import {
   getInitialState,
   updateA11yStatus,
   useMouseAndTouchTracker,
+  useLatestRef,
 } from '../utils'
 import {
   callAllEventHandlers,
@@ -51,10 +52,12 @@ function useSelect(userProps = {}) {
   const initialState = getInitialState(props)
 
   // Reducer init.
-  const [
-    {isOpen, highlightedIndex, selectedItem, inputValue},
-    dispatch,
-  ] = useControlledReducer(downshiftSelectReducer, initialState, props)
+  const [state, dispatch] = useControlledReducer(
+    downshiftSelectReducer,
+    initialState,
+    props,
+  )
+  const {isOpen, highlightedIndex, selectedItem, inputValue} = state
 
   // Refs
   const toggleButtonRef = useRef(null)
@@ -67,6 +70,10 @@ function useSelect(userProps = {}) {
   const clearTimeoutRef = useRef(null)
   const elementIdsRef = useRef(getElementIds(props))
   const previousResultCountRef = useRef()
+  const latest = useLatestRef({
+    state,
+    props,
+  })
 
   // Some utils.
   const getItemNodeFromIndex = index =>
@@ -207,287 +214,304 @@ function useSelect(userProps = {}) {
   )
 
   // Event handler functions.
-  const toggleButtonKeyDownHandlers = {
-    ArrowDown(event) {
-      event.preventDefault()
+  const toggleButtonKeyDownHandlers = useMemo(
+    () => ({
+      ArrowDown(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
-        getItemNodeFromIndex,
-        shiftKey: event.shiftKey,
-      })
-    },
-    ArrowUp(event) {
-      event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
+          getItemNodeFromIndex,
+          shiftKey: event.shiftKey,
+        })
+      },
+      ArrowUp(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.ToggleButtonKeyDownArrowUp,
-        getItemNodeFromIndex,
-        shiftKey: event.shiftKey,
-      })
-    },
-  }
-  const menuKeyDownHandlers = {
-    ArrowDown(event) {
-      event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.ToggleButtonKeyDownArrowUp,
+          getItemNodeFromIndex,
+          shiftKey: event.shiftKey,
+        })
+      },
+    }),
+    [dispatch],
+  )
+  const menuKeyDownHandlers = useMemo(
+    () => ({
+      ArrowDown(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownArrowDown,
-        getItemNodeFromIndex,
-        shiftKey: event.shiftKey,
-      })
-    },
-    ArrowUp(event) {
-      event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.MenuKeyDownArrowDown,
+          getItemNodeFromIndex,
+          shiftKey: event.shiftKey,
+        })
+      },
+      ArrowUp(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownArrowUp,
-        getItemNodeFromIndex,
-        shiftKey: event.shiftKey,
-      })
-    },
-    Home(event) {
-      event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.MenuKeyDownArrowUp,
+          getItemNodeFromIndex,
+          shiftKey: event.shiftKey,
+        })
+      },
+      Home(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownHome,
-        getItemNodeFromIndex,
-      })
-    },
-    End(event) {
-      event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.MenuKeyDownHome,
+          getItemNodeFromIndex,
+        })
+      },
+      End(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownEnd,
-        getItemNodeFromIndex,
-      })
-    },
-    Escape() {
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownEscape,
-      })
-    },
-    Enter(event) {
-      event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.MenuKeyDownEnd,
+          getItemNodeFromIndex,
+        })
+      },
+      Escape() {
+        dispatch({
+          type: stateChangeTypes.MenuKeyDownEscape,
+        })
+      },
+      Enter(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownEnter,
-      })
-    },
-    ' '(event) {
-      event.preventDefault()
+        dispatch({
+          type: stateChangeTypes.MenuKeyDownEnter,
+        })
+      },
+      ' '(event) {
+        event.preventDefault()
 
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownSpaceButton,
-      })
-    },
-  }
-
-  // Event handlers.
-  const menuHandleKeyDown = event => {
-    const key = normalizeArrowKey(event)
-    if (key && menuKeyDownHandlers[key]) {
-      menuKeyDownHandlers[key](event)
-    } else if (isAcceptedCharacterKey(key)) {
-      dispatch({
-        type: stateChangeTypes.MenuKeyDownCharacter,
-        key,
-        getItemNodeFromIndex,
-      })
-    }
-  }
-  const menuHandleBlur = () => {
-    // if the blur was a result of selection, we don't trigger this action.
-    if (shouldBlurRef.current === false) {
-      shouldBlurRef.current = true
-      return
-    }
-
-    const shouldBlur = !mouseAndTouchTrackersRef.current.isMouseDown
-    /* istanbul ignore else */
-    if (shouldBlur) {
-      dispatch({type: stateChangeTypes.MenuBlur})
-    }
-  }
-  const menuHandleMouseLeave = () => {
-    dispatch({
-      type: stateChangeTypes.MenuMouseLeave,
-    })
-  }
-  const toggleButtonHandleClick = () => {
-    dispatch({
-      type: stateChangeTypes.ToggleButtonClick,
-    })
-  }
-  const toggleButtonHandleKeyDown = event => {
-    const key = normalizeArrowKey(event)
-    if (key && toggleButtonKeyDownHandlers[key]) {
-      toggleButtonKeyDownHandlers[key](event)
-    } else if (isAcceptedCharacterKey(key)) {
-      dispatch({
-        type: stateChangeTypes.ToggleButtonKeyDownCharacter,
-        key,
-        getItemNodeFromIndex,
-      })
-    }
-  }
-  const itemHandleMouseMove = index => {
-    if (index === highlightedIndex) {
-      return
-    }
-    shouldScrollRef.current = false
-    dispatch({
-      type: stateChangeTypes.ItemMouseMove,
-      index,
-    })
-  }
-  const itemHandleClick = index => {
-    dispatch({
-      type: stateChangeTypes.ItemClick,
-      index,
-    })
-  }
+        dispatch({
+          type: stateChangeTypes.MenuKeyDownSpaceButton,
+        })
+      },
+    }),
+    [dispatch],
+  )
 
   // Action functions.
-  const toggleMenu = () => {
+  const toggleMenu = useCallback(() => {
     dispatch({
       type: stateChangeTypes.FunctionToggleMenu,
     })
-  }
-  const closeMenu = () => {
+  }, [dispatch])
+  const closeMenu = useCallback(() => {
     dispatch({
       type: stateChangeTypes.FunctionCloseMenu,
     })
-  }
-  const openMenu = () => {
+  }, [dispatch])
+  const openMenu = useCallback(() => {
     dispatch({
       type: stateChangeTypes.FunctionOpenMenu,
     })
-  }
-  const setHighlightedIndex = newHighlightedIndex => {
-    dispatch({
-      type: stateChangeTypes.FunctionSetHighlightedIndex,
-      highlightedIndex: newHighlightedIndex,
-    })
-  }
-  const selectItem = newSelectedItem => {
-    dispatch({
-      type: stateChangeTypes.FunctionSelectItem,
-      selectedItem: newSelectedItem,
-    })
-  }
-  const reset = () => {
+  }, [dispatch])
+  const setHighlightedIndex = useCallback(
+    newHighlightedIndex => {
+      dispatch({
+        type: stateChangeTypes.FunctionSetHighlightedIndex,
+        highlightedIndex: newHighlightedIndex,
+      })
+    },
+    [dispatch],
+  )
+  const selectItem = useCallback(
+    newSelectedItem => {
+      dispatch({
+        type: stateChangeTypes.FunctionSelectItem,
+        selectedItem: newSelectedItem,
+      })
+    },
+    [dispatch],
+  )
+  const reset = useCallback(() => {
     dispatch({
       type: stateChangeTypes.FunctionReset,
     })
-  }
-  const setInputValue = newInputValue => {
-    dispatch({
-      type: stateChangeTypes.FunctionSetInputValue,
-      inputValue: newInputValue,
-    })
-  }
+  }, [dispatch])
+  const setInputValue = useCallback(
+    newInputValue => {
+      dispatch({
+        type: stateChangeTypes.FunctionSetInputValue,
+        inputValue: newInputValue,
+      })
+    },
+    [dispatch],
+  )
   // Getter functions.
-  const getLabelProps = labelProps => ({
-    id: elementIdsRef.current.labelId,
-    htmlFor: elementIdsRef.current.toggleButtonId,
-    ...labelProps,
-  })
-  const getMenuProps = ({
-    onMouseLeave,
-    refKey = 'ref',
-    onKeyDown,
-    onBlur,
-    ref,
-    ...rest
-  } = {}) => ({
-    [refKey]: handleRefs(ref, menuNode => {
-      menuRef.current = menuNode
+  const getLabelProps = useCallback(
+    labelProps => ({
+      id: elementIdsRef.current.labelId,
+      htmlFor: elementIdsRef.current.toggleButtonId,
+      ...labelProps,
     }),
-    id: elementIdsRef.current.menuId,
-    role: 'listbox',
-    'aria-labelledby': elementIdsRef.current.labelId,
-    tabIndex: -1,
-    ...(isOpen &&
-      highlightedIndex > -1 && {
-        'aria-activedescendant': elementIdsRef.current.getItemId(
-          highlightedIndex,
-        ),
-      }),
-    onMouseLeave: callAllEventHandlers(onMouseLeave, menuHandleMouseLeave),
-    onKeyDown: callAllEventHandlers(onKeyDown, menuHandleKeyDown),
-    onBlur: callAllEventHandlers(onBlur, menuHandleBlur),
-    ...rest,
-  })
-  const getToggleButtonProps = ({
-    onClick,
-    onKeyDown,
-    refKey = 'ref',
-    ref,
-    ...rest
-  } = {}) => {
-    const toggleProps = {
-      [refKey]: handleRefs(ref, toggleButtonNode => {
-        toggleButtonRef.current = toggleButtonNode
-      }),
-      id: elementIdsRef.current.toggleButtonId,
-      'aria-haspopup': 'listbox',
-      'aria-expanded': isOpen,
-      'aria-labelledby': `${elementIdsRef.current.labelId} ${elementIdsRef.current.toggleButtonId}`,
-      ...rest,
-    }
+    [],
+  )
+  const getMenuProps = useCallback(
+    ({onMouseLeave, refKey = 'ref', onKeyDown, onBlur, ref, ...rest} = {}) => {
+      const latestState = latest.current.state
 
-    if (!rest.disabled) {
-      toggleProps.onClick = callAllEventHandlers(
-        onClick,
-        toggleButtonHandleClick,
-      )
-      toggleProps.onKeyDown = callAllEventHandlers(
-        onKeyDown,
-        toggleButtonHandleKeyDown,
-      )
-    }
-
-    return toggleProps
-  }
-  const getItemProps = ({
-    item,
-    index,
-    onMouseMove,
-    onClick,
-    refKey = 'ref',
-    ref,
-    ...rest
-  } = {}) => {
-    const itemIndex = getItemIndex(index, item, items)
-    if (itemIndex < 0) {
-      throw new Error('Pass either item or item index in getItemProps!')
-    }
-    const itemProps = {
-      role: 'option',
-      'aria-selected': `${itemIndex === highlightedIndex}`,
-      id: elementIdsRef.current.getItemId(itemIndex),
-      [refKey]: handleRefs(ref, itemNode => {
-        if (itemNode) {
-          itemRefs.current[
-            elementIdsRef.current.getItemId(itemIndex)
-          ] = itemNode
+      const menuHandleKeyDown = event => {
+        const key = normalizeArrowKey(event)
+        if (key && menuKeyDownHandlers[key]) {
+          menuKeyDownHandlers[key](event)
+        } else if (isAcceptedCharacterKey(key)) {
+          dispatch({
+            type: stateChangeTypes.MenuKeyDownCharacter,
+            key,
+            getItemNodeFromIndex,
+          })
         }
-      }),
-      ...rest,
-    }
+      }
+      const menuHandleBlur = () => {
+        // if the blur was a result of selection, we don't trigger this action.
+        if (shouldBlurRef.current === false) {
+          shouldBlurRef.current = true
+          return
+        }
 
-    if (!rest.disabled) {
-      itemProps.onMouseMove = callAllEventHandlers(onMouseMove, () =>
-        itemHandleMouseMove(itemIndex),
-      )
-      itemProps.onClick = callAllEventHandlers(onClick, () =>
-        itemHandleClick(itemIndex),
-      )
-    }
+        const shouldBlur = !mouseAndTouchTrackersRef.current.isMouseDown
+        /* istanbul ignore else */
+        if (shouldBlur) {
+          dispatch({type: stateChangeTypes.MenuBlur})
+        }
+      }
+      const menuHandleMouseLeave = () => {
+        dispatch({
+          type: stateChangeTypes.MenuMouseLeave,
+        })
+      }
+      return {
+        [refKey]: handleRefs(ref, menuNode => {
+          menuRef.current = menuNode
+        }),
+        id: elementIdsRef.current.menuId,
+        role: 'listbox',
+        'aria-labelledby': elementIdsRef.current.labelId,
+        tabIndex: -1,
+        ...(latestState.isOpen &&
+          latestState.highlightedIndex > -1 && {
+            'aria-activedescendant': elementIdsRef.current.getItemId(
+              latestState.highlightedIndex,
+            ),
+          }),
+        onMouseLeave: callAllEventHandlers(onMouseLeave, menuHandleMouseLeave),
+        onKeyDown: callAllEventHandlers(onKeyDown, menuHandleKeyDown),
+        onBlur: callAllEventHandlers(onBlur, menuHandleBlur),
+        ...rest,
+      }
+    },
+    [dispatch, latest, menuKeyDownHandlers, mouseAndTouchTrackersRef],
+  )
+  const getToggleButtonProps = useCallback(
+    ({onClick, onKeyDown, refKey = 'ref', ref, ...rest} = {}) => {
+      const toggleButtonHandleClick = () => {
+        dispatch({
+          type: stateChangeTypes.ToggleButtonClick,
+        })
+      }
+      const toggleButtonHandleKeyDown = event => {
+        const key = normalizeArrowKey(event)
+        if (key && toggleButtonKeyDownHandlers[key]) {
+          toggleButtonKeyDownHandlers[key](event)
+        } else if (isAcceptedCharacterKey(key)) {
+          dispatch({
+            type: stateChangeTypes.ToggleButtonKeyDownCharacter,
+            key,
+            getItemNodeFromIndex,
+          })
+        }
+      }
+      const toggleProps = {
+        [refKey]: handleRefs(ref, toggleButtonNode => {
+          toggleButtonRef.current = toggleButtonNode
+        }),
+        id: elementIdsRef.current.toggleButtonId,
+        'aria-haspopup': 'listbox',
+        'aria-expanded': latest.current.state.isOpen,
+        'aria-labelledby': `${elementIdsRef.current.labelId} ${elementIdsRef.current.toggleButtonId}`,
+        ...rest,
+      }
 
-    return itemProps
-  }
+      if (!rest.disabled) {
+        toggleProps.onClick = callAllEventHandlers(
+          onClick,
+          toggleButtonHandleClick,
+        )
+        toggleProps.onKeyDown = callAllEventHandlers(
+          onKeyDown,
+          toggleButtonHandleKeyDown,
+        )
+      }
+
+      return toggleProps
+    },
+    [dispatch, latest, toggleButtonKeyDownHandlers],
+  )
+  const getItemProps = useCallback(
+    ({
+      item,
+      index,
+      onMouseMove,
+      onClick,
+      refKey = 'ref',
+      ref,
+      ...rest
+    } = {}) => {
+      const {state: latestState, props: latestProps} = latest.current
+      const itemHandleMouseMove = () => {
+        if (index === latestState.highlightedIndex) {
+          return
+        }
+        shouldScrollRef.current = false
+        dispatch({
+          type: stateChangeTypes.ItemMouseMove,
+          index,
+        })
+      }
+      const itemHandleClick = () => {
+        dispatch({
+          type: stateChangeTypes.ItemClick,
+          index,
+        })
+      }
+
+      const itemIndex = getItemIndex(index, item, latestProps.items)
+      if (itemIndex < 0) {
+        throw new Error('Pass either item or item index in getItemProps!')
+      }
+      const itemProps = {
+        role: 'option',
+        'aria-selected': `${itemIndex === latestState.highlightedIndex}`,
+        id: elementIdsRef.current.getItemId(itemIndex),
+        [refKey]: handleRefs(ref, itemNode => {
+          if (itemNode) {
+            itemRefs.current[
+              elementIdsRef.current.getItemId(itemIndex)
+            ] = itemNode
+          }
+        }),
+        ...rest,
+      }
+
+      if (!rest.disabled) {
+        itemProps.onMouseMove = callAllEventHandlers(
+          onMouseMove,
+          itemHandleMouseMove,
+        )
+        itemProps.onClick = callAllEventHandlers(onClick, itemHandleClick)
+      }
+
+      return itemProps
+    },
+    [dispatch, latest],
+  )
 
   return {
     // prop getters.

--- a/src/hooks/useSelect/testUtils.js
+++ b/src/hooks/useSelect/testUtils.js
@@ -7,7 +7,7 @@ import {items} from '../testUtils'
 import useSelect from '.'
 
 jest.mock('../../utils', () => {
-  const utils = require.requireActual('../../utils')
+  const utils = jest.requireActual('../../utils')
 
   return {
     ...utils,


### PR DESCRIPTION
**What**:

This PR memoizes all callbacks returned from downshift so we can memoize function components and pass callbacks in dependency arrays.

**Why**: Closes #1050

**How**:

This was a bit tricky, but basically the way we made this work properly to avoid the issues brought up in #1050 is by making a `latest` ref which contains the latest version of `props` and `state` and then we could reference that in our memoized callbacks without having memoization broken whenever those values changed because our callbacks all only care about the latest values anyway (this is the way the class-based downshift works as well).

Had to memoize the `dispatch` function as well. Minimal impact there.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
