### PR TITLE
docs(useCombobox): fix the default value for circularNavigation

### DIFF
--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -490,7 +490,7 @@ for downshift.
 
 ### circularNavigation
 
-> `boolean` | defaults to `false`
+> `boolean` | defaults to `true`
 
 Controls the circular keyboard navigation between items. If set to `true`, when
 first item is highlighted, the Arrow Up will move highlight to the last item,


### PR DESCRIPTION
**What**:

Change in the Readme the default value for `circularNavigation` from `false` to `true` in order to correctly document the prop.

**Why**:

Fixes https://github.com/downshift-js/downshift/issues/1084.

**How**:

Readme change.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
