### PR TITLE
docs(useCombobox): fix the action example

### DIFF
--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -716,7 +716,9 @@ behaviors.
             <input
               {...getInputProps({
                 onFocus: () => {
-                  openMenu();
+                  if (!isOpen) {
+                    openMenu();
+                  }
                 }
               })}
             />


### PR DESCRIPTION
**What**:

Fixes the action example in the docsite for useCombobox.

**Why**:

Fixes https://github.com/downshift-js/downshift/issues/1100.

**How**:

Checks if isOpen and if true then opens menu.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
