### PR TITLE
(fix) UseMultipleSelection itemToString type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -576,7 +576,8 @@ export interface UseMultipleSelectionProps<Item> {
   selectedItems?: Item[]
   initialSelectedItems?: Item[]
   defaultSelectedItems?: Item[]
-  itemToString?: (item: Item) => string
+
+  itemToString?: (item: Item | null) => string
   getA11yRemovalMessage?: (options: A11yRemovalMessage<Item>) => string
   stateReducer?: (
     state: UseMultipleSelectionState<Item>,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -576,7 +576,6 @@ export interface UseMultipleSelectionProps<Item> {
   selectedItems?: Item[]
   initialSelectedItems?: Item[]
   defaultSelectedItems?: Item[]
-
   itemToString?: (item: Item | null) => string
   getA11yRemovalMessage?: (options: A11yRemovalMessage<Item>) => string
   stateReducer?: (


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Updates the `itemToString` type definition for the `UseMultipleSelection` interface.

<!-- Why are these changes necessary? -->

**Why**: The current definition causes errors and is inconsistent with the other hooks.

```ts
Type '((item: T) => string) | undefined' is not assignable to type '((item: T | null) => string) | undefined'.
  Type '(item: T) => string' is not assignable to type '(item: T | null) => string'.
    Types of parameters 'item' and 'item' are incompatible.
      Type 'T | null' is not assignable to type 'T'.
        'T' could be instantiated with an arbitrary type which could be unrelated to 'T | null'.
          Type 'null' is not assignable to type 'T'.
            'T' could be instantiated with an arbitrary type which could be unrelated to 'null'.
```

<!-- How were these changes implemented? -->

**How**: A type definition update.

<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] TypeScript Types
- [ ] Flow Types N/A
- [x] Ready to be merged