### PR TITLE
chore(tests): use expect.toHaveValue in tests

### DIFF
--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -685,7 +685,7 @@ describe('getInputProps', () => {
         keyDownOnInput('Enter')
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toEqual(items[initialHighlightedIndex])
+        expect(input).toHaveValue(items[initialHighlightedIndex])
       })
 
       test('enter selects highlighted item and resets to user defaults', () => {
@@ -697,7 +697,7 @@ describe('getInputProps', () => {
 
         keyDownOnInput('Enter')
 
-        expect(input.value).toEqual(items[defaultHighlightedIndex])
+        expect(input).toHaveValue(items[defaultHighlightedIndex])
         expect(getItems()).toHaveLength(items.length)
         expect(input).toHaveAttribute(
           'aria-activedescendant',
@@ -714,7 +714,7 @@ describe('getInputProps', () => {
 
         keyDownOnInput('Enter', {keyCode: 229})
 
-        expect(input.value).toEqual('')
+        expect(input).toHaveValue('')
         expect(getItems()).toHaveLength(items.length)
         expect(input).toHaveAttribute(
           'aria-activedescendant',
@@ -723,7 +723,7 @@ describe('getInputProps', () => {
 
         keyDownOnInput('Enter')
 
-        expect(input.value).toEqual(items[2])
+        expect(input).toHaveValue(items[2])
         expect(getItems()).toHaveLength(0)
         expect(input).not.toHaveAttribute('aria-activedescendant')
       })
@@ -764,7 +764,7 @@ describe('getInputProps', () => {
         userEvent.tab()
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toEqual(items[initialHighlightedIndex])
+        expect(input).toHaveValue(items[initialHighlightedIndex])
       })
 
       test('shift+tab it closes the menu', () => {
@@ -784,7 +784,7 @@ describe('getInputProps', () => {
         userEvent.tab()
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toEqual(items[initialHighlightedIndex])
+        expect(input).toHaveValue(items[initialHighlightedIndex])
       })
 
       test("other than the ones supported don't affect anything", () => {
@@ -799,7 +799,7 @@ describe('getInputProps', () => {
         keyDownOnInput('Control')
 
         expect(input).toHaveFocus()
-        expect(input.value).toEqual(items[highlightedIndex])
+        expect(input).toHaveValue(items[highlightedIndex])
         expect(input).toHaveAttribute(
           'aria-activedescendant',
           defaultIds.getItemId(highlightedIndex),
@@ -819,7 +819,7 @@ describe('getInputProps', () => {
         blurInput()
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toEqual(items[initialHighlightedIndex])
+        expect(input).toHaveValue(items[initialHighlightedIndex])
       })
 
       test('the open menu will be closed and highlighted item will not be selected if the highlight by mouse leaves the menu', () => {
@@ -833,7 +833,7 @@ describe('getInputProps', () => {
         blurInput()
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toEqual('')
+        expect(input).toHaveValue('')
       })
 
       test('the value in the input will stay the same', async () => {

--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -208,7 +208,7 @@ describe('getItemProps', () => {
     })
 
     describe('on click', () => {
-      test('it selects the item and moves focus on input', () => {
+      test('it selects the item', () => {
         const index = 1
         const {input, getItems, clickOnItemAtIndex} = renderCombobox({
           initialIsOpen: true,

--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -208,7 +208,7 @@ describe('getItemProps', () => {
     })
 
     describe('on click', () => {
-      test('it selects the item', () => {
+      test('it selects the item and moves focus on input', () => {
         const index = 1
         const {input, getItems, clickOnItemAtIndex} = renderCombobox({
           initialIsOpen: true,
@@ -217,7 +217,7 @@ describe('getItemProps', () => {
         clickOnItemAtIndex(index)
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toEqual(items[index])
+        expect(input).toHaveValue(items[index])
       })
 
       test('it selects the item and resets to user defined defaults', () => {
@@ -230,7 +230,7 @@ describe('getItemProps', () => {
 
         clickOnItemAtIndex(index)
 
-        expect(input.value).toEqual(items[index])
+        expect(input).toHaveValue(items[index])
         expect(getItems()).toHaveLength(items.length)
         expect(input).toHaveAttribute(
           'aria-activedescendant',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Use `toHaveValue` from the jest dom extended expect
<!-- Why are these changes necessary? -->

**Why**:
Make tests easier tor read and understand.
<!-- How were these changes implemented? -->

**How**:
Replace `expect(input.value).toEqual` with `expect(input).toHaveValue`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
