### PR TITLE
fix(hooks): call a11y status message on items change

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "downshift.cjs.js": {
-    "bundled": 144832,
+    "bundled": 144818,
     "minified": 65296,
-    "gzipped": 13967
+    "gzipped": 13968
   },
   "downshift.umd.min.js": {
-    "bundled": 159257,
+    "bundled": 159243,
     "minified": 50766,
-    "gzipped": 13739
+    "gzipped": 13742
   },
   "downshift.umd.js": {
-    "bundled": 195963,
+    "bundled": 195949,
     "minified": 67230,
-    "gzipped": 17330
+    "gzipped": 17332
   },
   "downshift.esm.js": {
-    "bundled": 143839,
+    "bundled": 143825,
     "minified": 64379,
     "gzipped": 13875,
     "treeshaked": {

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -284,15 +284,16 @@ reset or when an item is selected.
 
 > `string` | defaults to `''`
 
-Pass a string that sets the content of the input when downshift is reset or
-when an item is selected.
+Pass a string that sets the content of the input when downshift is reset or when
+an item is selected.
 
 ### getA11yStatusMessage
 
 > `function({/* see below */})` | default messages provided in English
 
-This function is passed as props to a `Status` component nested within and
-allows you to create your own assertive ARIA statuses.
+This function is passed as props to a status updating function nested within and
+allows you to create your own ARIA statuses. It is called when one of the
+following props change: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
 
 A default `getA11yStatusMessage` function is provided that will check
 `resultCount` and return "No results are available." or if there are results ,
@@ -306,14 +307,16 @@ Press Enter key to select."
 > `function({/* see below */})` | default messages provided in English
 
 This function is similar to the `getA11yStatusMessage` but it is generating a
-message when an item is selected.
+message when an item is selected. It is passed as props to a status updating
+function nested within and allows you to create your own ARIA statuses. It is
+called when `selectedItem` changes.
 
-A default `getA11ySelectionMessage` function is provided. It is called when
-`selectedItem` changes. When an item is selected, the message is a selection
-related one, narrating "`itemToString(selectedItem)` has been selected".
+A default `getA11ySelectionMessage` function is provided. When an item is
+selected, the message is a selection related one, narrating
+"`itemToString(selectedItem)` has been selected".
 
 The object you are passed to generate your status message, for both
-`getA11yStatusMessage` and `getA11ySelectionMessage` has the following
+`getA11yStatusMessage` and `getA11ySelectionMessage`, has the following
 properties:
 
 <!-- This table was generated via http://www.tablesgenerator.com/markdown_tables -->
@@ -646,8 +649,8 @@ Optional properties:
 In some cases, you might want to completely bypass the `refKey` check. Then you
 can provide the object `{suppressRefError : true}` as the second argument to
 `getMenuProps`. **Please use it with extreme care and only if you are absolutely
-sure that the ref is correctly forwarded otherwise `useCombobox` will unexpectedly
-fail.**
+sure that the ref is correctly forwarded otherwise `useCombobox` will
+unexpectedly fail.**
 
 ```jsx
 const {getMenuProps} = useCombobox({items})
@@ -777,8 +780,8 @@ Optional properties:
 In some cases, you might want to completely bypass the `refKey` check. Then you
 can provide the object `{suppressRefError : true}` as the second argument to
 `getInput`. **Please use it with extreme care and only if you are absolutely
-sure that the ref is correctly forwarded otherwise `useCombobox` will unexpectedly
-fail.**
+sure that the ref is correctly forwarded otherwise `useCombobox` will
+unexpectedly fail.**
 
 #### `getComboboxProps`
 
@@ -794,9 +797,9 @@ There are no required properties for this method.
 
 In some cases, you might want to completely bypass the `refKey` check. Then you
 can provide the object `{suppressRefError : true}` as the second argument to
-`getComboboxProps`. **Please use it with extreme care and only if you are absolutely
-sure that the ref is correctly forwarded otherwise `useCombobox` will unexpectedly
-fail.**
+`getComboboxProps`. **Please use it with extreme care and only if you are
+absolutely sure that the ref is correctly forwarded otherwise `useCombobox` will
+unexpectedly fail.**
 
 ### actions
 

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -291,8 +291,8 @@ an item is selected.
 
 > `function({/* see below */})` | default messages provided in English
 
-This function is passed as props to a status updating function nested within and
-allows you to create your own ARIA statuses. It is called when one of the
+This function is passed as props to a status updating function nested within
+that allows you to create your own ARIA statuses. It is called when one of the
 following props change: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
 
 A default `getA11yStatusMessage` function is provided that will check
@@ -308,7 +308,7 @@ Press Enter key to select."
 
 This function is similar to the `getA11yStatusMessage` but it is generating a
 message when an item is selected. It is passed as props to a status updating
-function nested within and allows you to create your own ARIA statuses. It is
+function nested within that allows you to create your own ARIA statuses. It is
 called when `selectedItem` changes.
 
 A default `getA11ySelectionMessage` function is provided. When an item is

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -293,6 +293,49 @@ describe('props', () => {
 
       expect(environment.document.getElementById).toHaveBeenCalledTimes(1)
     })
+
+    test('is called when isOpen, highlightedIndex, inputValue or items change', async () => {
+      const getA11yStatusMessage = jest.fn()
+      const inputItems = ['aaa', 'bbb']
+      const {clickOnToggleButton, rerender, keyDownOnInput, changeInputValue} = renderCombobox({
+        getA11yStatusMessage,
+        items,
+      })
+
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).not.toHaveBeenCalled()
+
+      // should not be called when any other prop is changed.
+      rerender({getA11yStatusMessage, items, circularNavigation: false})
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).not.toHaveBeenCalled()
+
+      rerender({getA11yStatusMessage, items: inputItems})
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({resultCount: inputItems.length}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(1)
+
+      clickOnToggleButton()
+      waitForDebouncedA11yStatusUpdate()
+      
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({isOpen: true}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(2)
+      
+      await changeInputValue('b')
+      waitForDebouncedA11yStatusUpdate()
+      
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({inputValue: 'b'}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(3)
+
+      keyDownOnInput('ArrowDown')
+      waitForDebouncedA11yStatusUpdate()
+      
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({highlightedIndex: 0}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(4)
+    })
   })
 
   describe('highlightedIndex', () => {

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -108,7 +108,7 @@ function useCombobox(userProps = {}) {
       environment.document,
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, highlightedIndex, selectedItem, inputValue])
+  }, [isOpen, highlightedIndex, inputValue, items])
   // Sets a11y status message on changes in selectedItem.
   useEffect(() => {
     if (isInitialMountRef.current) {

--- a/src/hooks/useMultipleSelection/README.md
+++ b/src/hooks/useMultipleSelection/README.md
@@ -313,14 +313,15 @@ downshift is reset.
 
 > `function({/* see below */})` | default messages provided in English
 
-This function is similar to the `getA11yStatusMessage` and
-`getA11ySelectionMessage` from `useSelect` and `useCombobox` but it is
-generating a message when an item is removed.
+This function is similar to the `getA11yStatusMessage` or
+`getA11ySelectionMessage` from `useSelect` and `useCombobox` but it is generating an ARIA a11y
+message when an item is removed. It is passed as props to a status updating
+function nested within that allows you to create your own ARIA statuses. It is
+called when an item is removed and the size of `selectedItems` decreases.
 
-A default `getA11yRemovalMessage` function is provided. It is called when an
-item is removed and the size of `selectedItems` decreases. When an item is
+A default `getA11yRemovalMessage` function is provided. When an item is
 removed, the message is a removal related one, narrating
-"`itemToString(removedItem)` has been removed".
+"`itemToString(remvedItem)` has been removed".
 
 The object you are passed to generate your status message for
 `getA11yRemovalMessage` has the following properties:

--- a/src/hooks/useMultipleSelection/README.md
+++ b/src/hooks/useMultipleSelection/README.md
@@ -321,7 +321,7 @@ called when an item is removed and the size of `selectedItems` decreases.
 
 A default `getA11yRemovalMessage` function is provided. When an item is
 removed, the message is a removal related one, narrating
-"`itemToString(remvedItem)` has been removed".
+"`itemToString(removedItem)` has been removed".
 
 The object you are passed to generate your status message for
 `getA11yRemovalMessage` has the following properties:

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -255,14 +255,14 @@ reset or when an item is selected.
 
 > `function({/* see below */})` | default messages provided in English
 
-This function is passed as props to a status updating function nested within and
-allows you to create your own ARIA statuses. It is called when one of the
+This function is passed as props to a status updating function nested within
+that allows you to create your own ARIA statuses. It is called when one of the
 following props change: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
 
 A default `getA11yStatusMessage` function is provided that will check
 `resultCount` and return "No results are available." or if there are results ,
 "`resultCount` results are available, use up and down arrow keys to navigate.
-Press Enter key to select."
+Press Enter or Space Bar keys to select."
 
 > Note: `resultCount` is `items.length` in our default version of the function.
 
@@ -272,7 +272,7 @@ Press Enter key to select."
 
 This function is similar to the `getA11yStatusMessage` but it is generating a
 message when an item is selected. It is passed as props to a status updating
-function nested within and allows you to create your own ARIA statuses. It is
+function nested within that allows you to create your own ARIA statuses. It is
 called when `selectedItem` changes.
 
 A default `getA11ySelectionMessage` function is provided. When an item is

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -255,13 +255,14 @@ reset or when an item is selected.
 
 > `function({/* see below */})` | default messages provided in English
 
-This function is passed as props to a `Status` component nested within and
-allows you to create your own assertive ARIA statuses.
+This function is passed as props to a status updating function nested within and
+allows you to create your own ARIA statuses. It is called when one of the
+following props change: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
 
 A default `getA11yStatusMessage` function is provided that will check
 `resultCount` and return "No results are available." or if there are results ,
 "`resultCount` results are available, use up and down arrow keys to navigate.
-Press Enter or Space Bar keys to select."
+Press Enter key to select."
 
 > Note: `resultCount` is `items.length` in our default version of the function.
 
@@ -270,14 +271,16 @@ Press Enter or Space Bar keys to select."
 > `function({/* see below */})` | default messages provided in English
 
 This function is similar to the `getA11yStatusMessage` but it is generating a
-message when an item is selected.
+message when an item is selected. It is passed as props to a status updating
+function nested within and allows you to create your own ARIA statuses. It is
+called when `selectedItem` changes.
 
-A default `getA11ySelectionMessage` function is provided. It is called when
-`selectedItem` changes. When an item is selected, the message is a selection
-related one, narrating "`itemToString(selectedItem)` has been selected".
+A default `getA11ySelectionMessage` function is provided. When an item is
+selected, the message is a selection related one, narrating
+"`itemToString(selectedItem)` has been selected".
 
 The object you are passed to generate your status message, for both
-`getA11yStatusMessage` and `getA11ySelectionMessage` has the following
+`getA11yStatusMessage` and `getA11ySelectionMessage`, has the following
 properties:
 
 <!-- This table was generated via http://www.tablesgenerator.com/markdown_tables -->

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -289,6 +289,49 @@ describe('props', () => {
 
       expect(environment.document.getElementById).toHaveBeenCalledTimes(1)
     })
+
+    test('is called when isOpen, highlightedIndex, inputValue or items change', () => {
+      const getA11yStatusMessage = jest.fn()
+      const inputItems = ['aaa', 'bbb']
+      const {clickOnToggleButton, rerender, keyDownOnMenu} = renderSelect({
+        getA11yStatusMessage,
+        items,
+      })
+
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).not.toHaveBeenCalled()
+
+      // should not be called when any other prop is changed.
+      rerender({getA11yStatusMessage, items, circularNavigation: true})
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).not.toHaveBeenCalled()
+
+      rerender({getA11yStatusMessage, items: inputItems})
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({resultCount: inputItems.length}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(1)
+
+      clickOnToggleButton()
+      waitForDebouncedA11yStatusUpdate()
+      
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({isOpen: true}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(2)
+      
+      keyDownOnMenu('b')
+      waitForDebouncedA11yStatusUpdate()
+      
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({inputValue: 'b', highlightedIndex: 1}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(3)
+
+      keyDownOnMenu('ArrowUp')
+      waitForDebouncedA11yStatusUpdate()
+      
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({highlightedIndex: 0}))
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(4)
+    })
   })
 
   describe('highlightedIndex', () => {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -111,7 +111,7 @@ function useSelect(userProps = {}) {
       environment.document,
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, highlightedIndex, selectedItem, inputValue])
+  }, [isOpen, highlightedIndex, inputValue, items])
   // Sets a11y status message on changes in selectedItem.
   useEffect(() => {
     if (isInitialMountRef.current) {
@@ -432,13 +432,7 @@ function useSelect(userProps = {}) {
         ...rest,
       }
     },
-    [
-      dispatch,
-      latest,
-      menuKeyDownHandlers,
-      mouseAndTouchTrackersRef,
-      setGetterPropCallInfo,
-    ],
+    [dispatch, latest, menuKeyDownHandlers, mouseAndTouchTrackersRef, setGetterPropCallInfo],
   )
   const getToggleButtonProps = useCallback(
     (


### PR DESCRIPTION
**What**:
Calling updateA11yStatus when `items ` prop change.

**Why**:
To reflect, for instance, the number of results change when combobox filters the items by input value
Closes https://github.com/downshift-js/downshift/issues/1076.

**How**:
Add `items` to the list of dependencies that trigger the effect with the status update.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
