### PR TITLE
fix: on escape, close menu and clear selection only if menu is closed

### DIFF
--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -403,12 +403,14 @@ test('enter on an input with an open menu and a highlightedIndex but with IME co
 
   // now it behaves normally
   expect(childrenSpy).toHaveBeenCalledTimes(1)
-  expect(childrenSpy).toHaveBeenCalledWith(expect.objectContaining({
-    selectedItem: colors[0],
-    inputValue: colors[0],
-    isOpen: false,
-    highlightedIndex: null,
-  }))
+  expect(childrenSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      selectedItem: colors[0],
+      inputValue: colors[0],
+      isOpen: false,
+      highlightedIndex: null,
+    }),
+  )
 })
 
 test('enter on an input with an open menu and a highlightedIndex selects that item', () => {
@@ -451,8 +453,17 @@ test('escape on an input without a selection should reset downshift and close th
   )
 })
 
-test('escape on an input with a selection should reset downshift, clear input and close the menu', () => {
+test('escape on an input with a selection and open should only reset downshift', () => {
+  const {escapeOnInput, childrenSpy} = renderDownshift()
+  escapeOnInput()
+  expect(childrenSpy).toHaveBeenLastCalledWith(
+    expect.objectContaining({isOpen: false}),
+  )
+})
+
+test('escape on an input with a selection and closed menu should reset downshift, clear input and close the menu', () => {
   const {escapeOnInput, childrenSpy} = setupDownshiftWithState()
+  escapeOnInput()
   escapeOnInput()
   expect(childrenSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -27,7 +27,7 @@ import {
   getNextNonDisabledIndex,
   getState,
   isControlledProp,
-  validateControlledUnchanged
+  validateControlledUnchanged,
 } from './utils'
 
 class Downshift extends Component {
@@ -597,8 +597,7 @@ class Downshift extends Component {
       event.preventDefault()
       this.reset({
         type: stateChangeTypes.keyDownEscape,
-        selectedItem: null,
-        inputValue: '',
+        ...(!this.state.isOpen && {selectedItem: null, inputValue: ''}),
       })
     },
   }

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -661,7 +661,7 @@ describe('getInputProps', () => {
         )
       })
 
-      test('escape it has the menu closed, item removed and focused kept on input', () => {
+      test('escape with menu open has the menu closed and focused kept on input', () => {
         const {keyDownOnInput, input, getItems} = renderCombobox({
           initialIsOpen: true,
           initialHighlightedIndex: 2,
@@ -671,7 +671,21 @@ describe('getInputProps', () => {
         keyDownOnInput('Escape')
 
         expect(getItems()).toHaveLength(0)
-        expect(input.value).toBe('')
+        expect(input).toHaveValue(items[0])
+        expect(input).toHaveFocus()
+      })
+
+      test('escape with closed menu has item removed and focused kept on input', () => {
+        const {keyDownOnInput, input, getItems} = renderCombobox({
+          initialHighlightedIndex: 2,
+          initialSelectedItem: items[0],
+        })
+
+        input.focus()
+        keyDownOnInput('Escape')
+
+        expect(getItems()).toHaveLength(0)
+        expect(input).toHaveValue('')
         expect(input).toHaveFocus()
       })
 
@@ -919,7 +933,7 @@ describe('getInputProps', () => {
         })
         getMenuProps({}, {suppressRefError: true})
         getComboboxProps({}, {suppressRefError: true})
-        
+
         if (firstRender) {
           firstRender = false
           getInputProps({}, {suppressRefError: true})

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -80,9 +80,11 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.InputKeyDownEscape:
       changes = {
         isOpen: false,
-        selectedItem: null,
         highlightedIndex: -1,
-        inputValue: '',
+        ...(!state.isOpen && {
+          selectedItem: null,
+          inputValue: '',
+        }),
       }
       break
     case stateChangeTypes.InputKeyDownHome:
@@ -157,7 +159,7 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.FunctionSelectItem:
       changes = {
         selectedItem: action.selectedItem,
-        inputValue: props.itemToString(action.selectedItem)
+        inputValue: props.itemToString(action.selectedItem),
       }
       break
     case stateChangeTypes.ControlledPropUpdatedSelectedItem:


### PR DESCRIPTION
**What**:

On Escape, if the menu is open, close it. If menu is closed, clear inputValue and selectedItem.

**Why**:

To close https://github.com/downshift-js/downshift/issues/719.

**How**:

In `downshift` revert to the previous behavior before the clear change was introduced.
In `useCombobox` change the reducer to clear `inputValue` and `selectedItem` if `state.isOpen` is false.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
