### PR TITLE
fix(useSelect): ensure the initial selected item is scrolled into view on first open

### DIFF
--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -1007,6 +1007,60 @@ describe('props', () => {
       expect(onHighlightedIndexChange).not.toHaveBeenCalled()
     })
 
+    test('is called on first open when initialSelectedItem is set', () => {
+      const index = 2
+      const onHighlightedIndexChange = jest.fn()
+      const {clickOnToggleButton} = renderCombobox({
+        initialSelectedItem: items[index],
+        onHighlightedIndexChange,
+      })
+
+      clickOnToggleButton()
+
+      expect(onHighlightedIndexChange).toHaveBeenCalledTimes(1)
+      expect(onHighlightedIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlightedIndex: index,
+        }),
+      )
+    })
+
+    test('is called on first open when selectedItem is set', () => {
+      const index = 2
+      const onHighlightedIndexChange = jest.fn()
+      const {clickOnToggleButton} = renderCombobox({
+        selectedItem: items[index],
+        onHighlightedIndexChange,
+      })
+
+      clickOnToggleButton()
+
+      expect(onHighlightedIndexChange).toHaveBeenCalledTimes(1)
+      expect(onHighlightedIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlightedIndex: index,
+        }),
+      )
+    })
+
+    test('is called on first open when defaultSelectedItem is set', () => {
+      const index = 2
+      const onHighlightedIndexChange = jest.fn()
+      const {clickOnToggleButton} = renderCombobox({
+        defaultSelectedItem: items[index],
+        onHighlightedIndexChange,
+      })
+
+      clickOnToggleButton()
+
+      expect(onHighlightedIndexChange).toHaveBeenCalledTimes(1)
+      expect(onHighlightedIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlightedIndex: index,
+        }),
+      )
+    })
+
     test('works correctly with the corresponding control prop', () => {
       let highlightedIndex = 2
       const {keyDownOnInput, input, rerender} = renderCombobox({

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -1033,6 +1033,42 @@ describe('props', () => {
       )
     })
 
+    test('is called on first open when selectedItem is set', () => {
+      const index = 2
+      const onHighlightedIndexChange = jest.fn()
+      const {clickOnToggleButton} = renderSelect({
+        selectedItem: items[index],
+        onHighlightedIndexChange,
+      })
+
+      clickOnToggleButton()
+
+      expect(onHighlightedIndexChange).toHaveBeenCalledTimes(1)
+      expect(onHighlightedIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlightedIndex: index,
+        }),
+      )
+    })
+
+    test('is called on first open when defaultSelectedItem is set', () => {
+      const index = 2
+      const onHighlightedIndexChange = jest.fn()
+      const {clickOnToggleButton} = renderSelect({
+        defaultSelectedItem: items[index],
+        onHighlightedIndexChange,
+      })
+
+      clickOnToggleButton()
+
+      expect(onHighlightedIndexChange).toHaveBeenCalledTimes(1)
+      expect(onHighlightedIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlightedIndex: index,
+        }),
+      )
+    })
+
     test('works correctly with the corresponding control prop', () => {
       let highlightedIndex = 2
       const {keyDownOnMenu, menu, rerender} = renderSelect({

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -1015,6 +1015,24 @@ describe('props', () => {
       expect(onHighlightedIndexChange).not.toHaveBeenCalled()
     })
 
+    test('is called on first open when initialSelectedItem is set', () => {
+      const index = 2
+      const onHighlightedIndexChange = jest.fn()
+      const {clickOnToggleButton} = renderSelect({
+        initialSelectedItem: items[index],
+        onHighlightedIndexChange,
+      })
+
+      clickOnToggleButton()
+
+      expect(onHighlightedIndexChange).toHaveBeenCalledTimes(1)
+      expect(onHighlightedIndexChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlightedIndex: index,
+        }),
+      )
+    })
+
     test('works correctly with the corresponding control prop', () => {
       let highlightedIndex = 2
       const {keyDownOnMenu, menu, rerender} = renderSelect({

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -250,7 +250,7 @@ export function getInitialState(props) {
 
   return {
     highlightedIndex:
-      highlightedIndex < 0 && selectedItem
+      highlightedIndex < 0 && selectedItem && isOpen
         ? props.items.indexOf(selectedItem)
         : highlightedIndex,
     isOpen,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

When the dropdown is first opened with a selected item, the item should be scrolled into view and onHighlightedItemChange should be called (Fixes #1106)

<!-- Why are these changes necessary? -->

**Why**:

Because the behavior is inconsistent between the first and subsequent opens.

<!-- How were these changes implemented? -->

**How**:

The useSelect `reducer` makes sure that whenever the dropdown would be closed (`isOpen: false`), the `highlightedIndex` is reset to -1 at the same time. However, if an item is selected initially, `initialState` would create a state with `isOpen: false` and `highlightedIndex` set to the item's index. This causes `onHighlightedIndexChange` not to fire on first open, as the index doesn't change from the initial state.

I've changed `initialState` to only set the `highlightedIndex` if the dropdown is already open, to keep the state internally consistent.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation [N/A]
- [x] Tests
- [ ] TypeScript Types [N/A]
- [ ] Flow Types [N/A]
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
