### PR TITLE
fix(useCombobox): fix onSelectedItemChange not triggering with controlled selectedItem in React.StrictMode

### DIFF
--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import {renderHook, act as hooksAct} from '@testing-library/react-hooks'
 import {act} from '@testing-library/react'
 import {renderCombobox, renderUseCombobox} from '../testUtils'
@@ -950,6 +951,23 @@ describe('props', () => {
       rerender({selectedItem})
 
       expect(input).toHaveValue(items[selectionIndex])
+    })
+
+    test('works correctly with the corresponding control prop in strict mode', () => {
+      const onSelectedItemChange = jest.fn()
+      const itemIndex = 0
+      const {clickOnItemAtIndex} = renderCombobox(
+        {selectedItem: null, initialIsOpen: true, onSelectedItemChange},
+        ui => <React.StrictMode>{ui}</React.StrictMode>,
+      )
+
+      clickOnItemAtIndex(itemIndex)
+
+      expect(onSelectedItemChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedItem: items[itemIndex],
+        }),
+      )
     })
 
     test('can have downshift actions executed', () => {

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -1,4 +1,4 @@
-import {useRef} from 'react'
+import {useRef, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {
   generateId,
@@ -102,19 +102,21 @@ export function useControlledReducer(reducer, initialState, props) {
   const [state, dispatch] = useEnhancedReducer(reducer, initialState, props)
 
   // ToDo: if needed, make same approach as selectedItemChanged from Downshift.
-  if (isControlledProp(props, 'selectedItem')) {
-    if (previousSelectedItemRef.current !== props.selectedItem) {
-      dispatch({
-        type: ControlledPropUpdatedSelectedItem,
-        inputValue: props.itemToString(props.selectedItem),
-      })
-    }
+  useEffect(() => {
+    if (isControlledProp(props, 'selectedItem')) {
+      if (previousSelectedItemRef.current !== props.selectedItem) {
+        dispatch({
+          type: ControlledPropUpdatedSelectedItem,
+          inputValue: props.itemToString(props.selectedItem),
+        })
+      }
 
-    previousSelectedItemRef.current =
-      state.selectedItem === previousSelectedItemRef.current
-        ? props.selectedItem
-        : state.selectedItem
-  }
+      previousSelectedItemRef.current =
+        state.selectedItem === previousSelectedItemRef.current
+          ? props.selectedItem
+          : state.selectedItem
+    }
+  })
 
   return [getState(state, props), dispatch]
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Make sure onSelectedItemChange triggers when selectedItem is controlled in strict mode (Fixes #1092)

<!-- Why are these changes necessary? -->

**Why**:

To ensure correct functionality under react strict mode

<!-- How were these changes implemented? -->

**How**:

I found that a side-effect happens during render inside `useControlledReducer` when the `previousSelectedItemRef.current` is set.
In strict mode, because of double rendering, this executes multiple times when an item is clicked and causes a `ControlledPropUpdatedSelectedItem` action to be dispatched even though the prop wasn't updated. This action doesn't update `selectedItem` from the initial value provided through the controlled prop, so the change to it is lost (I'm not 100% sure I understood exactly now this works, but it's my best guess). 

I wrapped the side-effect in `useEffect()` as suggested in the React docs, which fixed the issue - no extra action is triggered and `useEnhancedReducer` picks up the changes and calls `onSelectedItemChange` as expected.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation [N/A]
- [x] Tests
- [ ] TypeScript Types [N/A]
- [ ] Flow Types [N/A]
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
