### PR TITLE
docs(useCombobox): proposal to add button type "button"

### DIFF
--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -120,7 +120,7 @@ combobox `<div>` and the `<ul>` needs to be at the same level with the combobox
           <label {...getLabelProps()}>Choose an element:</label>
           <div style={comboboxStyles} {...getComboboxProps()}>
             <input {...getInputProps()} />
-            <button {...getToggleButtonProps()} aria-label="toggle menu">
+            <button type="button" {...getToggleButtonProps()} aria-label="toggle menu">
               &#8595;
             </button>
           </div>
@@ -309,7 +309,7 @@ update the value in the other one as well.
           <label {...getLabelProps()}>Choose an element:</label>
           <div style={comboboxStyles} {...getComboboxProps()}>
             <input {...getInputProps()} />
-            <button {...getToggleButtonProps()} aria-label="toggle menu">
+            <button type="button" {...getToggleButtonProps()} aria-label="toggle menu">
               &#8595;
             </button>
           </div>
@@ -434,7 +434,7 @@ In all other state change types, we return `Downshift` default changes.
           <label {...getLabelProps()}>Choose an element:</label>
           <div style={comboboxStyles} {...getComboboxProps()}>
             <input {...getInputProps()} />
-            <button {...getToggleButtonProps()} aria-label="toggle menu">
+            <button type="button" {...getToggleButtonProps()} aria-label="toggle menu">
               &#8595;
             </button>
           </div>
@@ -505,7 +505,7 @@ like shown below.
           <label {...getLabelProps()}>Choose an element:</label>
           <div style={comboboxStyles} {...getComboboxProps()}>
             <input {...getInputProps()} />
-            <button {...getToggleButtonProps()} aria-label="toggle menu">
+            <button type="button" {...getToggleButtonProps()} aria-label="toggle menu">
               &#8595;
             </button>
           </div>
@@ -632,7 +632,7 @@ of them and check only the ones that are selected.
           <label {...getLabelProps()}>Choose an element:</label>
           <div style={comboboxStyles} {...getComboboxProps()}>
             <input placeholder={placeholderText} {...getInputProps()} />
-            <button {...getToggleButtonProps()} aria-label="toggle menu">
+            <button type="button" {...getToggleButtonProps()} aria-label="toggle menu">
               &#8595;
             </button>
           </div>
@@ -729,7 +729,7 @@ behaviors.
             >
               &#215;
             </button>
-            <button {...getToggleButtonProps()} aria-label="toggle menu">
+            <button type="button" {...getToggleButtonProps()} aria-label="toggle menu">
               &#8595;
             </button>
           </div>

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -113,7 +113,7 @@ function DropdownCombobox() {
       <label {...getLabelProps()}>Choose an element:</label>
       <div style={comboboxStyles} {...getComboboxProps()}>
         <input {...getInputProps()} />
-        <button {...getToggleButtonProps()} aria-label={'toggle menu'}>
+        <button type="button" {...getToggleButtonProps()} aria-label={'toggle menu'}>
           &#8595;
         </button>
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This adds a default type of "button" to useCombobox examples. To avoid form automatic submissions.

**Why**:

When copy pasting basic usage examples in a page that has a real form, like when using https://react-hook-form.com/ with downshift, there's a bad behavior: any button within a form has the default type of submit. Which means that every time you click on open, it submits the form.

This is hard to track/debug and could be a timesink for developers.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

- [ ] I wonder if we should change more places or maybe just add a warning as a comment next to every button.
- [ ] Should CodeSandboxes be updated too?

Related: https://github.com/downshift-js/downshift/issues/1063
