### PR TITLE
docs(hooks): improve playgrounds and links

### DIFF
--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -17,6 +17,7 @@ import {
   Avatar,
 } from '@material-ui/core'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import Frame, { FrameContextConsumer } from 'react-frame-component'
 import {useCombobox} from '../../src'
 import {
   items,
@@ -73,8 +74,7 @@ according to the input value. The getter props are used as follows:
 | `selectedItem`         | `<button>` | Used to style the selected item.                                                             |
 
 For a complete documentation on all the returned props, hook props and more
-information check out the
-[Github Page](https://github.com/downshift-js/downshift/tree/master/src/hooks/useCombobox).
+information check out the [Github Page][use-combobox-github].
 
 ## Basic Usage
 
@@ -86,7 +86,7 @@ with the widget. Most importantly, the `<input>` needs to be contained by the
 combobox `<div>` and the `<ul>` needs to be at the same level with the combobox
 `<div>`.
 
-[CodeSandbox](https://codesandbox.io/s/usecombobox-usage-evufg)
+[CodeSandbox for basic usage example][code-sandbox-basic-usage].
 
 <Playground>
   {() => {
@@ -179,7 +179,7 @@ string equialent of each item object, so our prop will be passed as
 `Escape` key is also considered an element change, we will return an empty
 string in this case.
 
-[CodeSandbox](https://codesandbox.io/s/usecombobx-ui-libraries-materialui-8jfx1)
+[CodeSandbox for MaterialUI usage example][code-sandbox-material-ui-usage].
 
 <Playground>
   {() => {
@@ -273,7 +273,7 @@ The example below shows how to control `selectedItem`. Both comboboxes share the
 same `selectedItem` reference, and changing it in one of the dropdowns will
 update the value in the other one as well.
 
-[CodeSandbox](https://codesandbox.io/s/usecombobox-variations-controlling-state-wfr1j)
+[CodeSandbox for controlling state example][code-sandbox-controlling-state].
 
 <Playground>
   {() => {
@@ -372,7 +372,7 @@ the new value along with the rest of the changes. We will also uppercase the
 
 In all other state change types, we return `Downshift` default changes.
 
-[CodeSandbox](https://codesandbox.io/s/usecombobox-variations-state-reducer-x7feb)
+[CodeSandbox for state reducer example][code-sandbox-state-reducer].
 
 <Playground>
   {() => {
@@ -470,36 +470,75 @@ hook behave unexpectedly. For example, when using `react-frame-component` to
 produce an `iframe` container, we should pass its `window` object to the hook
 like shown below.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6) (with `useSelect`
-but same concepts apply).
+[CodeSandbox for custom window example][code-sandbox-custom-window].
 
-```js
-import React from 'react';
-import { render } from 'react-dom';
-import { useCombobox } from 'downshift';
-import Frame, { FrameContextConsumer } from 'react-frame-component';
-import { items } from './utils'
-
-function DropdownCombobox({ environment }) {
-  // use the environment prop to pass the custom iframe window to useCombobox.
-  useCombobox({ items, environment });
-  return (
-    // your combobox here.
-  )
-}
-
-render(
-  <Frame style={{ height: 300 }}>
-    <FrameContextConsumer>
-      {// get the window object from the context.
-      ({ document, window }) => (
-        // pass window to the combobox component as the environment prop.
-        <DropdownCombobox environment={window} />
-      )}
-    </FrameContextConsumer>
-  </Frame>,
-  document.getElementById("root")
-```
+<Playground>
+  {() => {
+    // import React, { useState } from 'react'
+    // import Frame, { FrameContextConsumer } from 'react-frame-component'
+    // import { useSelect } from 'downshift'
+    // import { items, menuStyles, comboboxStyles } from './utils'
+    function DropdownCombobox() {
+      const [inputItems, setInputItems] = useState(items);
+      const {
+        isOpen,
+        getToggleButtonProps,
+        getLabelProps,
+        getMenuProps,
+        getInputProps,
+        getComboboxProps,
+        highlightedIndex,
+        getItemProps
+      } = useCombobox({
+        items: inputItems,
+        onInputValueChange: ({ inputValue }) => {
+          setInputItems(
+            items.filter(item =>
+              item.toLowerCase().startsWith(inputValue.toLowerCase())
+            )
+          );
+        }
+      });
+      return (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <div style={comboboxStyles} {...getComboboxProps()}>
+            <input {...getInputProps()} />
+            <button {...getToggleButtonProps()} aria-label="toggle menu">
+              &#8595;
+            </button>
+          </div>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              inputItems.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index ? { backgroundColor: "#bde4ff" } : {}
+                  }
+                  key={`${item}${index}`}
+                  {...getItemProps({ item, index })}
+                >
+                  {item}
+                </li>
+              ))}
+          </ul>
+        </div>
+      );
+    }
+    return (
+      <Frame style={{ height: 250, width: 400 }}>
+        <FrameContextConsumer>
+          {// Callback is invoked with iframe's window and document instances
+            ({ document, window }) => (
+              // Render Children
+              <DropdownCombobox environment={window} />
+            )
+          }
+        </FrameContextConsumer>
+      </Frame>
+    )
+  }}
+</Playground>
 
 ## Basic Multiple Selection
 
@@ -520,6 +559,8 @@ also to keep the `highlightedIndex` to be the most recent selected item.
 
 In order to visually illustrate the selection, we render a checkbox before each
 of them and check only the ones that are selected.
+
+[CodeSandbox for basic multiple selection example][code-sandbox-basic-multiple-selection].
 
 <Playground>
   {() => {
@@ -637,30 +678,96 @@ the selection by clicking on the custom selection clearing button. We use the
 `openMenu` and `selectItem` action props in order to achieve these custom
 behaviors.
 
-[CodeSandbox](https://codesandbox.io/s/usecombobox-action-props-kzwos)
+[CodeSandbox for action props example][code-sandbox-action-props].
 
-```jsx
-import React from 'react';
-import { useCombobox } from 'downshift';
-import { items } from './utils'
-
-function DropdownCombobox() {
-  const {getInputProps, getMenuProps, isOpen, openMenu, selectItem} = useCombobox({items});
-  return (
-    <div>
-      {/* label and combobox container. */}
-      <input {...getInputProps({onFocus: () => { openMenu() }})} />
-      <button tabindex={-1} onClick={() => { selectItem(null) }} aria-label="clear selection">
-        &#215;
-      </button>
-      {/* toggle button. */}
-      <ul {...getMenuProps()}>
-        {isOpen && items.map((map, index) => /* render items when isOpen is true. */)}
-      </ul>
-    </div>
-  )
-}
-```
+<Playground>
+  {() => {
+    // import React, { useState } from 'react'
+    // import { useCombobox } from 'downshift'
+    // import { items, menuStyles, comboboxStyles } from './utils'
+    function DropdownCombobox() {
+      const [inputItems, setInputItems] = useState(items);
+      const {
+        isOpen,
+        getToggleButtonProps,
+        getLabelProps,
+        getMenuProps,
+        getInputProps,
+        getComboboxProps,
+        highlightedIndex,
+        getItemProps,
+        openMenu,
+        selectItem
+      } = useCombobox({
+        items: inputItems,
+        onInputValueChange: ({ inputValue }) => {
+          setInputItems(
+            items.filter(item =>
+              item.toLowerCase().startsWith(inputValue.toLowerCase())
+            )
+          );
+        }
+      });
+      return (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <div style={comboboxStyles} {...getComboboxProps()}>
+            <input
+              {...getInputProps({
+                onFocus: () => {
+                  openMenu();
+                }
+              })}
+            />
+            <button
+              tabindex={-1}
+              onClick={() => {
+                selectItem(null);
+              }}
+              aria-label="clear selection"
+            >
+              &#215;
+            </button>
+            <button {...getToggleButtonProps()} aria-label="toggle menu">
+              &#8595;
+            </button>
+          </div>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              inputItems.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index ? { backgroundColor: "#bde4ff" } : {}
+                  }
+                  key={`${item}${index}`}
+                  {...getItemProps({ item, index })}
+                >
+                  {item}
+                </li>
+              ))}
+          </ul>
+        </div>
+      );
+    }
+    return <DropdownCombobox />
+  }}
+</Playground>
 
 [combobox-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
+[use-combobox-github]:
+  https://github.com/downshift-js/downshift/tree/master/src/hooks/useCombobox
+[code-sandbox-basic-usage]:
+  https://codesandbox.io/s/usecombobox-usage-evufg
+[code-sandbox-material-ui-usage]:
+  https://codesandbox.io/s/usecombobx-ui-libraries-materialui-8jfx1
+[code-sandbox-controlling-state]:
+  https://codesandbox.io/s/usecombobox-variations-controlling-state-wfr1j
+[code-sandbox-state-reducer]:
+  https://codesandbox.io/s/usecombobox-variations-state-reducer-x7feb
+[code-sandbox-custom-window]:
+  https://codesandbox.io/s/usecombobox-iframe-n27ii
+[code-sandbox-basic-multiple-selection]:
+  https://codesandbox.io/s/usecombobox-usage-x2hsf
+[code-sandbox-action-props]:
+  https://codesandbox.io/s/usecombobox-action-props-kzwos

--- a/docs/hooks/useMultipleSelection.mdx
+++ b/docs/hooks/useMultipleSelection.mdx
@@ -65,8 +65,7 @@ occuring while the dropdown is open. The returned props are used as follows:
 | `removeSelectedItem`   | `<span>` icon           | Called on `X` icon click, removes item from selection.                                    |
 
 For a complete documentation on all the returned props, hook props and more
-information check out the
-[Github Page](https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection).
+information check out the [Github Page][use-multiple-selection-github].
 
 ## Usage with combobox
 
@@ -81,7 +80,7 @@ handler. Items are added using the `addSelectedItem` function inside the
 `useCombobox` and pass a `null` value since `useMultipleSelection` will handle
 the items selection in this case.
 
-[CodeSandbox](https://codesandbox.io/s/usemultipleselection-combobox-usage-ft8zd)
+[CodeSandbox for combobox usage example][code-sandbox-combobox-usage].
 
 <Playground>
   {() => {
@@ -208,7 +207,7 @@ use the basic `useSelect` example and add the selected items as `<span>`
 elements. Custom components from UI libraries can be used as well, since the UI
 is up to the developer.
 
-[CodeSandbox](https://codesandbox.io/s/usemultipleselection-select-usage-x4p1j)
+[CodeSandbox for select usage example][code-sandbox-select-usage].
 
 <Playground>
   {() => {
@@ -314,3 +313,10 @@ is up to the developer.
     return <DropdownMultipleSelect />
   }}
 </Playground>
+
+[use-multiple-selection-github]:
+  https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection
+[code-sandbox-combobox-usage]:
+  https://codesandbox.io/s/usemultipleselection-combobox-usage-ft8zd
+[code-sandbox-select-usage]:
+  https://codesandbox.io/s/usemultipleselection-select-usage-x4p1j

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -16,6 +16,7 @@ import {
   ListItemAvatar,
   Avatar,
 } from '@material-ui/core'
+import Frame, { FrameContextConsumer } from 'react-frame-component'
 import {useSelect} from '../../src'
 import {items, menuStyles, itemsAsObjects, useStyles, checkboxLabelStyles} from '../utils'
 
@@ -60,18 +61,16 @@ props and state variables it returns. These are used in the following way:
 | `selectedItem`         | `<button>` | Used to render text equivalent of selected item on the button.                 |
 
 For a complete documentation on all the returned props, hook props and more
-information check out the
-[Github Page](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect).
+information check out the [Github Page][use-select-github].
 
 ## Basic Usage
 
 A custom `<select>` element can be created with HTML elements such as:
 `<label>`, `<ul>`, `<li>` and `<button>`. Using other HTML elements to create a
 custom `<select>` is useful for the custom styling of the widget, since the
-`<select>` is notoriously difficult to style:
-https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
+`<select>` is notoriously [difficult to style][mdn-select].
 
-[CodeSandbox](https://codesandbox.io/s/useselect-usage-53qfj)
+[CodeSandbox for basic usage example][code-sandbox-basic-usage].
 
 <Playground>
   {() => {
@@ -142,13 +141,13 @@ selectionmessage that will occur on every item selection:
 `$ItemString has been selected`. `item.primary` is chosen to be the string
 equialent of each item object.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-ui-libraries-materialui-fls5o)
+[CodeSandbox for MaterialUI usage example][code-sandbox-material-ui-usage].
 
 <Playground>
   {() => {
     // import React from 'react'
     // import { useSelect } from 'downshift'
-    // import { items: itemsAsObjects, useStyles } from './utils'
+    // import { items, useStyles } from './utils'
     // import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
     // import {Button, FormLabel, List, ListItem, ListItemText } from '@material-ui/core'
     function MaterialDropdownSelect() {
@@ -162,10 +161,7 @@ equialent of each item object.
         getMenuProps,
         highlightedIndex,
         getItemProps,
-      } = useSelect({
-        items: itemsAsObjects,
-        itemToString,
-      })
+      } = useSelect({items, itemToString})
       return (
         <div>
           <FormLabel {...getLabelProps()}>Choose an employee:</FormLabel>
@@ -220,7 +216,7 @@ The example below shows how to control `selectedItem`. Both select elements
 share the same `selectedItem` reference, and changing it in one of the dropdowns
 will update the value in the other one as well.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-variations-controlling-state-8tvwj)
+[CodeSandbox for controlling state example][code-sandbox-controlling-state].
 
 <Playground>
   {() => {
@@ -306,7 +302,7 @@ index, and return it without any other changes.
 
 In all other state change types, we return `useSelect` default changes.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-variations-state-reducer-ysc2r)
+[CodeSandbox for state reducer example][code-sandbox-state-reducer].
 
 <Playground>
   {() => {
@@ -381,34 +377,59 @@ hook behave unexpectedly. For example, when using `react-frame-component` to
 produce an `iframe` container, we should pass its `window` object to the hook
 like shown below.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-iframe-l40g6)
+[CodeSandbox for custom window example][code-sandbox-custom-window].
 
-```js
-import React from 'react';
-import { render } from 'react-dom';
-import { useSelect } from 'downshift';
-import Frame, { FrameContextConsumer } from 'react-frame-component';
-
-function DropdownSelect({ environment }) {
-  // use the environment prop to pass the custom iframe window to useSelect.
-  useSelect({ items, environment });
-  return (
-    // your select here.
-  )
-}
-
-render(
-  <Frame style={{ height: 300 }}>
-    <FrameContextConsumer>
-      {// get the window object from the context.
-      ({ document, window }) => (
-        // pass it to the select component as prop.
-        <DropdownSelect environment={window} />
-      )}
-    </FrameContextConsumer>
-  </Frame>,
-  document.getElementById("root")
-```
+<Playground>
+  {() => {
+    // import React, { useState } from 'react'
+    // import Frame, { FrameContextConsumer } from 'react-frame-component'
+    // import { useSelect } from 'downshift'
+    // import { items, menuStyles } from './utils'
+    function DropdownSelect({ environment }) {
+      const {
+        isOpen,
+        selectedItem,
+        getToggleButtonProps,
+        getLabelProps,
+        getMenuProps,
+        highlightedIndex,
+        getItemProps
+      } = useSelect({ items, environment });
+      return (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <button {...getToggleButtonProps()}>{selectedItem || "Elements"}</button>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              items.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index ? { backgroundColor: "#bde4ff" } : {}
+                  }
+                  key={`${item}${index}`}
+                  {...getItemProps({ item, index })}
+                >
+                  {item}
+                </li>
+              ))}
+          </ul>
+        </div>
+      );
+    }
+    return (
+      <Frame style={{ height: 250, width: 400 }}>
+        <FrameContextConsumer>
+          {// Callback is invoked with iframe's window and document instances
+            ({ document, window }) => (
+              // Render Children
+              <DropdownSelect environment={window} />
+            )
+          }
+        </FrameContextConsumer>
+      </Frame>
+    )
+  }}
+</Playground>
 
 ## Basic Multiple selection
 
@@ -430,11 +451,13 @@ also to keep the `highlightedIndex` to be the most recent selected item.
 In order to visually illustrate the selection, we render a checkbox before each
 of them and check only the ones that are selected.
 
+[CodeSandbox for basic multiple selection example][code-sandbox-basic-multiple-selection].
+
 <Playground>
   {() => {
     // import React, { useState } from 'react'
-    // import { useCombobox } from 'downshift'
-    // import { items, menuStyles, comboboxStyles } from './utils'
+    // import { useSelect } from 'downshift'
+    // import { items, menuStyles } from './utils'
     function stateReducer(state, actionAndChanges) {
       const {changes, type} = actionAndChanges
       switch (type) {
@@ -528,43 +551,84 @@ the selection by clicking on the custom selection clearing button. We use the
 `openMenu` and `selectItem` action props in order to achieve these custom
 behaviors.
 
-[CodeSandbox](https://codesandbox.io/s/useselect-action-props-zljdg)
+[CodeSandbox for action props example][code-sandbox-action-props].
 
-```jsx
-import React from 'react';
-import { useCombobox } from 'downshift';
-import { items } from './utils'
-
-function DropdownCombobox() {
-  const {getInputProps, getMenuProps, isOpen, openMenu, selectItem} = useSelect({items});
-  return (
-    <div>
-      {/* label */}
-      <button
-        {...getToggleButtonProps({
-          onMouseEnter: () => {
-            openMenu()
-          }
-        })}
-      >
-        {selectedItem || "Elements"}
-      </button>
-      <button
-        tabindex={-1}
-        onClick={() => {
-          selectItem(null)
-        }}
-        aria-label="clear selection"
-      >
-        &#215;
-      </button>
-      <ul {...getMenuProps()}>
-        {isOpen && items.map((map, index) => /* render items when isOpen is true. */)}
-      </ul>
-    </div>
-  )
-}
-```
+<Playground>
+  {() => {
+    // import React from 'react'
+    // import { useSelect } from 'downshift'
+    // import { items, menuStyles } from './utils'
+    function DropdownSelect() {
+      const {
+        isOpen,
+        selectedItem,
+        getToggleButtonProps,
+        getLabelProps,
+        getMenuProps,
+        highlightedIndex,
+        getItemProps,
+        openMenu,
+        selectItem
+      } = useSelect({ items });
+      return (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <button
+            {...getToggleButtonProps({
+              onMouseEnter: () => {
+                openMenu();
+              }
+            })}
+          >
+            {selectedItem || "Elements"}
+          </button>
+          <button
+            tabindex={-1}
+            onClick={() => {
+              selectItem(null);
+            }}
+            aria-label="clear selection"
+          >
+            &#215;
+          </button>
+          <ul {...getMenuProps()} style={menuStyles}>
+            {isOpen &&
+              items.map((item, index) => (
+                <li
+                  style={
+                    highlightedIndex === index ? { backgroundColor: "#bde4ff" } : {}
+                  }
+                  key={`${item}${index}`}
+                  {...getItemProps({ item, index })}
+                >
+                  {item}
+                </li>
+              ))}
+          </ul>
+        </div>
+      );
+    }
+    return <DropdownSelect />
+  }}
+</Playground>
 
 [select-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html
+[mdn-select]:
+  https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
+[use-select-github]:
+  https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect
+[code-sandbox-basic-usage]:
+  https://codesandbox.io/s/useselect-usage-53qfj
+[code-sandbox-material-ui-usage]:
+  https://codesandbox.io/s/useselect-ui-libraries-materialui-fls5o
+[code-sandbox-controlling-state]:
+  https://codesandbox.io/s/useselect-variations-controlling-state-8tvwj
+[code-sandbox-state-reducer]:
+  https://codesandbox.io/s/useselect-variations-state-reducer-ysc2r
+[code-sandbox-custom-window]:
+  https://codesandbox.io/s/useselect-iframe-l40g6
+[code-sandbox-basic-multiple-selection]:
+  https://codesandbox.io/s/useselect-basic-multiple-selection-4lj25
+[code-sandbox-action-props]:
+  https://codesandbox.io/s/useselect-action-props-zljdg

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -381,7 +381,7 @@ like shown below.
 
 <Playground>
   {() => {
-    // import React, { useState } from 'react'
+    // import React from 'react'
     // import Frame, { FrameContextConsumer } from 'react-frame-component'
     // import { useSelect } from 'downshift'
     // import { items, menuStyles } from './utils'

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "preact": "^10.4.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-frame-component": "^4.1.2",
     "react-native": "^0.62.2",
     "react-test-renderer": "^16.13.1",
     "rollup-plugin-babel": "^4.4.0",


### PR DESCRIPTION
**What**:

Have playgrounds for all examples and have links at the bottom of the docsite.

**Why**:

Fixes https://github.com/downshift-js/downshift/issues/1081.

**How**:

Add sandboxes linked to the playgrounds, for each example, and move all links to the end of the page.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
