### PR TITLE
fix(TS): fix itemToString type in A11yStatusMessageOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -88,7 +88,7 @@ export interface A11yStatusMessageOptions<Item> {
   highlightedIndex: number | null
   inputValue: string
   isOpen: boolean
-  itemToString: (item: Item) => string
+  itemToString: (item: Item | null) => string
   previousResultCount: number
   resultCount: number
   highlightedItem: Item


### PR DESCRIPTION
**What**:

Make item parameter accept null for itemToString in the A11yStatusMessageOptions.

**Why**:

To finish the fixes added by https://github.com/downshift-js/downshift/pull/1075.

**How**:

Change the type for itemToString in A11yStatusMessageOptions.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
