### PR TITLE
fix(useCombobox): update inputValue when calling selectItem

### DIFF
--- a/src/hooks/useCombobox/__tests__/returnProps.test.js
+++ b/src/hooks/useCombobox/__tests__/returnProps.test.js
@@ -101,7 +101,7 @@ describe('returnProps', () => {
       expect(result.current.inputValue).toBe("I'm Batman!")
     })
 
-    test('selectItem sets selectedItem', () => {
+    test('selectItem sets selectedItem and inputValue', () => {
       const {result} = renderUseCombobox({})
 
       act(() => {
@@ -109,6 +109,18 @@ describe('returnProps', () => {
       })
 
       expect(result.current.selectedItem).toBe(items[2])
+      expect(result.current.inputValue).toBe(items[2])
+    })
+
+    test('selectItem with null clears inputvalue', () => {
+      const {result} = renderUseCombobox({initialSelectedItem: items[2]})
+
+      act(() => {
+        result.current.selectItem(null)
+      })
+
+      expect(result.current.selectedItem).toBe(null)
+      expect(result.current.inputValue).toBe('')
     })
 
     test('reset sets the state to default values', () => {

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -157,6 +157,7 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.FunctionSelectItem:
       changes = {
         selectedItem: action.selectedItem,
+        inputValue: props.itemToString(action.selectedItem)
       }
       break
     case stateChangeTypes.ControlledPropUpdatedSelectedItem:


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
When using action prop `selectItem` we should also update the `inputValue` to be its string 

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1049.
<!-- How were these changes implemented? -->

**How**:
Fix the state change in the reducer to also return the inputValue.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
