### PR TITLE
types: expand selectedItem to include null

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -279,7 +279,7 @@ export interface UseSelectProps<Item> {
   isOpen?: boolean
   initialIsOpen?: boolean
   defaultIsOpen?: boolean
-  selectedItem?: Item
+  selectedItem?: Item | null
   initialSelectedItem?: Item
   defaultSelectedItem?: Item
   id?: string
@@ -414,7 +414,7 @@ export interface UseComboboxProps<Item> {
   isOpen?: boolean
   initialIsOpen?: boolean
   defaultIsOpen?: boolean
-  selectedItem?: Item
+  selectedItem?: Item | null
   initialSelectedItem?: Item
   defaultSelectedItem?: Item
   inputValue?: string


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Expands the type definition of `selectedItem` in both the `useSelect` and `useCombobox` interfaces so that TS developers can effectively control their downshift instance without having to suppress warnings and compilation errors.

Note that this change isn't necessary (at least I don't think) for `useMultipleSelection` since passing an empty array effectively controls the Downshift.

**Why**:
https://github.com/downshift-js/downshift/issues/1088

As per the docs, `selectedItem` can be either:

- A value, resulting in a **controlled** Downshift
- Null, resulting in a **controlled** Downshift
- Undefined, resulting in an **uncontrolled** Downshift

Up to this point, that second state wasn't possible to achieve in TS land due to type errors.

<!-- How were these changes implemented? -->

**How**:

Expanded the type definition to include null.

<!-- Have you done all of these things?  -->

**Checklist**:
I'm not sure which of these are applicable 🤔 

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types 
- [ ] Ready to be merged
