### PR TITLE
fix(useCombobox): navigating up if all items are disabled

### DIFF
--- a/src/__tests__/utils.getNextWrappingIndex.js
+++ b/src/__tests__/utils.getNextWrappingIndex.js
@@ -223,3 +223,21 @@ test('should skip disabled and not wrap to first if circular when reaching last'
     ),
   ).toEqual(1)
 })
+
+test('should not select any if all disabled when arrow up', () => {
+  const moveAmount = -1
+  const baseIndex = -1
+  const itemCount = 3
+  const getItemNodeFromIndex = () => ({hasAttribute: () => true})
+  const circular = true
+
+  expect(
+    getNextWrappingIndex(
+      moveAmount,
+      baseIndex,
+      itemCount,
+      getItemNodeFromIndex,
+      circular,
+    ),
+  ).toEqual(-1)
+})

--- a/src/utils.js
+++ b/src/utils.js
@@ -342,7 +342,11 @@ function getNextWrappingIndex(
     circular,
   )
 
-  return nonDisabledNewIndex === -1 ? baseIndex : nonDisabledNewIndex
+  if (nonDisabledNewIndex === -1) {
+    return baseIndex >= itemCount ? -1 : baseIndex
+  }
+  
+  return nonDisabledNewIndex
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Prevent crash if all items are disabled and a user presses "Arrow Up"

**Why**:

To keep Downshift working
Fix #961 

**How**:

Return "-1" as next selecting index if there is no item to select

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
