### PR TITLE
chore(TS): accept null for selectedItem

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -92,7 +92,7 @@ export interface A11yStatusMessageOptions<Item> {
   previousResultCount: number
   resultCount: number
   highlightedItem: Item
-  selectedItem: Item
+  selectedItem: Item | null
 }
 
 export interface StateChangeOptions<Item>
@@ -236,9 +236,9 @@ export function resetIdCounter(): void
 
 export interface UseSelectState<Item> {
   highlightedIndex: number
-  selectedItem: Item
+  selectedItem: Item | null
   isOpen: boolean
-  keySoFar: string
+  inputValue: string
 }
 
 export enum UseSelectStateChangeTypes {
@@ -279,9 +279,9 @@ export interface UseSelectProps<Item> {
   isOpen?: boolean
   initialIsOpen?: boolean
   defaultIsOpen?: boolean
-  selectedItem?: Item
-  initialSelectedItem?: Item
-  defaultSelectedItem?: Item
+  selectedItem?: Item | null
+  initialSelectedItem?: Item | null
+  defaultSelectedItem?: Item | null
   id?: string
   labelId?: string
   menuId?: string
@@ -374,7 +374,7 @@ export const useSelect: UseSelectInterface
 
 export interface UseComboboxState<Item> {
   highlightedIndex: number
-  selectedItem: Item
+  selectedItem: Item | null
   isOpen: boolean
   inputValue: string
 }
@@ -414,9 +414,9 @@ export interface UseComboboxProps<Item> {
   isOpen?: boolean
   initialIsOpen?: boolean
   defaultIsOpen?: boolean
-  selectedItem?: Item
-  initialSelectedItem?: Item
-  defaultSelectedItem?: Item
+  selectedItem?: Item | null
+  initialSelectedItem?: Item | null
+  defaultSelectedItem?: Item | null
   inputValue?: string
   initialInputValue?: string
   defaultInputValue?: string


### PR DESCRIPTION
**What**:

Accept `null` for `selectedItem` in the TS typings. Also fixed an issue by replacing `keysSoFar` which was not used anymore in `useSelect`.

**Why**:

Fixes https://github.com/downshift-js/downshift/issues/1088.

**How**:

Add `| null` to `selectedItem` (state and prop), `defaultSelectedItem` and `initialSelectedItem` for `useSelect` and `useCombobox`. 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] TypeScript Types
- [ ] Flow Types N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
