### PR TITLE
downshift v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 <p align="center" style="font-size: 1.2rem;">Primitives to build simple, flexible, WAI-ARIA compliant React
 autocomplete, combobox or select dropdown components.</p>
 
-> [Read the docs](https://downshift-js.com)
-> |
+> [Read the docs](https://downshift-js.com) |
 > [See the intro blog post](https://kentcdodds.com/blog/introducing-downshift-for-react)
 > |
 > [Listen to the Episode 79 of the Full Stack Radio podcast](https://simplecast.com/s/f2e65eaf)
@@ -108,7 +107,6 @@ and `side-effect free`.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -972,9 +970,9 @@ described below.
   work normally). See below for customizing the handlers.
 
 - `Escape`: will clear downshift's state. This means that `highlightedIndex`
-  will be set to the `defaultHighlightedIndex`, the `inputValue` will be set to
-  empty string, `selectedItem` will be set to `null`, and the `isOpen` state
-  will be set to the `defaultIsOpen`.
+  will be set to the `defaultHighlightedIndex` and the `isOpen` state will be
+  set to the `defaultIsOpen`. If `isOpen` is already false, the `inputValue`
+  will be set to an empty string and `selectedItem` will be set to `null`
 
 ### customizing handlers
 
@@ -1426,6 +1424,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -403,12 +403,14 @@ test('enter on an input with an open menu and a highlightedIndex but with IME co
 
   // now it behaves normally
   expect(childrenSpy).toHaveBeenCalledTimes(1)
-  expect(childrenSpy).toHaveBeenCalledWith(expect.objectContaining({
-    selectedItem: colors[0],
-    inputValue: colors[0],
-    isOpen: false,
-    highlightedIndex: null,
-  }))
+  expect(childrenSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      selectedItem: colors[0],
+      inputValue: colors[0],
+      isOpen: false,
+      highlightedIndex: null,
+    }),
+  )
 })
 
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
@@ -451,8 +453,17 @@ test('escape on an input without a selection should reset downshift and close th
   )
 })
 
-test('escape on an input with a selection should reset downshift, clear input and close the menu', () => {
+test('escape on an input with a selection and open should only reset downshift', () => {
+  const {escapeOnInput, childrenSpy} = renderDownshift()
+  escapeOnInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({isOpen: false}),
+  )
+})
+
+test('escape on an input with a selection and closed menu should reset downshift, clear input and close the menu', () => {
   const {escapeOnInput, childrenSpy} = setupDownshiftWithState()
+  escapeOnInput()
   escapeOnInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -27,7 +27,7 @@ import {
   getNextNonDisabledIndex,
   getState,
   isControlledProp,
-  validateControlledUnchanged
+  validateControlledUnchanged,
 } from './utils'
 
 class Downshift extends Component {
@@ -597,8 +597,7 @@ class Downshift extends Component {
       event.preventDefault()
       this.reset({
         type: stateChangeTypes.keyDownEscape,
-        selectedItem: null,
-        inputValue: '',
+        ...(!this.state.isOpen && {selectedItem: null, inputValue: ''}),
       })
     },
   }

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -865,13 +865,16 @@ described below.
 - `Home`: Moves `highlightedIndex` to first position.
 - `Enter`: If there is a highlighted option, it will select it and close the
   menu.
-- `Escape`: It will close the menu if open and will clear selection: the value
-  in the `input` and the item stored as `selectedItem`.
-- `Blur(Tab, Shift+Tab, MouseClick outside)`: It will close the menu select the
-  highlighted item if any. In the case of `(Shift+)Tab` the focus will move
-  naturally.
+- `Escape`: It will close the menu if open. If the menu is closed, it will clear
+  selection: the value in the `input` will become an empty string and the item
+  stored as `selectedItem` will become `null`.
+- `Blur(Tab, Shift+Tab)`: It will close the menu and select the highlighted
+  item, if any. The focus will move naturally to the next/previous element in
+  the Tab order.
+- `Blur(mouse click outside)`: It will close the menu without selecting any
+  element, even if there is one highlighted.
 
-  #### Menu
+#### Menu
 
 - `MouseLeave`: Will clear the value of the `highlightedIndex` if it was set.
 

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -661,7 +661,7 @@ describe('getInputProps', () => {
         )
       })
 
-      test('escape it has the menu closed, item removed and focused kept on input', () => {
+      test('escape with menu open has the menu closed and focused kept on input', () => {
         const {keyDownOnInput, input, getItems} = renderCombobox({
           initialIsOpen: true,
           initialHighlightedIndex: 2,
@@ -671,7 +671,21 @@ describe('getInputProps', () => {
         keyDownOnInput('Escape')
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toBe('')
+        expect(input).toHaveValue(items[0])
+        expect(input).toHaveFocus()
+      })
+
+      test('escape with closed menu has item removed and focused kept on input', () => {
+        const {keyDownOnInput, input, getItems} = renderCombobox({
+          initialHighlightedIndex: 2,
+          initialSelectedItem: items[0],
+        })
+
+        input.focus()
+        keyDownOnInput('Escape')
+
+        expect(getItems()).toHaveLength(0)
+        expect(input).toHaveValue('')
         expect(input).toHaveFocus()
       })
 

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -845,13 +845,14 @@ describe('getInputProps', () => {
         await changeInputValue(inputValue)
         blurInput()
 
-        expect(input.value).toBe(inputValue)
+        expect(input).toHaveValue(inputValue)
       })
 
       test('by mouse is not triggered if target is within downshift', () => {
         const stateReducer = jest.fn().mockImplementation(s => s)
         const {input, container} = renderCombobox({
           isOpen: true,
+          highlightedIndex: 0,
           stateReducer,
         })
         document.body.appendChild(container)
@@ -866,8 +867,21 @@ describe('getInputProps', () => {
 
         expect(stateReducer).toHaveBeenCalledTimes(1)
         expect(stateReducer).toHaveBeenCalledWith(
-          expect.objectContaining({}),
-          expect.objectContaining({type: stateChangeTypes.InputBlur}),
+          {
+            highlightedIndex: 0,
+            inputValue: '',
+            isOpen: true,
+            selectedItem: null,
+          },
+          expect.objectContaining({
+            type: stateChangeTypes.InputBlur,
+            changes: {
+              highlightedIndex: -1,
+              inputValue: '',
+              isOpen: false,
+              selectedItem: null,
+            },
+          }),
         )
       })
 
@@ -875,6 +889,7 @@ describe('getInputProps', () => {
         const stateReducer = jest.fn().mockImplementation(s => s)
         const {container, input} = renderCombobox({
           isOpen: true,
+          highlightedIndex: 0,
           stateReducer,
         })
         document.body.appendChild(container)
@@ -890,8 +905,21 @@ describe('getInputProps', () => {
 
         expect(stateReducer).toHaveBeenCalledTimes(1)
         expect(stateReducer).toHaveBeenCalledWith(
-          expect.objectContaining({}),
-          expect.objectContaining({type: stateChangeTypes.InputBlur}),
+          {
+            highlightedIndex: 0,
+            inputValue: '',
+            isOpen: true,
+            selectedItem: null,
+          },
+          expect.objectContaining({
+            type: stateChangeTypes.InputBlur,
+            changes: {
+              highlightedIndex: -1,
+              inputValue: '',
+              isOpen: false,
+              selectedItem: null,
+            },
+          }),
         )
       })
     })
@@ -919,7 +947,7 @@ describe('getInputProps', () => {
         })
         getMenuProps({}, {suppressRefError: true})
         getComboboxProps({}, {suppressRefError: true})
-        
+
         if (firstRender) {
           firstRender = false
           getInputProps({}, {suppressRefError: true})

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -917,6 +917,7 @@ describe('props', () => {
       expect(onSelectedItemChange).toHaveBeenCalledWith(
         expect.objectContaining({
           selectedItem: items[itemIndex],
+          type: stateChangeTypes.ItemClick,
         }),
       )
     })
@@ -981,6 +982,7 @@ describe('props', () => {
       expect(onHighlightedIndexChange).toHaveBeenCalledWith(
         expect.objectContaining({
           highlightedIndex: 0,
+          type: stateChangeTypes.InputKeyDownArrowDown,
         }),
       )
     })
@@ -1058,6 +1060,7 @@ describe('props', () => {
       expect(onIsOpenChange).toHaveBeenCalledWith(
         expect.objectContaining({
           isOpen: false,
+          type: stateChangeTypes.InputKeyDownEscape,
         }),
       )
     })

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -185,6 +185,7 @@ function useCombobox(userProps = {}) {
     () => {
       dispatch({
         type: stateChangeTypes.InputBlur,
+        selectItem: false,
       })
     },
   )
@@ -425,6 +426,7 @@ function useCombobox(userProps = {}) {
         if (!mouseAndTouchTrackersRef.current.isMouseDown) {
           dispatch({
             type: stateChangeTypes.InputBlur,
+            selectItem: true,
           })
         }
       }

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -80,9 +80,11 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.InputKeyDownEscape:
       changes = {
         isOpen: false,
-        selectedItem: null,
         highlightedIndex: -1,
-        inputValue: '',
+        ...(!state.isOpen && {
+          selectedItem: null,
+          inputValue: '',
+        }),
       }
       break
     case stateChangeTypes.InputKeyDownHome:

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -110,11 +110,12 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.InputBlur:
       changes = {
         isOpen: false,
-        ...(state.highlightedIndex >= 0 && {
-          selectedItem: props.items[state.highlightedIndex],
-          inputValue: props.itemToString(props.items[state.highlightedIndex]),
-          highlightedIndex: -1,
-        }),
+        highlightedIndex: -1,
+        ...(state.highlightedIndex >= 0 &&
+          action.selectItem && {
+            selectedItem: props.items[state.highlightedIndex],
+            inputValue: props.itemToString(props.items[state.highlightedIndex]),
+          }),
       }
       break
     case stateChangeTypes.InputChange:
@@ -157,7 +158,7 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.FunctionSelectItem:
       changes = {
         selectedItem: action.selectedItem,
-        inputValue: props.itemToString(action.selectedItem)
+        inputValue: props.itemToString(action.selectedItem),
       }
       break
     case stateChangeTypes.ControlledPropUpdatedSelectedItem:

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -930,6 +930,7 @@ describe('props', () => {
       expect(onSelectedItemChange).toHaveBeenCalledWith(
         expect.objectContaining({
           selectedItem: items[index],
+          type: stateChangeTypes.ItemClick,
         }),
       )
     })
@@ -994,6 +995,7 @@ describe('props', () => {
       expect(onHighlightedIndexChange).toHaveBeenCalledWith(
         expect.objectContaining({
           highlightedIndex: 0,
+          type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
         }),
       )
     })
@@ -1066,6 +1068,7 @@ describe('props', () => {
       expect(onIsOpenChange).toHaveBeenCalledWith(
         expect.objectContaining({
           isOpen: false,
+          type: stateChangeTypes.MenuKeyDownEscape,
         }),
       )
     })

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -22,7 +22,7 @@ function callOnChangeProps(action, state, newState) {
   const changes = {}
 
   Object.keys(state).forEach(key => {
-    invokeOnChangeHandler(key, props, state, newState)
+    invokeOnChangeHandler(key, action, state, newState)
 
     if (newState[key] !== state[key]) {
       changes[key] = newState[key]
@@ -34,14 +34,15 @@ function callOnChangeProps(action, state, newState) {
   }
 }
 
-function invokeOnChangeHandler(key, props, state, newState) {
+function invokeOnChangeHandler(key, action, state, newState) {
+  const {props, type} = action
   const handler = `on${capitalizeString(key)}Change`
   if (
     props[handler] &&
     newState[key] !== undefined &&
     newState[key] !== state[key]
   ) {
-    props[handler](newState)
+    props[handler]({type, ...newState})
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -292,17 +292,32 @@ export interface UseSelectProps<Item> {
     state: UseSelectState<Item>,
     actionAndChanges: UseSelectStateChangeOptions<Item>,
   ) => UseSelectState<Item>
-  onSelectedItemChange?: (changes: Partial<UseSelectState<Item>>) => void
-  onIsOpenChange?: (changes: Partial<UseSelectState<Item>>) => void
-  onHighlightedIndexChange?: (changes: Partial<UseSelectState<Item>>) => void
-  onStateChange?: (changes: Partial<UseSelectState<Item>>) => void
+  onSelectedItemChange?: (changes: UseSelectStateChange<Item>) => void
+  onIsOpenChange?: (changes: UseSelectStateChange<Item>) => void
+  onHighlightedIndexChange?: (changes: UseSelectStateChange<Item>) => void
+  onStateChange?: (changes: UseSelectStateChange<Item>) => void
   environment?: Environment
 }
 
-export interface UseSelectStateChangeOptions<Item> {
+export interface UseSelectStateChangeOptions<Item>
+  extends UseSelectDispatchAction<Item> {
+  changes: Partial<UseSelectState<Item>>
+}
+
+export interface UseSelectDispatchAction<Item> {
   type: UseSelectStateChangeTypes
-  changes: UseSelectState<Item>
-  props: UseSelectProps<Item>
+  getItemNodeFromIndex?: (index: number) => HTMLElement
+  shiftKey?: boolean
+  key?: string
+  index?: number
+  highlightedIndex?: number
+  selectedItem?: Item | null
+  inputValue?: string
+}
+
+export interface UseSelectStateChange<Item>
+  extends Partial<UseSelectState<Item>> {
+  type: UseSelectStateChangeTypes
 }
 
 export interface UseSelectGetMenuPropsOptions
@@ -431,18 +446,32 @@ export interface UseComboboxProps<Item> {
     state: UseComboboxState<Item>,
     actionAndChanges: UseComboboxStateChangeOptions<Item>,
   ) => UseComboboxState<Item>
-  onSelectedItemChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onIsOpenChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onHighlightedIndexChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onStateChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onInputValueChange?: (changes: Partial<UseComboboxState<Item>>) => void
+  onSelectedItemChange?: (changes: UseComboboxStateChange<Item>) => void
+  onIsOpenChange?: (changes: UseComboboxStateChange<Item>) => void
+  onHighlightedIndexChange?: (changes: UseComboboxStateChange<Item>) => void
+  onStateChange?: (changes: UseComboboxStateChange<Item>) => void
+  onInputValueChange?: (changes: UseComboboxStateChange<Item>) => void
   environment?: Environment
 }
 
-export interface UseComboboxStateChangeOptions<Item> {
+export interface UseComboboxStateChangeOptions<Item>
+  extends UseComboboxDispatchAction<Item> {
+  changes: Partial<UseComboboxState<Item>>
+}
+
+export interface UseComboboxDispatchAction<Item> {
+  type: UseSelectStateChangeTypes
+  shiftKey?: boolean
+  getItemNodeFromIndex?: (index: number) => HTMLElement
+  inputValue?: string
+  index?: number
+  highlightedIndex?: number
+  selectedItem?: Item | null
+}
+
+export interface UseComboboxStateChange<Item>
+  extends Partial<UseComboboxState<Item>> {
   type: UseComboboxStateChangeTypes
-  changes: UseComboboxState<Item>
-  props: UseComboboxProps<Item>
 }
 
 export interface UseComboboxGetMenuPropsOptions
@@ -566,13 +595,16 @@ export interface UseMultipleSelectionProps<Item> {
 }
 
 export interface UseMultipleSelectionStateChangeOptions<Item>
-  extends UseMultipleSelectionDispatchAction {
+  extends UseMultipleSelectionDispatchAction<Item> {
   changes: Partial<UseMultipleSelectionState<Item>>
 }
 
-export interface UseMultipleSelectionDispatchAction {
+export interface UseMultipleSelectionDispatchAction<Item> {
   type: UseMultipleSelectionStateChangeTypes
-  [data: string]: any
+  index?: number
+  selectedItem?: Item | null
+  selectedItems?: Item[]
+  activeIndex?: number
 }
 
 export interface UseMultipleSelectionStateChange<Item>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -92,7 +92,7 @@ export interface A11yStatusMessageOptions<Item> {
   previousResultCount: number
   resultCount: number
   highlightedItem: Item
-  selectedItem: Item
+  selectedItem: Item | null
 }
 
 export interface StateChangeOptions<Item>
@@ -236,9 +236,9 @@ export function resetIdCounter(): void
 
 export interface UseSelectState<Item> {
   highlightedIndex: number
-  selectedItem: Item
+  selectedItem: Item | null
   isOpen: boolean
-  keySoFar: string
+  inputValue: string
 }
 
 export enum UseSelectStateChangeTypes {
@@ -279,9 +279,9 @@ export interface UseSelectProps<Item> {
   isOpen?: boolean
   initialIsOpen?: boolean
   defaultIsOpen?: boolean
-  selectedItem?: Item
-  initialSelectedItem?: Item
-  defaultSelectedItem?: Item
+  selectedItem?: Item | null
+  initialSelectedItem?: Item | null
+  defaultSelectedItem?: Item | null
   id?: string
   labelId?: string
   menuId?: string
@@ -374,7 +374,7 @@ export const useSelect: UseSelectInterface
 
 export interface UseComboboxState<Item> {
   highlightedIndex: number
-  selectedItem: Item
+  selectedItem: Item | null
   isOpen: boolean
   inputValue: string
 }
@@ -414,9 +414,9 @@ export interface UseComboboxProps<Item> {
   isOpen?: boolean
   initialIsOpen?: boolean
   defaultIsOpen?: boolean
-  selectedItem?: Item
-  initialSelectedItem?: Item
-  defaultSelectedItem?: Item
+  selectedItem?: Item | null
+  initialSelectedItem?: Item | null
+  defaultSelectedItem?: Item | null
   inputValue?: string
   initialInputValue?: string
   defaultInputValue?: string

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -88,7 +88,7 @@ export interface A11yStatusMessageOptions<Item> {
   highlightedIndex: number | null
   inputValue: string
   isOpen: boolean
-  itemToString: (item: Item) => string
+  itemToString: (item: Item | null) => string
   previousResultCount: number
   resultCount: number
   highlightedItem: Item

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -467,6 +467,7 @@ export interface UseComboboxDispatchAction<Item> {
   index?: number
   highlightedIndex?: number
   selectedItem?: Item | null
+  selectItem?: boolean
 }
 
 export interface UseComboboxStateChange<Item>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -197,7 +197,7 @@ export interface Actions<Item> {
     cb?: Callback,
   ) => void
   // props
-  itemToString: (item: Item) => string
+  itemToString: (item: Item | null) => string
 }
 
 export type ControllerStateAndHelpers<Item> = DownshiftState<Item> &
@@ -269,7 +269,7 @@ export enum UseSelectStateChangeTypes {
 
 export interface UseSelectProps<Item> {
   items: Item[]
-  itemToString?: (item: Item) => string
+  itemToString?: (item: Item | null) => string
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   getA11ySelectionMessage?: (options: A11yStatusMessageOptions<Item>) => string
   circularNavigation?: boolean
@@ -404,7 +404,7 @@ export enum UseComboboxStateChangeTypes {
 
 export interface UseComboboxProps<Item> {
   items: Item[]
-  itemToString?: (item: Item) => string
+  itemToString?: (item: Item | null) => string
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   getA11ySelectionMessage?: (options: A11yStatusMessageOptions<Item>) => string
   circularNavigation?: boolean


### PR DESCRIPTION
**What**:

Update downshift to v6.

**Why**:

Introduce breaking changes that fix the issues below.
Fixes https://github.com/downshift-js/downshift/issues/1088.
Fixes https://github.com/downshift-js/downshift/issues/1015.
Fixes https://github.com/downshift-js/downshift/issues/1010.
Fixes https://github.com/downshift-js/downshift/issues/719.

**How**:

**The list of breaking changes:**

BREAKING CHANGE: Update TS typings for `selectedItem` to accept `null` in both `useSelect` and `useCombobox`.

To migrate to the new change, update your types or code if necessary. `selectedItem`, `defaultSelectedItem` and `initialSelectedItem` now have `Item | null` instead of `Item` type. PR with the changes: https://github.com/downshift-js/downshift/pull/1090


BREAKING CHANGE: Update TS typings for `itemToString` to accept `null` for the `item` parameter, in `useSelect` and `useCombobox` + in `Downshift` where this was missing. `useMultipleSelection` type for `itemToString` stays the same as it can't receive `null` as `item`.

To migrate to the new change, update your types or code if necessary. `itemToString: (item: Item) => string` -> `itemToString: (item: Item | null) => string}`. PR with the changes: https://github.com/downshift-js/downshift/pull/1075 https://github.com/downshift-js/downshift/pull/1105


BREAKING CHANGE: Pass `type` to the onChange (onInputValueChange, onHighlightedIndexChange, onSelectedItemChange, onIsOpenChange) handler parameters, as specified in the documentation. Also updated the TS typings to reflect this + `onStateChange` - the `type` parameter was passed but it was not reflected in the TS types.

To migrate to the new change, update your types or code if necessary, better to view the changes in the PR: https://github.com/downshift-js/downshift/pull/985.


BREAKING BEHAVIOUR [useCombobox]: When an item is highlighted by keyboard and user closes the menu using mouse/touch, the item is not selected anymore. The only selection on Blur happens using either Tab / Shift+Tab. PR with the changes: https://github.com/downshift-js/downshift/pull/1109


BREAKING BEHAVIOUR [useCombobox & downshift]: When pressing Escape and the menu is open, only close the menu. When the menu is closed and there is an item selected and/or text in the input, clear the selectedItem and the inputValue. PR with the changes: https://github.com/downshift-js/downshift/issues/719

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
