### PR TITLE
docs(hooks): add more examples to the docsite

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,59 +1,30 @@
 {
-  "dist/downshift.cjs.js": {
-    "bundled": 146236,
-    "minified": 66472,
-    "gzipped": 14086
+  "downshift.cjs.js": {
+    "bundled": 144832,
+    "minified": 65296,
+    "gzipped": 13967
   },
-  "preact/dist/downshift.cjs.js": {
-    "bundled": 145020,
-    "minified": 65500,
-    "gzipped": 13988
+  "downshift.umd.min.js": {
+    "bundled": 159257,
+    "minified": 50766,
+    "gzipped": 13739
   },
-  "preact/dist/downshift.umd.min.js": {
-    "bundled": 155229,
-    "minified": 49470,
-    "gzipped": 13201
+  "downshift.umd.js": {
+    "bundled": 195963,
+    "minified": 67230,
+    "gzipped": 17330
   },
-  "dist/downshift.umd.min.js": {
-    "bundled": 159375,
-    "minified": 50771,
-    "gzipped": 13741
-  },
-  "preact/dist/downshift.umd.js": {
-    "bundled": 166545,
-    "minified": 58319,
-    "gzipped": 14734
-  },
-  "dist/downshift.umd.js": {
-    "bundled": 196081,
-    "minified": 67238,
-    "gzipped": 17326
-  },
-  "dist/downshift.esm.js": {
-    "bundled": 145339,
-    "minified": 65651,
-    "gzipped": 13987,
+  "downshift.esm.js": {
+    "bundled": 143839,
+    "minified": 64379,
+    "gzipped": 13875,
     "treeshaked": {
       "rollup": {
-        "code": 2286,
-        "import_statements": 317
-      },
-      "webpack": {
-        "code": 4513
-      }
-    }
-  },
-  "preact/dist/downshift.esm.js": {
-    "bundled": 144027,
-    "minified": 64583,
-    "gzipped": 13894,
-    "treeshaked": {
-      "rollup": {
-        "code": 2287,
+        "code": 2275,
         "import_statements": 318
       },
       "webpack": {
-        "code": 4512
+        "code": 4496
       }
     }
   }

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -463,12 +463,12 @@ In all other state change types, we return `Downshift` default changes.
 ## Custom window
 
 When using `useCombobox` in an `<iframe>` or in any other scenario that uses a
-`window` object different that the default browser `window`, it is required to
-provide that `window` object to the hook as well. Internally, we are using the
-`window` object for DOM related logic, and working with the wrong object will
-make the hook behave unexpectedly. For example, when using
-`react-frame-component` to produce an `iframe` container, we should pass its
-`window` object to the hook like this.
+`window` object different than the default browser `window`, it is required to
+provide that `window` object to the hook as well. Internally, we rely on the
+`window` for DOM related logic and working with the wrong object will make the 
+hook behave unexpectedly. For example, when using `react-frame-component` to
+produce an `iframe` container, we should pass its `window` object to the hook
+like below.
 
 [CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6) (with `useSelect`
 but same concepts apply).

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -459,5 +459,42 @@ In all other state change types, we return `Downshift` default changes.
   }}
 </Playground>
 
+## Custom window
+
+When using `useCombobox` in an `<iframe>` or in any other scenario that uses a `window` object different that the default
+browser `window`, it is required to provide that `window` object to the hook as well. Internally, we are using the
+`window` object for DOM related logic, and working with the wrong object will make the hook behave unexpectedly. For
+example, when using `react-frame-component` to produce an `iframe` container, we should pass its `window` object to the
+hook like this.
+
+[CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6) (with `useSelect` but same concept applies).
+
+```js
+import React from 'react';
+import { render } from 'react-dom';
+import { useCombobox } from 'downshift';
+import Frame, { FrameContextConsumer } from 'react-frame-component';
+
+function DropdownCombobox({ environment }) {
+  // use the environment prop to pass the custom iframe window to useCombobox.
+  useCombobox({ items, environment });
+  return (
+    // your select here.
+  )
+}
+
+render(
+  <Frame style={{ height: 300 }}>
+    <FrameContextConsumer>
+      {// get the window object from the context.
+      ({ document, window }) => (
+        // pass it to the select component as prop.
+        <DropdownCombobox environment={window} />
+      )}
+    </FrameContextConsumer>
+  </Frame>,
+  document.getElementById("root")
+```
+
 [combobox-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -579,21 +579,19 @@ render(
                       : {}
                   }
                   key={`${item}${index}`}
+                  {...getItemProps({
+                    item,
+                    index,
+                  })}
                 >
-                  <label style={checkboxLabelStyles}>
-                    <input
-                      type="checkbox"
-                      {...getItemProps({
-                        item,
-                        index,
-                        checked: selectedItems.includes(item)
-                      })}
-                      value={item}
-                      onChange={() => null}
-                    />
-                    <span />
-                    {item}
-                  </label>
+                  <input
+                    type="checkbox"
+                    checked={selectedItems.includes(item)}
+                    value={item}
+                    onChange={() => null}
+                  />
+                  <span />
+                  {item}
                 </li>
               ))}
           </ul>

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -24,7 +24,7 @@ import {
   itemsAsObjects,
   menuStyles,
   comboboxStyles,
-  checkboxLabelStyles
+  checkboxLabelStyles,
 } from '../utils'
 
 # useCombobox
@@ -42,8 +42,8 @@ needs.
 `useCombobox` is a React hook that manages all the stateful logic needed to make
 the combobox functional and accessible. It returns a set of props that are meant
 to be called and their results destructured on the combobox's elements: its
-label, toggle button, input, combobox container, list and list items. The props are
-similar to the ones provided by vanilla `<Downshift>` to the children render
+label, toggle button, input, combobox container, list and list items. The props
+are similar to the ones provided by vanilla `<Downshift>` to the children render
 prop.
 
 These props are called getter props and their return values are destructured as
@@ -462,25 +462,29 @@ In all other state change types, we return `Downshift` default changes.
 
 ## Custom window
 
-When using `useCombobox` in an `<iframe>` or in any other scenario that uses a `window` object different that the default
-browser `window`, it is required to provide that `window` object to the hook as well. Internally, we are using the
-`window` object for DOM related logic, and working with the wrong object will make the hook behave unexpectedly. For
-example, when using `react-frame-component` to produce an `iframe` container, we should pass its `window` object to the
-hook like this.
+When using `useCombobox` in an `<iframe>` or in any other scenario that uses a
+`window` object different that the default browser `window`, it is required to
+provide that `window` object to the hook as well. Internally, we are using the
+`window` object for DOM related logic, and working with the wrong object will
+make the hook behave unexpectedly. For example, when using
+`react-frame-component` to produce an `iframe` container, we should pass its
+`window` object to the hook like this.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6) (with `useSelect` but same concept applies).
+[CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6) (with `useSelect`
+but same concepts apply).
 
 ```js
 import React from 'react';
 import { render } from 'react-dom';
 import { useCombobox } from 'downshift';
 import Frame, { FrameContextConsumer } from 'react-frame-component';
+import { items } from './utils'
 
 function DropdownCombobox({ environment }) {
   // use the environment prop to pass the custom iframe window to useCombobox.
   useCombobox({ items, environment });
   return (
-    // your select here.
+    // your combobox here.
   )
 }
 
@@ -498,6 +502,24 @@ render(
 ```
 
 ## Basic Multiple Selection
+
+The `useCombobox` hook can be used to create a widget that supports multiple
+selection. In this case, our multiple selection only marks the selected items
+with checkboxes inside the menu list. Every other aspect remains the same as
+with the single selection combobox. For a more interactive example of multiple
+selection, you can use our `useMultipleSelection` hook together with
+`useCombobox`, as shown by the
+[multiple selection section](/use-multiple-selection).
+
+In the example below, we control the `selectedItem` to always be `null` and keep
+our selected items in a state variable, `selectedItems`. We use
+`onSelectedItemChange` prop to retrieve the `selectedItem` from `useCombobox`,
+which is added to / removed from the `selectedItems` array. We also use
+`stateReducer` to keep the menu open on selection by Enter key or by click, and
+also to keep the `highlightedIndex` to be the most recent selected item.
+
+In order to visually illustrate the selection, we render a checkbox before each
+of them and check only the ones that are selected.
 
 <Playground>
   {() => {
@@ -560,11 +582,14 @@ render(
           )
         },
       })
+      const placeholderText = selectedItems.length
+        ? `${selectedItems.length} elements selected`
+        : 'elements'
       return (
         <div>
           <label {...getLabelProps()}>Choose an element:</label>
           <div style={comboboxStyles} {...getComboboxProps()}>
-            <input {...getInputProps()} />
+            <input placeholder={placeholderText} {...getInputProps()} />
             <button {...getToggleButtonProps()} aria-label="toggle menu">
               &#8595;
             </button>
@@ -601,6 +626,41 @@ render(
     return <DropdownCombobox />
   }}
 </Playground>
+
+## Using action props
+
+Action props are functions returned by `useCombobox` along with the state props
+and getter props. They are handy when you need to execute combobox state changes
+from event handlers, state change handlers or any other external location. In the
+example below we open the menu when the combobox input is focused, and clear
+the selection by clicking on the custom selection clearing button. We use the
+`openMenu` and `selectItem` action props in order to achieve these custom
+behaviors.
+
+[CodeSandbox](https://codesandbox.io/s/usecombobox-action-props-kzwos)
+
+```jsx
+import React from 'react';
+import { useCombobox } from 'downshift';
+import { items } from './utils'
+
+function DropdownCombobox() {
+  const {getInputProps, getMenuProps, isOpen, openMenu, selectItem} = useCombobox({items});
+  return (
+    <div>
+      {/* label and combobox container. */}
+      <input {...getInputProps({onFocus: () => { openMenu() }})} />
+      <button tabindex={-1} onClick={() => { selectItem(null) }} aria-label="clear selection">
+        &#215;
+      </button>
+      {/* toggle button. */}
+      <ul {...getMenuProps()}>
+        {isOpen && items.map((map, index) => /* render items when isOpen is true. */)}
+      </ul>
+    </div>
+  )
+}
+```
 
 [combobox-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -24,6 +24,7 @@ import {
   itemsAsObjects,
   menuStyles,
   comboboxStyles,
+  checkboxLabelStyles
 } from '../utils'
 
 # useCombobox
@@ -495,6 +496,113 @@ render(
   </Frame>,
   document.getElementById("root")
 ```
+
+## Basic Multiple Selection
+
+<Playground>
+  {() => {
+    // import React, { useState } from 'react'
+    // import { useCombobox } from 'downshift'
+    // import { items, menuStyles, comboboxStyles } from './utils'
+    function DropdownCombobox() {
+      const [inputItems, setInputItems] = useState(items)
+      const [selectedItems, setSelectedItems] = useState([])
+      const {
+        isOpen,
+        getToggleButtonProps,
+        getLabelProps,
+        getMenuProps,
+        getInputProps,
+        getComboboxProps,
+        highlightedIndex,
+        getItemProps,
+      } = useCombobox({
+        items: inputItems,
+        onSelectedItemChange: ({selectedItem}) => {
+          if (!selectedItem) {
+            return
+          }
+          const index = selectedItems.indexOf(selectedItem)
+          if (index > 0) {
+            setSelectedItems([...selectedItems.slice(0, index), ...selectedItems.slice(index + 1)])
+          } else if (index === 0) {
+            setSelectedItems([...selectedItems.slice(1)])
+          } else {
+            setSelectedItems([...selectedItems, selectedItem])
+          }
+        },
+        selectedItem: null,
+        stateReducer: (state, actionAndChanges) => {
+          const {changes, type} = actionAndChanges
+          switch (type) {
+            case useCombobox.stateChangeTypes.InputKeyDownEnter:
+            case useCombobox.stateChangeTypes.ItemClick:
+              return {
+                ...changes,
+                isOpen: true, // keep menu open after selection.
+                highlightedIndex: state.highlightedIndex,
+                inputValue: '', // don't add the item string as input value at selection.
+              }
+            case useCombobox.stateChangeTypes.InputBlur:
+              return {
+                ...changes,
+                inputValue: '', // don't add the item string as input value at selection.
+              }
+            default:
+              return changes
+          }
+        },
+        onInputValueChange: ({inputValue}) => {
+          setInputItems(
+            items.filter(item =>
+              item.toLowerCase().startsWith(inputValue.toLowerCase()),
+            ),
+          )
+        },
+      })
+      return (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <div style={comboboxStyles} {...getComboboxProps()}>
+            <input {...getInputProps()} />
+            <button {...getToggleButtonProps()} aria-label="toggle menu">
+              &#8595;
+            </button>
+          </div>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              inputItems.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index
+                      ? {backgroundColor: '#bde4ff'}
+                      : {}
+                  }
+                  key={`${item}${index}`}
+                >
+                  <label style={checkboxLabelStyles}>
+                    <input
+                      type="checkbox"
+                      {...getItemProps({
+                        item,
+                        index,
+                        checked: selectedItems.includes(item)
+                      })}
+                      value={item}
+                      onChange={() => null}
+                    />
+                    <span />
+                    {item}
+                  </label>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )
+    }
+    return <DropdownCombobox />
+  }}
+</Playground>
 
 [combobox-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -468,7 +468,7 @@ provide that `window` object to the hook as well. Internally, we rely on the
 `window` for DOM related logic and working with the wrong object will make the 
 hook behave unexpectedly. For example, when using `react-frame-component` to
 produce an `iframe` container, we should pass its `window` object to the hook
-like below.
+like shown below.
 
 [CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6) (with `useSelect`
 but same concepts apply).
@@ -493,7 +493,7 @@ render(
     <FrameContextConsumer>
       {// get the window object from the context.
       ({ document, window }) => (
-        // pass it to the select component as prop.
+        // pass window to the combobox component as the environment prop.
         <DropdownCombobox environment={window} />
       )}
     </FrameContextConsumer>
@@ -504,12 +504,12 @@ render(
 ## Basic Multiple Selection
 
 The `useCombobox` hook can be used to create a widget that supports multiple
-selection. In this case, our multiple selection only marks the selected items
-with checkboxes inside the menu list. Every other aspect remains the same as
+selection. In the example below, we mark each selected item with a checked
+checkbox inside the menu list. Every other aspect remains the same as
 with the single selection combobox. For a more interactive example of multiple
 selection, you can use our `useMultipleSelection` hook together with
-`useCombobox`, as shown by the
-[multiple selection section](/use-multiple-selection).
+`useCombobox`, as shown in the
+[multiple selection section](/use-multiple-selection#usage-with-combobox).
 
 In the example below, we control the `selectedItem` to always be `null` and keep
 our selected items in a state variable, `selectedItems`. We use

--- a/docs/hooks/useMultipleSelection.mdx
+++ b/docs/hooks/useMultipleSelection.mdx
@@ -114,8 +114,21 @@ the items selection in this case.
         getItemProps,
       } = useCombobox({
         inputValue,
+        defaultHighlightedIndex: 0, // after selection, highlight the first item.
         selectedItem: null,
         items: getFilteredItems(),
+        stateReducer: (state, actionAndChanges) => {
+          const {changes, type} = actionAndChanges
+          switch (type) {
+            case useCombobox.stateChangeTypes.InputKeyDownEnter:
+            case useCombobox.stateChangeTypes.ItemClick:
+              return {
+                ...changes,
+                isOpen: true // keep menu open after selection.
+              }
+          }
+          return changes
+        },
         onStateChange: ({inputValue, type, selectedItem}) => {
           switch (type) {
             case useCombobox.stateChangeTypes.InputChange:
@@ -222,7 +235,21 @@ is up to the developer.
         getItemProps,
       } = useSelect({
         selectedItem: null,
+        defaultHighlightedIndex: 0, // after selection, highlight the first item.
         items: getFilteredItems(),
+          stateReducer: (state, actionAndChanges) => {
+          const {changes, type} = actionAndChanges
+          switch (type) {
+            case useSelect.stateChangeTypes.MenuKeyDownEnter:
+            case useSelect.stateChangeTypes.MenuKeyDownSpaceButton:
+            case useSelect.stateChangeTypes.ItemClick:
+              return {
+                ...changes,
+                isOpen: true // keep menu open after selection.
+              }
+          }
+          return changes
+        },
         onStateChange: ({type, selectedItem}) => {
           switch (type) {
             case useSelect.stateChangeTypes.MenuKeyDownEnter:

--- a/docs/hooks/useMultipleSelection.mdx
+++ b/docs/hooks/useMultipleSelection.mdx
@@ -124,7 +124,7 @@ the items selection in this case.
             case useCombobox.stateChangeTypes.ItemClick:
               return {
                 ...changes,
-                isOpen: true // keep menu open after selection.
+                isOpen: true // keep the menu open after selection.
               }
           }
           return changes
@@ -245,7 +245,7 @@ is up to the developer.
             case useSelect.stateChangeTypes.ItemClick:
               return {
                 ...changes,
-                isOpen: true // keep menu open after selection.
+                isOpen: true // keep the menu open after selection.
               }
           }
           return changes

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -17,7 +17,7 @@ import {
   Avatar,
 } from '@material-ui/core'
 import {useSelect} from '../../src'
-import {items, menuStyles, itemsAsObjects, useStyles} from '../utils'
+import {items, menuStyles, itemsAsObjects, useStyles, checkboxLabelStyles} from '../utils'
 
 # useSelect
 
@@ -265,7 +265,7 @@ will update the value in the other one as well.
         </div>
       )
     }
-    function ControlledComboboxes() {
+    function ControlledSelects() {
       const [selectedItem, setSelectedItem] = useState(null)
       function handleSelectedItemChange({selectedItem}) {
         setSelectedItem(selectedItem)
@@ -283,7 +283,7 @@ will update the value in the other one as well.
         </div>
       )
     }
-    return <ControlledComboboxes />
+    return <ControlledSelects />
   }}
 </Playground>
 
@@ -407,6 +407,95 @@ render(
   </Frame>,
   document.getElementById("root")
 ```
+
+## Basic Multiple selection
+
+<Playground>
+  {() => {
+    // import React, { useState } from 'react'
+    // import { useCombobox } from 'downshift'
+    // import { items, menuStyles, comboboxStyles } from './utils'
+    function stateReducer(state, actionAndChanges) {
+      const {changes, type} = actionAndChanges
+      switch (type) {
+        case useSelect.stateChangeTypes.MenuKeyDownEnter:
+        case useSelect.stateChangeTypes.MenuKeyDownSpaceButton:
+        case useSelect.stateChangeTypes.ItemClick:
+          return {
+            ...changes,
+            isOpen: true, // keep menu open after selection.
+            highlightedIndex: state.highlightedIndex,
+          }
+        default:
+          return changes
+      }
+    }
+    function DropdownSelect() {
+      const [selectedItems, setSelectedItems] = useState([])
+      const {
+        isOpen,
+        getToggleButtonProps,
+        getLabelProps,
+        getMenuProps,
+        highlightedIndex,
+        getItemProps,
+      } = useSelect({
+        items,
+        stateReducer,
+        selectedItem: null,
+        onSelectedItemChange: ({selectedItem}) => {
+          if (!selectedItem) {
+            return
+          }
+          const index = selectedItems.indexOf(selectedItem)
+          if (index > 0) {
+            setSelectedItems([
+              ...selectedItems.slice(0, index),
+              ...selectedItems.slice(index + 1),
+            ])
+          } else if (index === 0) {
+            setSelectedItems([...selectedItems.slice(1)])
+          } else {
+            setSelectedItems([...selectedItems, selectedItem])
+          }
+        },
+      })
+      return (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <button {...getToggleButtonProps()}>{'Elements'}</button>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              items.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index ? {backgroundColor: '#bde4ff'} : {}
+                  }
+                  key={`${item}${index}`}
+                >
+                  <label style={checkboxLabelStyles}>
+                    <input
+                      type="checkbox"
+                      {...getItemProps({
+                        item,
+                        index,
+                        checked: selectedItems.includes(item),
+                      })}
+                      value={item}
+                      onChange={() => null}
+                    />
+                    <span />
+                    {item}
+                  </label>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )
+    }
+    return <DropdownSelect />
+  }}
+</Playground>
 
 [select-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -371,5 +371,42 @@ In all other state change types, we return `useSelect` default changes.
   }}
 </Playground>
 
+## Custom window
+
+When using `useSelect` in an `<iframe>` or in any other scenario that uses a `window` object different that the default
+browser `window`, it is required to provide that `window` object to the hook as well. Internally, we are using the
+`window` object for DOM related logic, and working with the wrong object will make the hook behave unexpectedly. For
+example, when using `react-frame-component` to produce an `iframe` container, we should pass its `window` object to the
+hook like this.
+
+[CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6)
+
+```js
+import React from 'react';
+import { render } from 'react-dom';
+import { useSelect } from 'downshift';
+import Frame, { FrameContextConsumer } from 'react-frame-component';
+
+function DropdownSelect({ environment }) {
+  // use the environment prop to pass the custom iframe window to useSelect.
+  useSelect({ items, environment });
+  return (
+    // your select here.
+  )
+}
+
+render(
+  <Frame style={{ height: 300 }}>
+    <FrameContextConsumer>
+      {// get the window object from the context.
+      ({ document, window }) => (
+        // pass it to the select component as prop.
+        <DropdownSelect environment={window} />
+      )}
+    </FrameContextConsumer>
+  </Frame>,
+  document.getElementById("root")
+```
+
 [select-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -374,12 +374,12 @@ In all other state change types, we return `useSelect` default changes.
 ## Custom window
 
 When using `useSelect` in an `<iframe>` or in any other scenario that uses a
-`window` object different that the default browser `window`, it is required to
-provide that `window` object to the hook as well. Internally, we are using the
-`window` object for DOM related logic, and working with the wrong object will
-make the hook behave unexpectedly. For example, when using
-`react-frame-component` to produce an `iframe` container, we should pass its
-`window` object to the hook like this.
+`window` object different than the default browser `window`, it is required to
+provide that `window` object to the hook as well. Internally, we rely on the
+`window` for DOM related logic and working with the wrong object will make the 
+hook behave unexpectedly. For example, when using `react-frame-component` to
+produce an `iframe` container, we should pass its `window` object to the hook
+like below.
 
 [CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6)
 

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -472,21 +472,19 @@ render(
                     highlightedIndex === index ? {backgroundColor: '#bde4ff'} : {}
                   }
                   key={`${item}${index}`}
+                  {...getItemProps({
+                    item,
+                    index,
+                  })}
                 >
-                  <label style={checkboxLabelStyles}>
-                    <input
-                      type="checkbox"
-                      {...getItemProps({
-                        item,
-                        index,
-                        checked: selectedItems.includes(item),
-                      })}
-                      value={item}
-                      onChange={() => null}
-                    />
-                    <span />
-                    {item}
-                  </label>
+                  <input
+                    type="checkbox"
+                    checked={selectedItems.includes(item)}
+                    value={item}
+                    onChange={() => null}
+                  />
+                  <span />
+                  {item}
                 </li>
               ))}
           </ul>

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -373,11 +373,13 @@ In all other state change types, we return `useSelect` default changes.
 
 ## Custom window
 
-When using `useSelect` in an `<iframe>` or in any other scenario that uses a `window` object different that the default
-browser `window`, it is required to provide that `window` object to the hook as well. Internally, we are using the
-`window` object for DOM related logic, and working with the wrong object will make the hook behave unexpectedly. For
-example, when using `react-frame-component` to produce an `iframe` container, we should pass its `window` object to the
-hook like this.
+When using `useSelect` in an `<iframe>` or in any other scenario that uses a
+`window` object different that the default browser `window`, it is required to
+provide that `window` object to the hook as well. Internally, we are using the
+`window` object for DOM related logic, and working with the wrong object will
+make the hook behave unexpectedly. For example, when using
+`react-frame-component` to produce an `iframe` container, we should pass its
+`window` object to the hook like this.
 
 [CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6)
 
@@ -409,6 +411,24 @@ render(
 ```
 
 ## Basic Multiple selection
+
+The `useSelect` hook can be used to create a widget that supports multiple
+selection. In this case, our multiple selection only marks the selected items
+with checkboxes inside the menu list. Every other aspect remains the same as
+with the single selection dropdown. For a more interactive example of multiple
+selection, you can use our `useMultipleSelection` hook together with
+`useSelect`, as shown by the
+[multiple selection section](/use-multiple-selection).
+
+In the example below, we control the `selectedItem` to always be `null` and keep
+our selected items in a state variable, `selectedItems`. We use
+`onSelectedItemChange` prop to retrieve the `selectedItem` from `useSelect`,
+which is added to / removed from the `selectedItems` array. We also use
+`stateReducer` to keep the menu open on selection by Enter key or by click, and
+also to keep the `highlightedIndex` to be the most recent selected item.
+
+In order to visually illustrate the selection, we render a checkbox before each
+of them and check only the ones that are selected.
 
 <Playground>
   {() => {
@@ -460,10 +480,13 @@ render(
           }
         },
       })
+      const buttonText = selectedItems.length
+        ? `${selectedItems.length} elements selected`
+        : 'Elements'
       return (
         <div>
           <label {...getLabelProps()}>Choose an element:</label>
-          <button {...getToggleButtonProps()}>{'Elements'}</button>
+          <button {...getToggleButtonProps()}>{buttonText}</button>
           <ul {...getMenuProps()} style={menuStyles}>
             {isOpen &&
               items.map((item, index) => (
@@ -494,6 +517,54 @@ render(
     return <DropdownSelect />
   }}
 </Playground>
+
+## Using action props
+
+Action props are functions returned by `useSelect` along with the state props
+and getter props. They are handy when you need to execute select state changes
+from event handlers, state change handlers or any other external location. In the
+example below we open the menu when the toggle button is hovered, and clear
+the selection by clicking on the custom selection clearing button. We use the
+`openMenu` and `selectItem` action props in order to achieve these custom
+behaviors.
+
+[CodeSandbox](https://codesandbox.io/s/useselect-action-props-zljdg)
+
+```jsx
+import React from 'react';
+import { useCombobox } from 'downshift';
+import { items } from './utils'
+
+function DropdownCombobox() {
+  const {getInputProps, getMenuProps, isOpen, openMenu, selectItem} = useSelect({items});
+  return (
+    <div>
+      {/* label */}
+      <button
+        {...getToggleButtonProps({
+          onMouseEnter: () => {
+            openMenu()
+          }
+        })}
+      >
+        {selectedItem || "Elements"}
+      </button>
+      <button
+        tabindex={-1}
+        onClick={() => {
+          selectItem(null)
+        }}
+        aria-label="clear selection"
+      >
+        &#215;
+      </button>
+      <ul {...getMenuProps()}>
+        {isOpen && items.map((map, index) => /* render items when isOpen is true. */)}
+      </ul>
+    </div>
+  )
+}
+```
 
 [select-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -379,7 +379,7 @@ provide that `window` object to the hook as well. Internally, we rely on the
 `window` for DOM related logic and working with the wrong object will make the 
 hook behave unexpectedly. For example, when using `react-frame-component` to
 produce an `iframe` container, we should pass its `window` object to the hook
-like below.
+like shown below.
 
 [CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6)
 
@@ -413,12 +413,12 @@ render(
 ## Basic Multiple selection
 
 The `useSelect` hook can be used to create a widget that supports multiple
-selection. In this case, our multiple selection only marks the selected items
-with checkboxes inside the menu list. Every other aspect remains the same as
+selection. In the example below, we mark each selected item with a checked
+checkbox inside the menu list. Every other aspect remains the same as
 with the single selection dropdown. For a more interactive example of multiple
 selection, you can use our `useMultipleSelection` hook together with
-`useSelect`, as shown by the
-[multiple selection section](/use-multiple-selection).
+`useSelect`, as shown in the
+[multiple selection section](/use-multiple-selection#usage-with-select).
 
 In the example below, we control the `selectedItem` to always be `null` and keep
 our selected items in a state variable, `selectedItems`. We use

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -19,6 +19,10 @@ export const menuMultipleStlyes = {
   left: '380px',
 }
 
+export const checkboxLabelStyles = {
+  display: 'block'
+}
+
 export const selectedItemStyles = {
   marginLeft: '5px',
   backgroundColor: 'aliceblue',

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -58,7 +58,7 @@ const renderCombobox = (props, uiCallback) => {
     await userEvent.type(input, inputValue)
   }
   const focusInput = () => {
-    input.focus()
+    fireEvent.focus(input)
   }
   const keyDownOnInput = (key, options = {}) => {
     if (document.activeElement !== input) {
@@ -68,7 +68,7 @@ const renderCombobox = (props, uiCallback) => {
     fireEvent.keyDown(input, {key, ...options})
   }
   const blurInput = () => {
-    input.blur()
+    fireEvent.blur(input)
   }
 
   return {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -432,7 +432,13 @@ function useSelect(userProps = {}) {
         ...rest,
       }
     },
-    [dispatch, latest, menuKeyDownHandlers, mouseAndTouchTrackersRef, setGetterPropCallInfo],
+    [
+      dispatch,
+      latest,
+      menuKeyDownHandlers,
+      mouseAndTouchTrackersRef,
+      setGetterPropCallInfo,
+    ],
   )
   const getToggleButtonProps = useCallback(
     (

--- a/src/hooks/useSelect/testUtils.js
+++ b/src/hooks/useSelect/testUtils.js
@@ -57,7 +57,7 @@ const renderSelect = (props, uiCallback) => {
     fireEvent.keyDown(menu, {key, ...options})
   }
   const blurMenu = () => {
-    menu.blur()
+    fireEvent.blur(menu)
   }
   const getA11yStatusContainer = () => wrapper.queryByRole('status')
   const mouseLeaveMenu = () => {

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -171,7 +171,11 @@ export function useEnhancedReducer(reducer, initialState, props) {
 
   useEffect(() => {
     if (action && prevStateRef.current && prevStateRef.current !== state) {
-      callOnChangeProps(action, prevStateRef.current, state)
+      callOnChangeProps(
+        action,
+        getState(prevStateRef.current, action.props),
+        state,
+      )
     }
 
     prevStateRef.current = state
@@ -377,7 +381,7 @@ export function useMouseAndTouchTracker(
 
 /**
  * Custom hook that checks if getter props are called correctly.
- * 
+ *
  * @param  {...any} propKeys Getter prop names to be handled.
  * @returns {Function} Setter function called inside getter props to set call information.
  */


### PR DESCRIPTION
**What**:
Adding more usage examples for the hooks in the docsite, https://www.downshift-js.com/.
<!-- Why are these changes necessary? -->

**Why**:
To help users develop widgets better and faster.
Closes https://github.com/downshift-js/downshift/issues/1035
Closes https://github.com/downshift-js/downshift/issues/1029
Closes https://github.com/downshift-js/downshift/issues/939
<!-- How were these changes implemented? -->

**How**:
Adding examples in the docsite, also creating code sandboxes where needed.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
