### PR TITLE
fix(useCombobox): focus input after selection by click

### DIFF
--- a/cypress/integration/useCombobox.js
+++ b/cypress/integration/useCombobox.js
@@ -1,0 +1,15 @@
+describe('useCombobox', () => {
+  before(() => {
+    cy.visit('/')
+    cy.findByText(/^Tests$/).click()
+    cy.findByText(/^useCombobox$/, {
+      selector: '[href="/tests/use-combobox"]',
+    }).click()
+  })
+
+  it('should keep focus on the input when selecting by click', () => {
+    cy.findByTestId('combobox-toggle-button').click()
+    cy.findByTestId('downshift-item-0').click()
+    cy.findByTestId('combobox-input').should('have.focus')
+  })
+})

--- a/docs/tests/useCombobox.js
+++ b/docs/tests/useCombobox.js
@@ -1,0 +1,59 @@
+import React, {useState} from 'react'
+import {useCombobox} from '../../src'
+import {items, menuStyles, comboboxStyles} from '../utils'
+
+export default function DropdownCombobox() {
+  const [inputItems, setInputItems] = useState(items)
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    getComboboxProps,
+    highlightedIndex,
+    getItemProps,
+  } = useCombobox({
+    items: inputItems,
+    onInputValueChange: ({inputValue}) => {
+      setInputItems(
+        items.filter(item =>
+          item.toLowerCase().startsWith(inputValue.toLowerCase()),
+        ),
+      )
+    },
+  })
+  return (
+    <div>
+      <label {...getLabelProps()}>Choose an element:</label>
+      <div style={comboboxStyles} {...getComboboxProps()}>
+        <input {...getInputProps()} data-testid="combobox-input" />
+        <button
+          data-testid="combobox-toggle-button"
+          {...getToggleButtonProps()}
+          aria-label="toggle menu"
+        >
+          &#8595;
+        </button>
+      </div>
+      <ul {...getMenuProps()} style={menuStyles}>
+        {isOpen &&
+          inputItems.map((item, index) => (
+            <li
+              style={
+                highlightedIndex === index ? {backgroundColor: '#bde4ff'} : {}
+              }
+              key={`${item}${index}`}
+              {...getItemProps({
+                item,
+                index,
+                'data-testid': `downshift-item-${index}`,
+              })}
+            >
+              {item}
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/docs/tests/useCombobox.mdx
+++ b/docs/tests/useCombobox.mdx
@@ -1,0 +1,11 @@
+---
+name: useCombobox
+route: /tests/use-combobox
+menu: Tests
+---
+
+import DropdownCombobox from './useCombobox'
+
+# Combobox with useCombobox
+
+<DropdownCombobox />

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -328,6 +328,10 @@ function useCombobox(userProps = {}) {
           type: stateChangeTypes.ItemClick,
           index,
         })
+
+        if (inputRef.current) {
+          inputRef.current.focus()
+        }
       }
 
       return {


### PR DESCRIPTION
**What**:
Focus the `input` after item click
<!-- Why are these changes necessary? -->

**Why**:
To have consistency with Downshift behavior and other libraries.
Fixes https://github.com/downshift-js/downshift/issues/1014.
<!-- How were these changes implemented? -->

**How**:
Use `inputRef.current.focus` after the dispatch.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
