### PR TITLE
fix(ts): specify that itemToString can receive null

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -197,7 +197,7 @@ export interface Actions<Item> {
     cb?: Callback,
   ) => void
   // props
-  itemToString: (item: Item) => string
+  itemToString: (item: Item | null) => string
 }
 
 export type ControllerStateAndHelpers<Item> = DownshiftState<Item> &
@@ -269,7 +269,7 @@ export enum UseSelectStateChangeTypes {
 
 export interface UseSelectProps<Item> {
   items: Item[]
-  itemToString?: (item: Item) => string
+  itemToString?: (item: Item | null) => string
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   getA11ySelectionMessage?: (options: A11yStatusMessageOptions<Item>) => string
   circularNavigation?: boolean
@@ -403,7 +403,7 @@ export enum UseComboboxStateChangeTypes {
 
 export interface UseComboboxProps<Item> {
   items: Item[]
-  itemToString?: (item: Item) => string
+  itemToString?: (item: Item | null) => string
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   getA11ySelectionMessage?: (options: A11yStatusMessageOptions<Item>) => string
   circularNavigation?: boolean


### PR DESCRIPTION
**What**:

This makes it so the argument passed to `itemToString` can be `null` for the following interfaces:

- `UseSelectProps`
- `UseComboboxProps`
- `Actions`

**Why**:

This makes them behave in line with various documentation, which states that they can receive null:

- [`useCombobox#itemToString`](https://github.com/downshift-js/downshift/tree/master/src/hooks/useCombobox#itemtostring)
- [`useSelect#itemToString`](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect#itemtostring)
- [Downshift component](https://github.com/downshift-js/downshift#itemtostring)

**How**:

I looked for all instances for `itemToString` in the typescript types and looked up their documentation to determine which ones have been specified to potentially be `null`. I then added `| null` to the relevant ones, which will make it so the argument can either be of the `Item` type or `null`.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [X] TypeScript Types
- [ ] Flow Types N/A
- [X] Ready to be merged

I didn’t touch `useMultipleSelection`, because its documentation didn’t have this line: [`useMultipleSelection#itemToString`](https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection#itemtostring)

I was also not sure about `itemToString` passed to the various `A11y`-functions, so I didn’t touch these either.

This fix has previously been applied to the main Downshift component: https://github.com/downshift-js/downshift/pull/505

This will be a breaking change for people using typescript with `strictNullChecks` turned on if they don’t already check for null. I will leave that decision with you, though.