### PR TITLE
fix(useCombobox): Fixing useCombobox onStateChange typing.

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "downshift.cjs.js": {
-    "bundled": 144687,
-    "minified": 65258,
-    "gzipped": 13988
+    "bundled": 144869,
+    "minified": 65327,
+    "gzipped": 14000
   },
   "downshift.umd.min.js": {
-    "bundled": 153598,
-    "minified": 49248,
-    "gzipped": 13187
+    "bundled": 157953,
+    "minified": 50614,
+    "gzipped": 13723
   },
   "downshift.umd.js": {
-    "bundled": 194384,
-    "minified": 67011,
-    "gzipped": 17300
+    "bundled": 165034,
+    "minified": 58166,
+    "gzipped": 14739
   },
   "downshift.esm.js": {
-    "bundled": 143687,
-    "minified": 64334,
-    "gzipped": 13896,
+    "bundled": 145187,
+    "minified": 65464,
+    "gzipped": 13999,
     "treeshaked": {
       "rollup": {
-        "code": 2275,
-        "import_statements": 318
+        "code": 2274,
+        "import_statements": 317
       },
       "webpack": {
-        "code": 4496
+        "code": 4497
       }
     }
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -379,6 +379,11 @@ export interface UseComboboxState<Item> {
   inputValue: string
 }
 
+export interface UseComboboxStateWithType<Item>
+  extends Partial<UseComboboxState<Item>> {
+  type: UseComboboxStateChangeTypes
+}
+
 export enum UseComboboxStateChangeTypes {
   InputKeyDownArrowDown = '__input_keydown_arrow_down__',
   InputKeyDownArrowUp = '__input_keydown_arrow_up__',
@@ -399,7 +404,7 @@ export enum UseComboboxStateChangeTypes {
   FunctionSelectItem = '__function_select_item__',
   FunctionSetInputValue = '__function_set_input_value__',
   FunctionReset = '__function_reset__',
-  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__'
+  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__',
 }
 
 export interface UseComboboxProps<Item> {
@@ -434,7 +439,7 @@ export interface UseComboboxProps<Item> {
   onSelectedItemChange?: (changes: Partial<UseComboboxState<Item>>) => void
   onIsOpenChange?: (changes: Partial<UseComboboxState<Item>>) => void
   onHighlightedIndexChange?: (changes: Partial<UseComboboxState<Item>>) => void
-  onStateChange?: (changes: Partial<UseComboboxState<Item>>) => void
+  onStateChange?: (changes: UseComboboxStateWithType<Item>) => void
   onInputValueChange?: (changes: Partial<UseComboboxState<Item>>) => void
   environment?: Environment
 }
@@ -589,7 +594,8 @@ export interface A11yRemovalMessage<Item> {
 }
 
 export interface UseMultipleSelectionGetSelectedItemPropsOptions<Item>
-  extends React.HTMLProps<HTMLElement>, GetPropsWithRefKey {
+  extends React.HTMLProps<HTMLElement>,
+    GetPropsWithRefKey {
   index?: number
   selectedItem: Item
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Updating useCombobox `onStateChanges` typings.

<!-- Why are these changes necessary? -->

**Why**: When using Typescript, `type` was not included in the `onStateChange`
parameter typing. This was causing ts errors when accessing the `type`.

<!-- How were these changes implemented? -->

**How**: Updated the typing to include `type`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation ("N/A")
- [x] Tests ("N/A")
- [x] TypeScript Types
- [x] Flow Types ("N/A")
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Not 100% sure about the naming conventions expected, but since the current convention of `UseComboboxStateChangeOptions` was already used, I opted for this. I'll happily change it!