### PR TITLE
Fix link on docs page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -52,4 +52,4 @@ actively maintained but we are cool kids from the future and prefer to share
 - [useCombobox](/use-combobox)
 - [useMultipleSelection](/use-multiple-selection)
 
-[github-page]: https://github.com/downshift-js/downshift)
+[github-page]: https://github.com/downshift-js/downshift


### PR DESCRIPTION
The docs page has a broken link because it has an ending parenthesis ")" at the end.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This removes a parenthesis character that causes a broken link

<!-- Why are these changes necessary? -->

**Why**:

The link does not work without this change.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Free to do more work to merge this if needed