### PR TITLE
docs(hooks): changed name of a style in use multiple combobox example

### DIFF
--- a/docs/hooks/useMultipleSelection.mdx
+++ b/docs/hooks/useMultipleSelection.mdx
@@ -14,7 +14,7 @@ import {
   comboboxWrapperStyles,
   selectedItemStyles,
   selectedItemIconStyles,
-  menuMultipleStlyes,
+  menuMultipleStyles,
 } from '../utils'
 
 # useMultipleSelection
@@ -87,7 +87,7 @@ the items selection in this case.
   {() => {
     // import React, { useState } from 'react'
     // import { useCombobox, useMultipleSelection } from 'downshift'
-    // import { items, menuMultipleStlyes, comboboxStyles, comboboxWrapperStyles, selectedItemStyles, selectedItemIconStyles } from './utils'
+    // import { items, menuMultipleStyles, comboboxStyles, comboboxWrapperStyles, selectedItemStyles, selectedItemIconStyles } from './utils'
     function DropdownMultipleCombobox() {
       const [inputValue, setInputValue] = useState('')
       const {
@@ -178,7 +178,7 @@ the items selection in this case.
               </button>
             </div>
           </div>
-          <ul {...getMenuProps()} style={menuMultipleStlyes}>
+          <ul {...getMenuProps()} style={menuMultipleStyles}>
             {isOpen &&
               getFilteredItems(items).map((item, index) => (
                 <li
@@ -214,7 +214,7 @@ is up to the developer.
   {() => {
     // import React from 'react'
     // import { useSelect, useMultipleSelection } from 'downshift'
-    // import { items, menuMultipleStlyes, selectedItemStyles, selectedItemIconStyles } from './utils'
+    // import { items, menuMultipleStyles, selectedItemStyles, selectedItemIconStyles } from './utils'
     function DropdownMultipleSelect() {
       const {
         getSelectedItemProps,
@@ -292,7 +292,7 @@ is up to the developer.
           >
             {selectedItem || 'Elements'}
           </button>
-          <ul {...getMenuProps()} style={menuMultipleStlyes}>
+          <ul {...getMenuProps()} style={menuMultipleStyles}>
             {isOpen &&
               getFilteredItems(items).map((item, index) => (
                 <li

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -14,7 +14,7 @@ export const menuStyles = {
   minWidth: '200px',
 }
 
-export const menuMultipleStlyes = {
+export const menuMultipleStyles = {
   ...menuStyles,
   left: '380px',
 }

--- a/src/hooks/useMultipleSelection/README.md
+++ b/src/hooks/useMultipleSelection/README.md
@@ -158,7 +158,7 @@ const DropdownMultipleCombobox = () => {
           </button>
         </div>
       </div>
-      <ul {...getMenuProps()} style={menuMultipleStlyes}>
+      <ul {...getMenuProps()} style={menuMultipleStyles}>
         {isOpen &&
           getFilteredItems(items).map((item, index) => (
             <li


### PR DESCRIPTION
Correct a typo in use multiple select documentation page.

**What**:

We want to keep documentation clear without any typos.

**Why**:

Changed the style name from `menuMultipleStlyes` to `menuMultipleStyles` in all possible places.

**How**:

- [x] Find all `menuMultipleStlyes` and change them to `menuMultipleStyles`.

**Checklist**:

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
