### PR TITLE
chore(hooks): add controlled props and getter props warnings

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 137552,
-    "minified": 62918,
-    "gzipped": 13275
+    "bundled": 146382,
+    "minified": 66785,
+    "gzipped": 14090
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 136289,
-    "minified": 61899,
-    "gzipped": 13179
+    "bundled": 145166,
+    "minified": 65813,
+    "gzipped": 14000
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 147655,
-    "minified": 46960,
-    "gzipped": 12608
+    "bundled": 155865,
+    "minified": 50004,
+    "gzipped": 13246
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 151848,
-    "minified": 48265,
-    "gzipped": 13163
+    "bundled": 160011,
+    "minified": 51305,
+    "gzipped": 13791
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 157809,
-    "minified": 55316,
-    "gzipped": 13940
+    "bundled": 166822,
+    "minified": 58709,
+    "gzipped": 14735
   },
   "dist/downshift.umd.js": {
-    "bundled": 187392,
-    "minified": 64241,
-    "gzipped": 16575
+    "bundled": 196358,
+    "minified": 67628,
+    "gzipped": 17328
   },
   "dist/downshift.esm.js": {
-    "bundled": 136928,
-    "minified": 62371,
-    "gzipped": 13197,
+    "bundled": 145485,
+    "minified": 65964,
+    "gzipped": 14015,
     "treeshaked": {
       "rollup": {
         "code": 2293,
@@ -44,9 +44,9 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 135616,
-    "minified": 61303,
-    "gzipped": 13095,
+    "bundled": 144173,
+    "minified": 64896,
+    "gzipped": 13920,
     "treeshaked": {
       "rollup": {
         "code": 2294,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,38 +1,38 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 146382,
-    "minified": 66785,
-    "gzipped": 14090
+    "bundled": 146603,
+    "minified": 66554,
+    "gzipped": 14075
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 145166,
-    "minified": 65813,
-    "gzipped": 14000
+    "bundled": 145388,
+    "minified": 65583,
+    "gzipped": 13976
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 155865,
-    "minified": 50004,
-    "gzipped": 13246
+    "bundled": 156099,
+    "minified": 49636,
+    "gzipped": 13213
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 160011,
-    "minified": 51305,
-    "gzipped": 13791
+    "bundled": 160244,
+    "minified": 50937,
+    "gzipped": 13751
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 166822,
-    "minified": 58709,
-    "gzipped": 14735
+    "bundled": 167056,
+    "minified": 58341,
+    "gzipped": 14702
   },
   "dist/downshift.umd.js": {
-    "bundled": 196358,
-    "minified": 67628,
-    "gzipped": 17328
+    "bundled": 196591,
+    "minified": 67260,
+    "gzipped": 17288
   },
   "dist/downshift.esm.js": {
-    "bundled": 145485,
-    "minified": 65964,
-    "gzipped": 14015,
+    "bundled": 145700,
+    "minified": 65727,
+    "gzipped": 13989,
     "treeshaked": {
       "rollup": {
         "code": 2293,
@@ -44,9 +44,9 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 144173,
-    "minified": 64896,
-    "gzipped": 13920,
+    "bundled": 144388,
+    "minified": 64659,
+    "gzipped": 13896,
     "treeshaked": {
       "rollup": {
         "code": 2294,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,37 +1,37 @@
 {
   "dist/downshift.cjs.js": {
-    "bundled": 146603,
-    "minified": 66554,
-    "gzipped": 14075
+    "bundled": 146013,
+    "minified": 66479,
+    "gzipped": 14087
   },
   "preact/dist/downshift.cjs.js": {
-    "bundled": 145388,
-    "minified": 65583,
-    "gzipped": 13976
+    "bundled": 144797,
+    "minified": 65507,
+    "gzipped": 13989
   },
   "preact/dist/downshift.umd.min.js": {
-    "bundled": 156099,
-    "minified": 49636,
-    "gzipped": 13213
+    "bundled": 154994,
+    "minified": 49477,
+    "gzipped": 13200
   },
   "dist/downshift.umd.min.js": {
-    "bundled": 160244,
-    "minified": 50937,
-    "gzipped": 13751
+    "bundled": 159140,
+    "minified": 50778,
+    "gzipped": 13741
   },
   "preact/dist/downshift.umd.js": {
-    "bundled": 167056,
-    "minified": 58341,
-    "gzipped": 14702
+    "bundled": 166310,
+    "minified": 58326,
+    "gzipped": 14735
   },
   "dist/downshift.umd.js": {
-    "bundled": 196591,
-    "minified": 67260,
-    "gzipped": 17288
+    "bundled": 195846,
+    "minified": 67245,
+    "gzipped": 17327
   },
   "dist/downshift.esm.js": {
-    "bundled": 145700,
-    "minified": 65727,
+    "bundled": 145116,
+    "minified": 65658,
     "gzipped": 13989,
     "treeshaked": {
       "rollup": {
@@ -44,8 +44,8 @@
     }
   },
   "preact/dist/downshift.esm.js": {
-    "bundled": 144388,
-    "minified": 64659,
+    "bundled": 143804,
+    "minified": 64590,
     "gzipped": 13896,
     "treeshaked": {
       "rollup": {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -27,6 +27,7 @@ import {
   getNextNonDisabledIndex,
   getState,
   isControlledProp,
+  validateControlledUnchanged
 } from './utils'
 
 class Downshift extends Component {
@@ -1129,7 +1130,7 @@ class Downshift extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (process.env.NODE_ENV !== 'production') {
-      validateControlledUnchanged(prevProps, this.props)
+      validateControlledUnchanged(this.state, prevProps, this.props)
       /* istanbul ignore if (react-native) */
       if (
         !isReactNative &&
@@ -1254,29 +1255,4 @@ function validateGetRootPropsCalledCorrectly(element, {refKey}) {
       `downshift: You must apply the ref prop "${refKey}" from getRootProps onto your root element.`,
     )
   }
-}
-
-function validateControlledUnchanged(prevProps, nextProps) {
-  const warningDescription = `This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props`
-  ;['selectedItem', 'isOpen', 'inputValue', 'highlightedIndex'].forEach(
-    propKey => {
-      if (
-        prevProps[propKey] !== undefined &&
-        nextProps[propKey] === undefined
-      ) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `downshift: A component has changed the controlled prop "${propKey}" to be uncontrolled. ${warningDescription}`,
-        )
-      } else if (
-        prevProps[propKey] === undefined &&
-        nextProps[propKey] !== undefined
-      ) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `downshift: A component has changed the uncontrolled prop "${propKey}" to be controlled. ${warningDescription}`,
-        )
-      }
-    },
-  )
 }

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -643,6 +643,12 @@ Optional properties:
   available, then `aria-labelledby` will not be provided and screen readers can
   use your `aria-label` instead.
 
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getMenuProps`. **Please use it with extreme care and only if you are absolutely
+sure that the ref is correctly forwarded otherwise `useCombobox` will unexpectedly
+fail.**
+
 ```jsx
 const {getMenuProps} = useCombobox({items})
 const ui = (
@@ -768,6 +774,12 @@ Optional properties:
   However, if you are just rendering a primitive component like `<div>`, there
   is no need to specify this property. It defaults to `ref`.
 
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getInput`. **Please use it with extreme care and only if you are absolutely
+sure that the ref is correctly forwarded otherwise `useCombobox` will unexpectedly
+fail.**
+
 #### `getComboboxProps`
 
 This method should be applied to the `input` wrapper element. It has similar
@@ -779,6 +791,12 @@ contain the `input` and the `toggleButton` and it should be on the same level
 with the `menu`.
 
 There are no required properties for this method.
+
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getComboboxProps`. **Please use it with extreme care and only if you are absolutely
+sure that the ref is correctly forwarded otherwise `useCombobox` will unexpectedly
+fail.**
 
 ### actions
 

--- a/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
@@ -1,12 +1,10 @@
-import {cleanup} from '@testing-library/react'
-import {act} from '@testing-library/react-hooks'
+import {act, renderHook} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'
 import {renderUseCombobox} from '../testUtils'
-import {defaultIds} from '../../testUtils'
+import {defaultIds, items} from '../../testUtils'
+import useCombobox from '..'
 
 describe('getComboboxProps', () => {
-  afterEach(cleanup)
-
   describe('hook props', () => {
     test("assign 'combobox' to role", () => {
       const {result} = renderUseCombobox()
@@ -70,6 +68,88 @@ describe('getComboboxProps', () => {
         'foo',
         'bar',
       )
+    })
+  })
+
+  describe('non production errors', () => {
+    test('will be displayed if getComboboxProps is not called', () => {
+      renderHook(() => {
+        const {getInputProps, getMenuProps} = useCombobox({items})
+        getInputProps({}, {suppressRefError: true})
+        getMenuProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: You forgot to call the getComboboxProps getter function on your component / element."`,
+      )
+    })
+
+    test('will be displayed if element ref is not set and suppressRefError is false', () => {
+      renderHook(() => {
+        const {getInputProps, getMenuProps, getComboboxProps} = useCombobox({
+          items,
+        })
+
+        getInputProps({}, {suppressRefError: true})
+        getMenuProps({}, {suppressRefError: true})
+        getComboboxProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: The ref prop \\"ref\\" from getComboboxProps was not applied correctly on your menu element."`,
+      )
+    })
+
+    test('will not be displayed if element ref is not set and suppressRefError is true', () => {
+      renderHook(() => {
+        const {getInputProps, getMenuProps, getComboboxProps} = useCombobox({
+          items,
+        })
+
+        getInputProps({}, {suppressRefError: true})
+        getMenuProps({}, {suppressRefError: true})
+        getComboboxProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
+    test('will not be displayed if getComboboxProps is not called but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        const {getInputProps, getMenuProps} = useCombobox({
+          items,
+        })
+
+        getInputProps({}, {suppressRefError: true})
+        getMenuProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
+    })
+
+    test('will not be displayed if element ref is not set but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        const {getInputProps, getMenuProps, getComboboxProps} = useCombobox({
+          items,
+        })
+
+        getInputProps({}, {suppressRefError: true})
+        getMenuProps({}, {suppressRefError: true})
+        getComboboxProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
     })
   })
 })

--- a/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
@@ -134,6 +134,28 @@ describe('getComboboxProps', () => {
       process.env.NODE_ENV = originalEnv
     })
 
+    test('will not be displayed if called with a correct ref', () => {
+      const refFn = jest.fn()
+      const comboboxNode = {}
+
+      renderHook(() => {
+        const {getInputProps, getMenuProps, getComboboxProps} = useCombobox({
+          items,
+        })
+
+        getMenuProps({}, {suppressRefError: true})
+        getInputProps({}, {suppressRefError: true})
+
+        const {ref} = getComboboxProps({
+          ref: refFn,
+        })
+        ref(comboboxNode)
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
     test('will not be displayed if element ref is not set but environment is production', () => {
       const originalEnv = process.env.NODE_ENV
       process.env.NODE_ENV = 'production'

--- a/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
@@ -98,7 +98,7 @@ describe('getComboboxProps', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"downshift: The ref prop \\"ref\\" from getComboboxProps was not applied correctly on your menu element."`,
+        `"downshift: The ref prop \\"ref\\" from getComboboxProps was not applied correctly on your element."`,
       )
     })
 

--- a/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getComboboxProps.test.js
@@ -102,6 +102,7 @@ describe('getComboboxProps', () => {
       )
     })
 
+    // this test will cover also the equivalent getInputProps and getMenuProps cases.
     test('will not be displayed if element ref is not set and suppressRefError is true', () => {
       renderHook(() => {
         const {getInputProps, getMenuProps, getComboboxProps} = useCombobox({

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -928,6 +928,28 @@ describe('getInputProps', () => {
       )
     })
 
+    test('will not be displayed if called with a correct ref', () => {
+      const refFn = jest.fn()
+      const inputNode = {}
+
+      renderHook(() => {
+        const {getInputProps, getMenuProps, getComboboxProps} = useCombobox({
+          items,
+        })
+
+        getMenuProps({}, {suppressRefError: true})
+        getComboboxProps({}, {suppressRefError: true})
+
+        const {ref} = getInputProps({
+          ref: refFn,
+        })
+        ref(inputNode)
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
     test('will not be displayed if getInputProps is not called but environment is production', () => {
       const originalEnv = process.env.NODE_ENV
       process.env.NODE_ENV = 'production'

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -924,7 +924,7 @@ describe('getInputProps', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"downshift: The ref prop \\"ref\\" from getInputProps was not applied correctly on your menu element."`,
+        `"downshift: The ref prop \\"ref\\" from getInputProps was not applied correctly on your element."`,
       )
     })
 

--- a/src/hooks/useCombobox/__tests__/getMenuProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getMenuProps.test.js
@@ -143,7 +143,7 @@ describe('getMenuProps', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"downshift: The ref prop \\"ref\\" from getMenuProps was not applied correctly on your menu element."`,
+        `"downshift: The ref prop \\"ref\\" from getMenuProps was not applied correctly on your element."`,
       )
     })
 

--- a/src/hooks/useCombobox/__tests__/getMenuProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getMenuProps.test.js
@@ -147,6 +147,28 @@ describe('getMenuProps', () => {
       )
     })
 
+    test('will not be displayed if called with a correct ref', () => {
+      const refFn = jest.fn()
+      const menuNode = {}
+
+      renderHook(() => {
+        const {getInputProps, getMenuProps, getComboboxProps} = useCombobox({
+          items,
+        })
+
+        getInputProps({}, {suppressRefError: true})
+        getComboboxProps({}, {suppressRefError: true})
+
+        const {ref} = getMenuProps({
+          ref: refFn,
+        })
+        ref(menuNode)
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
     test('will not be displayed if getMenuProps is not called but environment is production', () => {
       const originalEnv = process.env.NODE_ENV
       process.env.NODE_ENV = 'production'

--- a/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
@@ -1,12 +1,9 @@
 /* eslint-disable jest/no-disabled-tests */
-import {cleanup} from '@testing-library/react'
 import {act} from '@testing-library/react-hooks'
 import {renderCombobox, renderUseCombobox} from '../testUtils'
 import {items, defaultIds} from '../../testUtils'
 
 describe('getToggleButtonProps', () => {
-  afterEach(cleanup)
-
   describe('hook props', () => {
     test('assign default value to id', () => {
       const {result} = renderUseCombobox()

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -1,5 +1,6 @@
+/* eslint-disable no-console */
 import {renderHook, act as hooksAct} from '@testing-library/react-hooks'
-import {cleanup, act} from '@testing-library/react'
+import {act} from '@testing-library/react'
 import {renderCombobox, renderUseCombobox} from '../testUtils'
 import * as stateChangeTypes from '../stateChangeTypes'
 import {
@@ -13,13 +14,14 @@ jest.useFakeTimers()
 
 describe('props', () => {
   beforeEach(jest.runAllTimers)
-  afterEach(cleanup)
 
   test('if falsy then prop types error is thrown', () => {
     global.console.error = jest.fn()
     renderHook(() => useCombobox())
 
-    expect(global.console.error).toBeCalledWith(expect.any(String))
+    expect(global.console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"Warning: Failed items type: The items \`items\` is marked as required in \`useCombobox\`, but its value is \`undefined\`."`,
+    )
     global.console.error.mockRestore()
   })
 
@@ -1217,5 +1219,29 @@ describe('props', () => {
 
       expect(result.current.isOpen).toEqual(true)
     })
+  })
+
+  it('that are controlled should not become uncontrolled', () => {
+    global.console.error = jest.fn()
+    const {rerender} = renderCombobox()
+
+    rerender({selectedItem: 'controlled'})
+
+    expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"downshift: A component has changed the uncontrolled prop \\"selectedItem\\" to be controlled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
+    )
+    global.console.error.mockRestore()
+  })
+
+  it('that are uncontrolled should not become controlled', () => {
+    global.console.error = jest.fn()
+    const {rerender} = renderCombobox({inputValue: 'controlled value'})
+
+    rerender({})
+
+    expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"downshift: A component has changed the controlled prop \\"inputValue\\" to be uncontrolled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
+    )
+    global.console.error.mockRestore()
   })
 })

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -1218,7 +1218,7 @@ describe('props', () => {
     })
   })
 
-  test('that are controlled should not become uncontrolled', () => {
+  test('that are uncontrolled should not become controlled', () => {
     const {rerender} = renderCombobox()
 
     rerender({selectedItem: 'controlled'})
@@ -1229,7 +1229,7 @@ describe('props', () => {
     )
   })
 
-  test('that are uncontrolled should not become controlled', () => {
+  test('that are controlled should not become uncontrolled', () => {
     const {rerender} = renderCombobox({inputValue: 'controlled value'})
 
     rerender({})

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {renderHook, act as hooksAct} from '@testing-library/react-hooks'
 import {act} from '@testing-library/react'
 import {renderCombobox, renderUseCombobox} from '../testUtils'
@@ -16,13 +15,11 @@ describe('props', () => {
   beforeEach(jest.runAllTimers)
 
   test('if falsy then prop types error is thrown', () => {
-    global.console.error = jest.fn()
     renderHook(() => useCombobox())
 
     expect(global.console.error.mock.calls[0][0]).toMatchInlineSnapshot(
       `"Warning: Failed items type: The items \`items\` is marked as required in \`useCombobox\`, but its value is \`undefined\`."`,
     )
-    global.console.error.mockRestore()
   })
 
   describe('id', () => {
@@ -1221,27 +1218,51 @@ describe('props', () => {
     })
   })
 
-  it('that are controlled should not become uncontrolled', () => {
-    global.console.error = jest.fn()
+  test('that are controlled should not become uncontrolled', () => {
     const {rerender} = renderCombobox()
 
     rerender({selectedItem: 'controlled'})
 
+    // eslint-disable-next-line no-console
     expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
       `"downshift: A component has changed the uncontrolled prop \\"selectedItem\\" to be controlled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
     )
-    global.console.error.mockRestore()
   })
 
-  it('that are uncontrolled should not become controlled', () => {
-    global.console.error = jest.fn()
+  test('that are uncontrolled should not become controlled', () => {
     const {rerender} = renderCombobox({inputValue: 'controlled value'})
 
     rerender({})
 
+    // eslint-disable-next-line no-console
     expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
       `"downshift: A component has changed the controlled prop \\"inputValue\\" to be uncontrolled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
     )
-    global.console.error.mockRestore()
+  })
+
+  test('should not throw the controlled error if on production', () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    const {rerender} = renderCombobox({inputValue: 'controlled value'})
+
+    rerender({})
+
+    /* eslint-disable no-console */
+    expect(console.error).not.toHaveBeenCalled()
+    process.env.NODE_ENV = originalEnv
+  })
+
+  test('should not throw the uncontrolled error if on production', () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    const {rerender} = renderCombobox()
+
+    rerender({inputValue: 'controlled value'})
+
+    /* eslint-disable no-console */
+    expect(console.error).not.toHaveBeenCalled()
+    process.env.NODE_ENV = originalEnv
   })
 })

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -14,7 +14,6 @@ import {
   useMouseAndTouchTracker,
   useGetterPropsCalledChecker,
   useLatestRef,
-  setGetterPropCallInfo,
 } from '../utils'
 import {
   getInitialState,
@@ -79,11 +78,6 @@ function useCombobox(userProps = {}) {
   // used for checking when props are moving from controlled to uncontrolled.
   const prevPropsRef = useRef(props)
   // used to store information about getter props being called on render.
-  const getterPropsCalledRef = useRef({
-    getInputProps: {},
-    getComboboxProps: {},
-    getMenuProps: {},
-  })
   // utility callback to get item element.
   const latest = useLatestRef({state, props})
 
@@ -195,7 +189,11 @@ function useCombobox(userProps = {}) {
       })
     },
   )
-  useGetterPropsCalledChecker(getterPropsCalledRef)
+  const setGetterPropCallInfo = useGetterPropsCalledChecker(
+    'getInputProps',
+    'getComboboxProps',
+    'getMenuProps',
+  )
   // Make initial ref false.
   useEffect(() => {
     isInitialMountRef.current = false
@@ -272,13 +270,7 @@ function useCombobox(userProps = {}) {
       {onMouseLeave, refKey = 'ref', ref, ...rest} = {},
       {suppressRefError = false} = {},
     ) => {
-      setGetterPropCallInfo(
-        'getMenuProps',
-        getterPropsCalledRef,
-        suppressRefError,
-        refKey,
-        menuRef,
-      )
+      setGetterPropCallInfo('getMenuProps', suppressRefError, refKey, menuRef)
       return {
         [refKey]: handleRefs(ref, menuNode => {
           menuRef.current = menuNode
@@ -294,7 +286,7 @@ function useCombobox(userProps = {}) {
         ...rest,
       }
     },
-    [dispatch],
+    [dispatch, setGetterPropCallInfo],
   )
 
   const getItemProps = useCallback(
@@ -408,13 +400,7 @@ function useCombobox(userProps = {}) {
       } = {},
       {suppressRefError = false} = {},
     ) => {
-      setGetterPropCallInfo(
-        'getInputProps',
-        getterPropsCalledRef,
-        suppressRefError,
-        refKey,
-        inputRef,
-      )
+      setGetterPropCallInfo('getInputProps', suppressRefError, refKey, inputRef)
 
       const latestState = latest.current.state
       const inputHandleKeyDown = event => {
@@ -494,13 +480,18 @@ function useCombobox(userProps = {}) {
         ...rest,
       }
     },
-    [dispatch, inputKeyDownHandlers, latest, mouseAndTouchTrackersRef],
+    [
+      dispatch,
+      inputKeyDownHandlers,
+      latest,
+      mouseAndTouchTrackersRef,
+      setGetterPropCallInfo,
+    ],
   )
   const getComboboxProps = useCallback(
     ({refKey = 'ref', ref, ...rest} = {}, {suppressRefError = false} = {}) => {
       setGetterPropCallInfo(
         'getComboboxProps',
-        getterPropsCalledRef,
         suppressRefError,
         refKey,
         comboboxRef,
@@ -517,7 +508,7 @@ function useCombobox(userProps = {}) {
         ...rest,
       }
     },
-    [latest],
+    [latest, setGetterPropCallInfo],
   )
 
   // returns

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -47,30 +47,31 @@ function useCombobox(userProps = {}) {
   } = props
   // Initial state depending on controlled props.
   const initialState = getInitialState(props)
-
-  // Reducer init.
   const [
     {isOpen, highlightedIndex, selectedItem, inputValue},
     dispatch,
   ] = useControlledReducer(downshiftUseComboboxReducer, initialState, props)
 
-  /* Refs */
+  // Element refs.
   const menuRef = useRef(null)
   const itemRefs = useRef()
   const inputRef = useRef(null)
   const toggleButtonRef = useRef(null)
   const comboboxRef = useRef(null)
   itemRefs.current = {}
+  // used not to scroll on highlight by mouse.
   const shouldScroll = useRef(true)
   const isInitialMount = useRef(true)
+  // prevent id re-generation between renders.
   const elementIdsRef = useRef(getElementIds(props))
+  // used to keep track of how many items we had on previous cycle.
   const previousResultCountRef = useRef()
-
+  // utility callback to get item element.
   const getItemNodeFromIndex = index =>
     itemRefs.current[elementIdsRef.current.getItemId(index)]
 
-  /* Effects */
-  /* Sets a11y status message on changes in state. */
+  // Effects.
+  // Sets a11y status message on changes in state.
   useEffect(() => {
     if (isInitialMount.current) {
       return
@@ -94,7 +95,7 @@ function useCombobox(userProps = {}) {
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, highlightedIndex, selectedItem, inputValue])
-  /* Sets a11y status message on changes in selectedItem. */
+  // Sets a11y status message on changes in selectedItem.
   useEffect(() => {
     if (isInitialMount.current) {
       return
@@ -118,7 +119,7 @@ function useCombobox(userProps = {}) {
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedItem])
-  /* Scroll on highlighted item if change comes from keyboard. */
+  // Scroll on highlighted item if change comes from keyboard.
   useEffect(() => {
     if (
       highlightedIndex < 0 ||
@@ -135,7 +136,7 @@ function useCombobox(userProps = {}) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [highlightedIndex])
-  /* Controls the focus on the menu or the toggle button. */
+  // Controls the focus on the menu or the toggle button.
   useEffect(() => {
     // Don't focus menu on first render.
     if (isInitialMount.current) {
@@ -158,7 +159,7 @@ function useCombobox(userProps = {}) {
   useEffect(() => {
     isInitialMount.current = false
   }, [])
-  /* Add mouse/touch events to document. */
+  // Add mouse/touch events to document.
   const mouseAndTouchTrackersRef = useMouseAndTouchTracker(
     isOpen,
     [comboboxRef, menuRef, toggleButtonRef],
@@ -169,7 +170,7 @@ function useCombobox(userProps = {}) {
       })
     },
   )
-  /* Event handler functions */
+  // Event handler functions.
   const inputKeyDownHandlers = {
     ArrowDown(event) {
       event.preventDefault()

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -14,6 +14,7 @@ import {
   useMouseAndTouchTracker,
   useGetterPropsCalledChecker,
   useLatestRef,
+  setGetterPropCallInfo,
 } from '../utils'
 import {
   getInitialState,
@@ -271,11 +272,13 @@ function useCombobox(userProps = {}) {
       {onMouseLeave, refKey = 'ref', ref, ...rest} = {},
       {suppressRefError = false} = {},
     ) => {
-      getterPropsCalledRef.current.getMenuProps.called = true
-      getterPropsCalledRef.current.getMenuProps.suppressRefError = suppressRefError
-      getterPropsCalledRef.current.getMenuProps.refKey = refKey
-      getterPropsCalledRef.current.getMenuProps.elementRef = menuRef
-
+      setGetterPropCallInfo(
+        'getMenuProps',
+        getterPropsCalledRef,
+        suppressRefError,
+        refKey,
+        menuRef,
+      )
       return {
         [refKey]: handleRefs(ref, menuNode => {
           menuRef.current = menuNode
@@ -405,10 +408,13 @@ function useCombobox(userProps = {}) {
       } = {},
       {suppressRefError = false} = {},
     ) => {
-      getterPropsCalledRef.current.getInputProps.called = true
-      getterPropsCalledRef.current.getInputProps.suppressRefError = suppressRefError
-      getterPropsCalledRef.current.getInputProps.refKey = refKey
-      getterPropsCalledRef.current.getInputProps.elementRef = inputRef
+      setGetterPropCallInfo(
+        'getInputProps',
+        getterPropsCalledRef,
+        suppressRefError,
+        refKey,
+        inputRef,
+      )
 
       const latestState = latest.current.state
       const inputHandleKeyDown = event => {
@@ -492,10 +498,14 @@ function useCombobox(userProps = {}) {
   )
   const getComboboxProps = useCallback(
     ({refKey = 'ref', ref, ...rest} = {}, {suppressRefError = false} = {}) => {
-      getterPropsCalledRef.current.getComboboxProps.called = true
-      getterPropsCalledRef.current.getComboboxProps.suppressRefError = suppressRefError
-      getterPropsCalledRef.current.getComboboxProps.refKey = refKey
-      getterPropsCalledRef.current.getComboboxProps.elementRef = comboboxRef
+      setGetterPropCallInfo(
+        'getComboboxProps',
+        getterPropsCalledRef,
+        suppressRefError,
+        refKey,
+        comboboxRef,
+      )
+
       return {
         [refKey]: handleRefs(ref, comboboxNode => {
           comboboxRef.current = comboboxNode

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -70,7 +70,7 @@ function useCombobox(userProps = {}) {
   const comboboxRef = useRef(null)
   itemRefs.current = {}
   // used not to scroll on highlight by mouse.
-  const shouldScroll = useRef(true)
+  const shouldScrollRef = useRef(true)
   const isInitialMountRef = useRef(true)
   // prevent id re-generation between renders.
   const elementIdsRef = useRef(getElementIds(props))
@@ -149,8 +149,8 @@ function useCombobox(userProps = {}) {
       return
     }
 
-    if (shouldScroll.current === false) {
-      shouldScroll.current = true
+    if (shouldScrollRef.current === false) {
+      shouldScrollRef.current = true
     } else {
       scrollIntoView(getItemNodeFromIndex(highlightedIndex), menuRef.current)
     }
@@ -325,7 +325,7 @@ function useCombobox(userProps = {}) {
         if (index === latestState.highlightedIndex) {
           return
         }
-        shouldScroll.current = false
+        shouldScrollRef.current = false
         dispatch({
           type: stateChangeTypes.ItemMouseMove,
           index,

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -195,6 +195,11 @@ function useCombobox(userProps = {}) {
     },
   )
   useGetterPropsCalledChecker(getterPropsCalledRef)
+  // Make initial ref false.
+  useEffect(() => {
+    isInitialMountRef.current = false
+  }, [])
+
   /* Event handler functions */
   const inputKeyDownHandlers = useMemo(
     () => ({

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -21,6 +21,7 @@ jest.mock('../../utils', () => {
   }
 })
 
+/* istanbul ignore next */
 beforeAll(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
 // eslint-disable-next-line no-console
 beforeEach(() => console.error.mockReset())

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -21,6 +21,12 @@ jest.mock('../../utils', () => {
   }
 })
 
+beforeAll(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
+// eslint-disable-next-line no-console
+beforeEach(() => console.error.mockReset())
+// eslint-disable-next-line no-console
+afterAll(() => console.error.mockRestore())
+
 const renderCombobox = (props, uiCallback) => {
   const renderSpy = jest.fn()
   const ui = <DropdownCombobox renderSpy={renderSpy} {...props} />

--- a/src/hooks/useMultipleSelection/README.md
+++ b/src/hooks/useMultipleSelection/README.md
@@ -617,6 +617,12 @@ Optional properties:
   primitive component like `<div>`, there is no need to specify this property.
   It defaults to `ref`.
 
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getDropdownProps`. **Please use it with extreme care and only if you are
+absolutely sure that the ref is correctly forwarded otherwise
+`useMultipleSelection` will unexpectedly fail.**
+
 ```javascript
 const {getDropdownProps} = useMultipleSelection()
 const {isOpen, ...rest} = useSelect({items})

--- a/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
@@ -264,7 +264,7 @@ describe('getDropdownProps', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"downshift: The ref prop \\"ref\\" from getDropdownProps was not applied correctly on your menu element."`,
+        `"downshift: The ref prop \\"ref\\" from getDropdownProps was not applied correctly on your element."`,
       )
     })
 

--- a/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
@@ -268,7 +268,23 @@ describe('getDropdownProps', () => {
       )
     })
 
-    test('will not be displayed if getMenuProps is not called but environment is production', () => {
+    test('will not be displayed if called with a correct ref', () => {
+      const refFn = jest.fn()
+      const dropdownNode = {}
+
+      renderHook(() => {
+        const {getDropdownProps} = useMultipleSelection()
+        const {ref} = getDropdownProps({
+          ref: refFn,
+        })
+        ref(dropdownNode)
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
+    test('will not be displayed if getDropdownProps is not called but environment is production', () => {
       const originalEnv = process.env.NODE_ENV
       process.env.NODE_ENV = 'production'
       renderHook(() => {

--- a/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
@@ -268,6 +268,17 @@ describe('getDropdownProps', () => {
       )
     })
 
+    test('will not be displayed if element ref is not set but suppressRefError is true', () => {
+      renderHook(() => {
+        const {getDropdownProps} = useMultipleSelection()
+
+        getDropdownProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
     test('will not be displayed if called with a correct ref', () => {
       const refFn = jest.fn()
       const dropdownNode = {}

--- a/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/getDropdownProps.test.js
@@ -1,12 +1,14 @@
-import {act} from '@testing-library/react-hooks'
-
+import {act, renderHook} from '@testing-library/react-hooks'
 import {renderMultipleCombobox, renderUseMultipleSelection} from '../testUtils'
 import {items} from '../../testUtils'
+import useMultipleSelection from '..'
 
 describe('getDropdownProps', () => {
   test('returns no keydown events if preventKeyAction is true', () => {
     const {result} = renderUseMultipleSelection()
-    const dropdownProps = result.current.getDropdownProps({preventKeyAction: true})
+    const dropdownProps = result.current.getDropdownProps({
+      preventKeyAction: true,
+    })
 
     expect(dropdownProps.onKeyDown).toBeUndefined()
   })
@@ -15,9 +17,10 @@ describe('getDropdownProps', () => {
     test('are passed down', () => {
       const {result} = renderUseMultipleSelection()
 
-      expect(
-        result.current.getDropdownProps({foo: 'bar'}),
-      ).toHaveProperty('foo', 'bar')
+      expect(result.current.getDropdownProps({foo: 'bar'})).toHaveProperty(
+        'foo',
+        'bar',
+      )
     })
 
     test('custom ref passed by the user is used', () => {
@@ -237,6 +240,58 @@ describe('getDropdownProps', () => {
 
       expect(getSelectedItemAtIndex(1)).toHaveFocus()
       expect(getSelectedItemAtIndex(1)).toHaveAttribute('tabindex', '0')
+    })
+  })
+
+  describe('non production errors', () => {
+    test('will be displayed if getDropdownProps is not called', () => {
+      renderHook(() => {
+        useMultipleSelection()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: You forgot to call the getDropdownProps getter function on your component / element."`,
+      )
+    })
+
+    test('will be displayed if element ref is not set and suppressRefError is false', () => {
+      renderHook(() => {
+        const {getDropdownProps} = useMultipleSelection()
+
+        getDropdownProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: The ref prop \\"ref\\" from getDropdownProps was not applied correctly on your menu element."`,
+      )
+    })
+
+    test('will not be displayed if getMenuProps is not called but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        useMultipleSelection()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
+    })
+
+    test('will not be displayed if element ref is not set but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        const {getDropdownProps} = useMultipleSelection()
+
+        getDropdownProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
     })
   })
 })

--- a/src/hooks/useMultipleSelection/__tests__/props.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/props.test.js
@@ -740,7 +740,7 @@ describe('props', () => {
     expect(result.current.activeIndex).toEqual(4)
   })
 
-  test('that are controlled should not become uncontrolled', () => {
+  test('that are uncontrolled should not become controlled', () => {
     const {rerender} = renderMultipleCombobox()
 
     rerender({multipleSelectionProps: {activeIndex: 1}})
@@ -751,7 +751,7 @@ describe('props', () => {
     )
   })
 
-  test('that are uncontrolled should not become controlled', () => {
+  test('that are controlled should not become uncontrolled', () => {
     const {rerender} = renderMultipleCombobox({
       multipleSelectionProps: {selectedItems: [items[1]]},
     })

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -11,7 +11,6 @@ import {
   getItemIndex,
   useGetterPropsCalledChecker,
   useLatestRef,
-  setGetterPropCallInfo
 } from '../utils'
 import {
   getInitialState,
@@ -51,10 +50,6 @@ function useMultipleSelection(userProps = {}) {
   const previousSelectedItemsRef = useRef(selectedItems)
   const selectedItemRefs = useRef()
   selectedItemRefs.current = []
-  // used to store information about getter props being called on render.
-  const getterPropsCalledRef = useRef({
-    getDropdownProps: {},
-  })
   // used for checking when props are moving from controlled to uncontrolled.
   const prevPropsRef = useRef(props)
   const latest = useLatestRef({state, props})
@@ -107,7 +102,7 @@ function useMultipleSelection(userProps = {}) {
     validateControlledUnchanged(state, prevPropsRef.current, props)
     prevPropsRef.current = props
   }, [state, props])
-  useGetterPropsCalledChecker(getterPropsCalledRef)
+  const setGetterPropCallInfo = useGetterPropsCalledChecker('getDropdownProps')
   // Make initial ref false.
   useEffect(() => {
     isInitialMountRef.current = false
@@ -223,7 +218,6 @@ function useMultipleSelection(userProps = {}) {
     ) => {
       setGetterPropCallInfo(
         'getDropdownProps',
-        getterPropsCalledRef,
         suppressRefError,
         refKey,
         dropdownRef,
@@ -254,7 +248,7 @@ function useMultipleSelection(userProps = {}) {
         ...rest,
       }
     },
-    [dispatch, dropdownKeyDownHandlers],
+    [dispatch, dropdownKeyDownHandlers, setGetterPropCallInfo],
   )
 
   // returns

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -106,11 +106,11 @@ function useMultipleSelection(userProps = {}) {
     validateControlledUnchanged(state, prevPropsRef.current, props)
     prevPropsRef.current = props
   }, [state, props])
+  useGetterPropsCalledChecker(getterPropsCalledRef)
   // Make initial ref false.
   useEffect(() => {
     isInitialMountRef.current = false
   }, [])
-  useGetterPropsCalledChecker(getterPropsCalledRef)
 
   // Event handler functions.
   const selectedItemKeyDownHandlers = useMemo(

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -11,6 +11,7 @@ import {
   getItemIndex,
   useGetterPropsCalledChecker,
   useLatestRef,
+  setGetterPropCallInfo
 } from '../utils'
 import {
   getInitialState,
@@ -220,10 +221,13 @@ function useMultipleSelection(userProps = {}) {
       } = {},
       {suppressRefError = false} = {},
     ) => {
-      getterPropsCalledRef.current.getDropdownProps.called = true
-      getterPropsCalledRef.current.getDropdownProps.suppressRefError = suppressRefError
-      getterPropsCalledRef.current.getDropdownProps.refKey = refKey
-      getterPropsCalledRef.current.getDropdownProps.elementRef = dropdownRef
+      setGetterPropCallInfo(
+        'getDropdownProps',
+        getterPropsCalledRef,
+        suppressRefError,
+        refKey,
+        dropdownRef,
+      )
 
       const dropdownHandleKeyDown = event => {
         const key = normalizeArrowKey(event)

--- a/src/hooks/useMultipleSelection/testUtils.js
+++ b/src/hooks/useMultipleSelection/testUtils.js
@@ -16,6 +16,12 @@ jest.mock('../../utils', () => {
   }
 })
 
+beforeAll(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
+// eslint-disable-next-line no-console
+beforeEach(() => console.error.mockReset())
+// eslint-disable-next-line no-console
+afterAll(() => console.error.mockRestore())
+
 export const dataTestIds = {
   selectedItemPrefix: 'selected-item-id',
   selectedItem: index => `selected-item-id-${index}`,
@@ -23,7 +29,7 @@ export const dataTestIds = {
 }
 
 const DropdownMultipleCombobox = ({
-  multipleSelectionProps,
+  multipleSelectionProps = {},
   comboboxProps = {},
 }) => {
   const {

--- a/src/hooks/useMultipleSelection/testUtils.js
+++ b/src/hooks/useMultipleSelection/testUtils.js
@@ -16,6 +16,7 @@ jest.mock('../../utils', () => {
   }
 })
 
+/* istanbul ignore next */
 beforeAll(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
 // eslint-disable-next-line no-console
 beforeEach(() => console.error.mockReset())

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -580,6 +580,12 @@ Optional properties:
   available, then `aria-labelledby` will not be provided and screen readers can
   use your `aria-label` instead.
 
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getMenuProps`. **Please use it with extreme care and only if you are absolutely
+sure that the ref is correctly forwarded otherwise `useSelect` will unexpectedly
+fail.**
+
 ```jsx
 const {getMenuProps} = useSelect({items})
 const ui = (
@@ -674,6 +680,12 @@ Optional properties:
   `<button ref={props.innerRef} />`. However, if you are just rendering a
   primitive component like `<div>`, there is no need to specify this property.
   It defaults to `ref`.
+
+In some cases, you might want to completely bypass the `refKey` check. Then you
+can provide the object `{suppressRefError : true}` as the second argument to
+`getToggleButtonProps`. **Please use it with extreme care and only if you are
+absolutely sure that the ref is correctly forwarded otherwise `useSelect` will
+unexpectedly fail.**
 
 ```jsx
 const {getToggleButtonProps} = useSelect({items})

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -914,6 +914,27 @@ describe('getMenuProps', () => {
       )
     })
 
+    test('will not be displayed if called with a correct ref', () => {
+      const refFn = jest.fn()
+      const menuNode = {}
+
+      renderHook(() => {
+        const {getToggleButtonProps, getMenuProps} = useSelect({
+          items,
+        })
+
+        getToggleButtonProps({}, {suppressRefError: true})
+
+        const {ref} = getMenuProps({
+          ref: refFn,
+        })
+        ref(menuNode)
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
     test('will not be displayed if getMenuProps is not called but environment is production', () => {
       const originalEnv = process.env.NODE_ENV
       process.env.NODE_ENV = 'production'

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -910,7 +910,7 @@ describe('getMenuProps', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"downshift: The ref prop \\"ref\\" from getMenuProps was not applied correctly on your menu element."`,
+        `"downshift: The ref prop \\"ref\\" from getMenuProps was not applied correctly on your element."`,
       )
     })
 

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -914,6 +914,21 @@ describe('getMenuProps', () => {
       )
     })
 
+    // this test will cover also the equivalent getToggleButtonProps case.
+    test('will not be displayed if element ref is not set and suppressRefError is true', () => {
+      renderHook(() => {
+        const {getMenuProps, getToggleButtonProps} = useSelect({
+          items,
+        })
+
+        getToggleButtonProps({}, {suppressRefError: true})
+        getMenuProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
     test('will not be displayed if called with a correct ref', () => {
       const refFn = jest.fn()
       const menuNode = {}

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -1,10 +1,11 @@
 /* eslint-disable jest/no-disabled-tests */
 import * as React from 'react'
-import {act} from '@testing-library/react-hooks'
+import {act, renderHook} from '@testing-library/react-hooks'
 import {cleanup, act as reactAct, fireEvent} from '@testing-library/react'
 import {renderUseSelect, renderSelect} from '../testUtils'
 import {defaultIds, items} from '../../testUtils'
 import * as stateChangeTypes from '../stateChangeTypes'
+import useSelect from '..'
 
 jest.useFakeTimers()
 
@@ -881,6 +882,69 @@ describe('getMenuProps', () => {
           expect.objectContaining({type: stateChangeTypes.MenuBlur}),
         )
       })
+    })
+  })
+
+  describe('non production errors', () => {
+    test('will be displayed if getMenuProps is not called', () => {
+      renderHook(() => {
+        const {getToggleButtonProps} = useSelect({items})
+        getToggleButtonProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: You forgot to call the getMenuProps getter function on your component / element."`,
+      )
+    })
+
+    test('will be displayed if element ref is not set and suppressRefError is false', () => {
+      renderHook(() => {
+        const {getMenuProps, getToggleButtonProps} = useSelect({
+          items,
+        })
+
+        getToggleButtonProps({}, {suppressRefError: true})
+        getMenuProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: The ref prop \\"ref\\" from getMenuProps was not applied correctly on your menu element."`,
+      )
+    })
+
+    test('will not be displayed if getMenuProps is not called but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        const {getToggleButtonProps} = useSelect({
+          items,
+        })
+
+        getToggleButtonProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
+    })
+
+    test('will not be displayed if element ref is not set but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        const {getMenuProps, getToggleButtonProps} = useSelect({
+          items,
+        })
+
+        getToggleButtonProps({}, {suppressRefError: true})
+        getMenuProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
     })
   })
 })

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -665,6 +665,27 @@ describe('getToggleButtonProps', () => {
       )
     })
 
+    test('will not be displayed if called with a correct ref', () => {
+      const refFn = jest.fn()
+      const toggleButtonNode = {}
+
+      renderHook(() => {
+        const {getToggleButtonProps, getMenuProps} = useSelect({
+          items,
+        })
+
+        getMenuProps({}, {suppressRefError: true})
+
+        const {ref} = getToggleButtonProps({
+          ref: refFn,
+        })
+        ref(toggleButtonNode)
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
     test('will not be displayed if getMenuProps is not called but environment is production', () => {
       const originalEnv = process.env.NODE_ENV
       process.env.NODE_ENV = 'production'

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -1,15 +1,14 @@
 /* eslint-disable jest/no-disabled-tests */
-import {cleanup, act as reactAct} from '@testing-library/react'
-import {act as reactHooksAct} from '@testing-library/react-hooks'
+import {act as reactAct} from '@testing-library/react'
+import {act as reactHooksAct, renderHook} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'
 import {renderUseSelect, renderSelect} from '../testUtils'
 import {items, defaultIds} from '../../testUtils'
+import useSelect from '..'
 
 jest.useFakeTimers()
 
 describe('getToggleButtonProps', () => {
-  afterEach(cleanup)
-
   describe('hook props', () => {
     test('assign default value to aria-labelledby', () => {
       const {result} = renderUseSelect()
@@ -634,6 +633,69 @@ describe('getToggleButtonProps', () => {
         expect(toggleButton).not.toHaveAttribute('aria-activedescendant')
         expect(getItems()).toHaveLength(0)
       })
+    })
+  })
+
+  describe('non production errors', () => {
+    test('will be displayed if getMenuProps is not called', () => {
+      renderHook(() => {
+        const {getMenuProps} = useSelect({items})
+        getMenuProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: You forgot to call the getToggleButtonProps getter function on your component / element."`,
+      )
+    })
+
+    test('will be displayed if element ref is not set and suppressRefError is false', () => {
+      renderHook(() => {
+        const {getMenuProps, getToggleButtonProps} = useSelect({
+          items,
+        })
+
+        getMenuProps({}, {suppressRefError: true})
+        getToggleButtonProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"downshift: The ref prop \\"ref\\" from getToggleButtonProps was not applied correctly on your menu element."`,
+      )
+    })
+
+    test('will not be displayed if getMenuProps is not called but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        const {getMenuProps} = useSelect({
+          items,
+        })
+
+        getMenuProps({}, {suppressRefError: true})
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
+    })
+
+    test('will not be displayed if element ref is not set but environment is production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      renderHook(() => {
+        const {getMenuProps, getToggleButtonProps} = useSelect({
+          items,
+        })
+
+        getMenuProps({}, {suppressRefError: true})
+        getToggleButtonProps()
+      })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).not.toHaveBeenCalled()
+      process.env.NODE_ENV = originalEnv
     })
   })
 })

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -661,7 +661,7 @@ describe('getToggleButtonProps', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"downshift: The ref prop \\"ref\\" from getToggleButtonProps was not applied correctly on your menu element."`,
+        `"downshift: The ref prop \\"ref\\" from getToggleButtonProps was not applied correctly on your element."`,
       )
     })
 

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -17,14 +17,11 @@ describe('props', () => {
   afterEach(cleanup)
 
   test('if falsy then prop types error is thrown', () => {
-    global.console.error = jest.fn()
     renderHook(() => useSelect())
 
     expect(global.console.error.mock.calls[0][0]).toMatchInlineSnapshot(
       `"Warning: Failed items type: The items \`items\` is marked as required in \`useSelect\`, but its value is \`undefined\`."`,
     )
-
-    global.console.error.mockRestore()
   })
 
   describe('id', () => {
@@ -1272,7 +1269,6 @@ describe('props', () => {
   })
 
   it('that are controlled should not become uncontrolled', () => {
-    global.console.error = jest.fn()
     const {rerender} = renderSelect()
 
     rerender({isOpen: true})
@@ -1280,11 +1276,9 @@ describe('props', () => {
     expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
       `"downshift: A component has changed the uncontrolled prop \\"isOpen\\" to be controlled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
     )
-    global.console.error.mockRestore()
   })
 
   it('that are uncontrolled should not become controlled', () => {
-    global.console.error = jest.fn()
     const {rerender} = renderSelect({highlightedIndex: 3})
 
     rerender({})
@@ -1292,6 +1286,31 @@ describe('props', () => {
     expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
       `"downshift: A component has changed the controlled prop \\"highlightedIndex\\" to be uncontrolled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
     )
-    global.console.error.mockRestore()
+  })
+
+  test('should not throw the controlled error if on production', () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    const {rerender} = renderSelect({highlightedIndex: 3})
+
+    rerender({})
+
+    /* eslint-disable no-console */
+    expect(console.error).not.toHaveBeenCalled()
+    process.env.NODE_ENV = originalEnv
+  })
+
+  test('should not throw the uncontrolled error if on production', () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    const {rerender} = renderSelect()
+
+    rerender({highlightedIndex: 3})
+
+    /* eslint-disable no-console */
+    expect(console.error).not.toHaveBeenCalled()
+    process.env.NODE_ENV = originalEnv
   })
 })

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import {renderHook, act as hooksAct} from '@testing-library/react-hooks'
 import {cleanup, act} from '@testing-library/react'
 import {renderSelect, renderUseSelect} from '../testUtils'
@@ -19,7 +20,9 @@ describe('props', () => {
     global.console.error = jest.fn()
     renderHook(() => useSelect())
 
-    expect(global.console.error).toBeCalledWith(expect.any(String))
+    expect(global.console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"Warning: Failed items type: The items \`items\` is marked as required in \`useSelect\`, but its value is \`undefined\`."`,
+    )
 
     global.console.error.mockRestore()
   })
@@ -1266,5 +1269,29 @@ describe('props', () => {
 
       expect(result.current.isOpen).toEqual(true)
     })
+  })
+
+  it('that are controlled should not become uncontrolled', () => {
+    global.console.error = jest.fn()
+    const {rerender} = renderSelect()
+
+    rerender({isOpen: true})
+
+    expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"downshift: A component has changed the uncontrolled prop \\"isOpen\\" to be controlled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
+    )
+    global.console.error.mockRestore()
+  })
+
+  it('that are uncontrolled should not become controlled', () => {
+    global.console.error = jest.fn()
+    const {rerender} = renderSelect({highlightedIndex: 3})
+
+    rerender({})
+
+    expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"downshift: A component has changed the controlled prop \\"highlightedIndex\\" to be uncontrolled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props"`,
+    )
+    global.console.error.mockRestore()
   })
 })

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -1268,7 +1268,7 @@ describe('props', () => {
     })
   })
 
-  it('that are controlled should not become uncontrolled', () => {
+  it('that are uncontrolled should not become controlled', () => {
     const {rerender} = renderSelect()
 
     rerender({isOpen: true})
@@ -1278,7 +1278,7 @@ describe('props', () => {
     )
   })
 
-  it('that are uncontrolled should not become controlled', () => {
+  it('that are controlled should not become uncontrolled', () => {
     const {rerender} = renderSelect({highlightedIndex: 3})
 
     rerender({})

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -210,10 +210,6 @@ function useSelect(userProps = {}) {
 
     previousResultCountRef.current = items.length
   })
-  // Make initial ref false.
-  useEffect(() => {
-    isInitialMountRef.current = false
-  }, [])
   useEffect(() => {
     if (isInitialMountRef.current) {
       return
@@ -234,6 +230,10 @@ function useSelect(userProps = {}) {
     },
   )
   useGetterPropsCalledChecker(getterPropsCalledRef)
+  // Make initial ref false.
+  useEffect(() => {
+    isInitialMountRef.current = false
+  }, [])
 
   // Event handler functions.
   const toggleButtonKeyDownHandlers = useMemo(
@@ -440,7 +440,15 @@ function useSelect(userProps = {}) {
     [dispatch, latest, menuKeyDownHandlers, mouseAndTouchTrackersRef],
   )
   const getToggleButtonProps = useCallback(
-    ({onClick, onKeyDown, refKey = 'ref', ref, ...rest} = {}) => {
+    (
+      {onClick, onKeyDown, refKey = 'ref', ref, ...rest} = {},
+      {suppressRefError = false} = {},
+    ) => {
+      getterPropsCalledRef.current.getToggleButtonProps.called = true
+      getterPropsCalledRef.current.getToggleButtonProps.suppressRefError = suppressRefError
+      getterPropsCalledRef.current.getToggleButtonProps.refKey = refKey
+      getterPropsCalledRef.current.getToggleButtonProps.elementRef = toggleButtonRef
+
       const toggleButtonHandleClick = () => {
         dispatch({
           type: stateChangeTypes.ToggleButtonClick,

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -11,6 +11,7 @@ import {
   useMouseAndTouchTracker,
   useGetterPropsCalledChecker,
   useLatestRef,
+  setGetterPropCallInfo
 } from '../utils'
 import {
   callAllEventHandlers,
@@ -380,13 +381,15 @@ function useSelect(userProps = {}) {
       {onMouseLeave, refKey = 'ref', onKeyDown, onBlur, ref, ...rest} = {},
       {suppressRefError = false} = {},
     ) => {
-      getterPropsCalledRef.current.getMenuProps.called = true
-      getterPropsCalledRef.current.getMenuProps.suppressRefError = suppressRefError
-      getterPropsCalledRef.current.getMenuProps.refKey = refKey
-      getterPropsCalledRef.current.getMenuProps.elementRef = menuRef
+      setGetterPropCallInfo(
+        'getMenuProps',
+        getterPropsCalledRef,
+        suppressRefError,
+        refKey,
+        menuRef,
+      )
 
       const latestState = latest.current.state
-
       const menuHandleKeyDown = event => {
         const key = normalizeArrowKey(event)
         if (key && menuKeyDownHandlers[key]) {
@@ -444,10 +447,13 @@ function useSelect(userProps = {}) {
       {onClick, onKeyDown, refKey = 'ref', ref, ...rest} = {},
       {suppressRefError = false} = {},
     ) => {
-      getterPropsCalledRef.current.getToggleButtonProps.called = true
-      getterPropsCalledRef.current.getToggleButtonProps.suppressRefError = suppressRefError
-      getterPropsCalledRef.current.getToggleButtonProps.refKey = refKey
-      getterPropsCalledRef.current.getToggleButtonProps.elementRef = toggleButtonRef
+      setGetterPropCallInfo(
+        'getToggleButtonProps',
+        getterPropsCalledRef,
+        suppressRefError,
+        refKey,
+        toggleButtonRef,
+      )
 
       const toggleButtonHandleClick = () => {
         dispatch({

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -49,31 +49,34 @@ function useSelect(userProps = {}) {
   } = props
   // Initial state depending on controlled props.
   const initialState = getInitialState(props)
-
-  // Reducer init.
   const [
     {isOpen, highlightedIndex, selectedItem, inputValue},
     dispatch,
   ] = useControlledReducer(downshiftSelectReducer, initialState, props)
 
-  // Refs
+  // Element efs.
   const toggleButtonRef = useRef(null)
   const menuRef = useRef(null)
   const itemRefs = useRef()
   itemRefs.current = {}
-  const isInitialMountRef = useRef(true)
+  // used not to scroll when highlight by mouse.
   const shouldScrollRef = useRef(true)
+  // used not to trigger menu blur action in some scenarios.
   const shouldBlurRef = useRef(true)
+  // used to keep the inputValue clearTimeout object between renders.
   const clearTimeoutRef = useRef(null)
+  // prevent id re-generation between renders.
   const elementIdsRef = useRef(getElementIds(props))
+  // used to keep track of how many items we had on previous cycle.
   const previousResultCountRef = useRef()
+  const isInitialMountRef = useRef(true)
 
   // Some utils.
   const getItemNodeFromIndex = index =>
     itemRefs.current[elementIdsRef.current.getItemId(index)]
 
   // Effects.
-  /* Sets a11y status message on changes in state. */
+  // Sets a11y status message on changes in state.
   useEffect(() => {
     if (isInitialMountRef.current) {
       return
@@ -97,7 +100,7 @@ function useSelect(userProps = {}) {
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, highlightedIndex, selectedItem, inputValue])
-  /* Sets a11y status message on changes in selectedItem. */
+  // Sets a11y status message on changes in selectedItem.
   useEffect(() => {
     if (isInitialMountRef.current) {
       return
@@ -121,7 +124,7 @@ function useSelect(userProps = {}) {
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedItem])
-  /* Sets cleanup for the keysSoFar after 500ms. */
+  // Sets cleanup for the keysSoFar after 500ms.
   useEffect(() => {
     // init the clean function here as we need access to dispatch.
     if (isInitialMountRef.current) {
@@ -154,10 +157,10 @@ function useSelect(userProps = {}) {
       // istanbul ignore else
       if (menuRef.current) {
         menuRef.current.focus()
-        return
       }
+      return
     }
-    // Focus toggleButton on close, but on if was closed with (Shift+)Tab.
+    // Focus toggleButton on close, but not if it was closed with (Shift+)Tab.
     if (environment.document.activeElement === menuRef.current) {
       // istanbul ignore else
       if (toggleButtonRef.current) {
@@ -167,7 +170,7 @@ function useSelect(userProps = {}) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])
-  /* Scroll on highlighted item if change comes from keyboard. */
+  // Scroll on highlighted item if change comes from keyboard.
   useEffect(() => {
     if (
       highlightedIndex < 0 ||
@@ -190,11 +193,11 @@ function useSelect(userProps = {}) {
 
     previousResultCountRef.current = items.length
   })
-  /* Make initial ref false. */
+  // Make initial ref false.
   useEffect(() => {
     isInitialMountRef.current = false
   }, [])
-  /* Add mouse/touch events to document. */
+  // Add mouse/touch events to document.
   const mouseAndTouchTrackersRef = useMouseAndTouchTracker(
     isOpen,
     [menuRef, toggleButtonRef],
@@ -297,7 +300,7 @@ function useSelect(userProps = {}) {
     }
   }
   const menuHandleBlur = () => {
-    // if the blur was a result of selection, we don't trigger this action.
+    // if the blur was a result of selection, we don't trigger the blur action.
     if (shouldBlurRef.current === false) {
       shouldBlurRef.current = true
       return

--- a/src/hooks/useSelect/testUtils.js
+++ b/src/hooks/useSelect/testUtils.js
@@ -15,6 +15,7 @@ jest.mock('../../utils', () => {
   }
 })
 
+/* istanbul ignore next */
 beforeAll(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
 // eslint-disable-next-line no-console
 beforeEach(() => console.error.mockReset())

--- a/src/hooks/useSelect/testUtils.js
+++ b/src/hooks/useSelect/testUtils.js
@@ -15,6 +15,12 @@ jest.mock('../../utils', () => {
   }
 })
 
+beforeAll(() => jest.spyOn(console, 'error').mockImplementation(() => {}))
+// eslint-disable-next-line no-console
+beforeEach(() => console.error.mockReset())
+// eslint-disable-next-line no-console
+afterAll(() => console.error.mockRestore())
+
 const dataTestIds = {
   toggleButton: 'toggle-button-id',
   menu: 'menu-id',

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -375,6 +375,12 @@ export function useMouseAndTouchTracker(
   return mouseAndTouchTrackersRef
 }
 
+/**
+ * Custom hook that checks if getter props are called correctly.
+ * 
+ * @param  {...any} propKeys Getter prop names to be handled.
+ * @returns {Function} Setter function called inside getter props to set call information.
+ */
 export function useGetterPropsCalledChecker(...propKeys) {
   const getterPropsCalledRef = useRef(
     propKeys.reduce((acc, propKey) => {

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -359,3 +359,44 @@ export function useMouseAndTouchTracker(
 
   return mouseAndTouchTrackersRef
 }
+
+export function useGetterPropsCalledChecker(getterPropsCalledRef) {
+  const {current: getterPropsCalled} = getterPropsCalledRef
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      Object.keys(getterPropsCalledRef.current).forEach(propKey => {
+        const {
+          called,
+          suppressRefError,
+          refKey,
+          elementRef,
+        } = getterPropsCalled[propKey]
+
+        if (!called) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `downshift: You forgot to call the ${propKey} getter function on your component / element.`,
+          )
+          return
+        }
+        if ((!elementRef || !elementRef.current) && !suppressRefError) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `downshift: The ref prop "${refKey}" from ${propKey} was not applied correctly on your menu element.`,
+          )
+        }
+      })
+    }
+
+    return function cleanup() {
+
+      Object.keys(getterPropsCalled).forEach(propKey => {
+        getterPropsCalled[propKey].called = false
+        getterPropsCalled[propKey].refKey = undefined
+        getterPropsCalled[propKey].suppressRefError = undefined
+        getterPropsCalled[propKey].elementRef = undefined
+      })
+    }
+  })
+}

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -419,9 +419,9 @@ export function useGetterPropsCalledChecker(getterPropsCalledRef) {
  *
  * @param {string} propKey The getter prop name.
  * @param {Object} getterPropsCalledRef The ref container for the info.
- * @param {Object} elementRef The ref containing the element.
- * @param {string} refKey The ref key to get the element.
  * @param {boolean} suppressRefError Whether or not to suppress the ref error.
+ * @param {string} refKey The ref key to get the element.
+ * @param {Object} elementRef The ref containing the element.
  */
 export function setGetterPropCallInfo(
   propKey,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -405,7 +405,6 @@ export function useGetterPropsCalledChecker(getterPropsCalledRef) {
     }
 
     return function cleanup() {
-
       Object.keys(getterPropsCalled).forEach(propKey => {
         getterPropsCalled[propKey].called = false
         getterPropsCalled[propKey].refKey = undefined
@@ -414,4 +413,25 @@ export function useGetterPropsCalledChecker(getterPropsCalledRef) {
       })
     }
   })
+}
+
+/**
+ *
+ * @param {string} propKey The getter prop name.
+ * @param {Object} getterPropsCalledRef The ref container for the info.
+ * @param {Object} elementRef The ref containing the element.
+ * @param {string} refKey The ref key to get the element.
+ * @param {boolean} suppressRefError Whether or not to suppress the ref error.
+ */
+export function setGetterPropCallInfo(
+  propKey,
+  getterPropsCalledRef,
+  suppressRefError,
+  refKey,
+  elementRef,
+) {
+  getterPropsCalledRef.current[propKey].called = true
+  getterPropsCalledRef.current[propKey].suppressRefError = suppressRefError
+  getterPropsCalledRef.current[propKey].refKey = refKey
+  getterPropsCalledRef.current[propKey].elementRef = elementRef
 }

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -405,12 +405,14 @@ export function useGetterPropsCalledChecker(getterPropsCalledRef) {
     }
 
     return function cleanup() {
-      Object.keys(getterPropsCalled).forEach(propKey => {
-        getterPropsCalled[propKey].called = false
-        getterPropsCalled[propKey].refKey = undefined
-        getterPropsCalled[propKey].suppressRefError = undefined
-        getterPropsCalled[propKey].elementRef = undefined
-      })
+      if (process.env.NODE_ENV !== 'production') {
+        Object.keys(getterPropsCalled).forEach(propKey => {
+          getterPropsCalled[propKey].called = false
+          getterPropsCalled[propKey].refKey = undefined
+          getterPropsCalled[propKey].suppressRefError = undefined
+          getterPropsCalled[propKey].elementRef = undefined
+        })
+      }
     }
   })
 }
@@ -430,8 +432,10 @@ export function setGetterPropCallInfo(
   refKey,
   elementRef,
 ) {
-  getterPropsCalledRef.current[propKey].called = true
-  getterPropsCalledRef.current[propKey].suppressRefError = suppressRefError
-  getterPropsCalledRef.current[propKey].refKey = refKey
-  getterPropsCalledRef.current[propKey].elementRef = elementRef
+  if (process.env.NODE_ENV !== 'production') {
+    getterPropsCalledRef.current[propKey].called = true
+    getterPropsCalledRef.current[propKey].suppressRefError = suppressRefError
+    getterPropsCalledRef.current[propKey].refKey = refKey
+    getterPropsCalledRef.current[propKey].elementRef = elementRef
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -422,7 +422,12 @@ function targetWithinDownshift(
 }
 
 export function validateControlledUnchanged(state, prevProps, nextProps) {
+  if (process.env.NODE_ENV === 'production') {
+    return
+  }
+
   const warningDescription = `This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props`
+
   Object.keys(state).forEach(propKey => {
     if (prevProps[propKey] !== undefined && nextProps[propKey] === undefined) {
       // eslint-disable-next-line no-console

--- a/src/utils.js
+++ b/src/utils.js
@@ -421,6 +421,26 @@ function targetWithinDownshift(
   )
 }
 
+export function validateControlledUnchanged(state, prevProps, nextProps) {
+  const warningDescription = `This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props`
+  Object.keys(state).forEach(propKey => {
+    if (prevProps[propKey] !== undefined && nextProps[propKey] === undefined) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `downshift: A component has changed the controlled prop "${propKey}" to be uncontrolled. ${warningDescription}`,
+      )
+    } else if (
+      prevProps[propKey] === undefined &&
+      nextProps[propKey] !== undefined
+    ) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `downshift: A component has changed the uncontrolled prop "${propKey}" to be controlled. ${warningDescription}`,
+      )
+    }
+  })
+}
+
 export {
   cbToCb,
   callAllEventHandlers,


### PR DESCRIPTION
**What**:
Adding non-production build errors in the hooks similar to the ones in Downshift: for controlled-uncontrolled props switch and also for incorrect call of getter props.
<!-- Why are these changes necessary? -->

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1024.
Fixes https://github.com/downshift-js/downshift/issues/974.
<!-- How were these changes implemented? -->

**How**:
Keep a ref with previous props and check with current props if there was a switch between controlled and uncontrolled state.
Keep a ref to keep information about whether the getter props were called and if were called correctly (ref was correctly set).

If issues are found, we console.error messages in non-production environments.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
