### PR TITLE
chore(Typescript): add type for the second argument of the appropriate getter props

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -148,19 +148,13 @@ export interface PropGetters<Item> {
     options?: GetRootPropsOptions,
     otherOptions?: GetPropsCommonOptions,
   ) => any
-  getToggleButtonProps: (
-    options?: GetToggleButtonPropsOptions,
-    otherOptions?: GetPropsCommonOptions,
-  ) => any
+  getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
   getLabelProps: (options?: GetLabelPropsOptions) => any
   getMenuProps: (
     options?: GetMenuPropsOptions,
     otherOptions?: GetPropsCommonOptions,
   ) => any
-  getInputProps: <T>(
-    options?: T,
-    otherOptions?: GetPropsCommonOptions,
-  ) => T & GetInputPropsOptions
+  getInputProps: <T>(options?: T) => T & GetInputPropsOptions
   getItemProps: (options: GetItemPropsOptions<Item>) => any
 }
 
@@ -326,11 +320,14 @@ export interface UseSelectGetItemPropsOptions<Item>
     GetPropsWithRefKey {}
 
 export interface UseSelectPropGetters<Item> {
-  getToggleButtonProps: (options?: UseSelectGetToggleButtonPropsOptions) => any
+  getToggleButtonProps: (
+    options?: UseSelectGetToggleButtonPropsOptions,
+    otherOptions?: GetPropsCommonOptions,
+  ) => any
   getLabelProps: (options?: UseSelectGetLabelPropsOptions) => any
   getMenuProps: (
     options?: UseSelectGetMenuPropsOptions,
-    extraOptions?: GetPropsCommonOptions,
+    otherOptions?: GetPropsCommonOptions,
   ) => any
   getItemProps: (options: UseSelectGetItemPropsOptions<Item>) => any
 }
@@ -482,16 +479,16 @@ export interface UseComboboxPropGetters<Item> {
   getLabelProps: (options?: UseComboboxGetLabelPropsOptions) => any
   getMenuProps: (
     options?: UseComboboxGetMenuPropsOptions,
-    extraOptions?: GetPropsCommonOptions,
+    otherOptions?: GetPropsCommonOptions,
   ) => any
   getItemProps: (options: UseComboboxGetItemPropsOptions<Item>) => any
   getInputProps: (
     options?: UseComboboxGetInputPropsOptions,
-    extraOptions?: GetPropsCommonOptions,
+    otherOptions?: GetPropsCommonOptions,
   ) => any
   getComboboxProps: (
     options?: UseComboboxGetComboboxPropsOptions,
-    extraOptions?: GetPropsCommonOptions,
+    otherOptions?: GetPropsCommonOptions,
   ) => any
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -148,7 +148,10 @@ export interface PropGetters<Item> {
     options?: GetRootPropsOptions,
     otherOptions?: GetPropsCommonOptions,
   ) => any
-  getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
+  getToggleButtonProps: (
+    options?: GetToggleButtonPropsOptions,
+    otherOptions?: GetPropsCommonOptions,
+  ) => any
   getLabelProps: (options?: GetLabelPropsOptions) => any
   getMenuProps: (
     options?: GetMenuPropsOptions,
@@ -325,7 +328,10 @@ export interface UseSelectGetItemPropsOptions<Item>
 export interface UseSelectPropGetters<Item> {
   getToggleButtonProps: (options?: UseSelectGetToggleButtonPropsOptions) => any
   getLabelProps: (options?: UseSelectGetLabelPropsOptions) => any
-  getMenuProps: (options?: UseSelectGetMenuPropsOptions) => any
+  getMenuProps: (
+    options?: UseSelectGetMenuPropsOptions,
+    extraOptions?: GetPropsCommonOptions,
+  ) => any
   getItemProps: (options: UseSelectGetItemPropsOptions<Item>) => any
 }
 
@@ -483,7 +489,10 @@ export interface UseComboboxPropGetters<Item> {
     options?: UseComboboxGetInputPropsOptions,
     extraOptions?: GetPropsCommonOptions,
   ) => any
-  getComboboxProps: (options?: UseComboboxGetComboboxPropsOptions) => any
+  getComboboxProps: (
+    options?: UseComboboxGetComboboxPropsOptions,
+    extraOptions?: GetPropsCommonOptions,
+  ) => any
 }
 
 export interface UseComboboxActions<Item> {
@@ -621,7 +630,10 @@ export type UseMultipleSelectionGetDropdownProps =
   | UseMultipleSelectionComboboxGetDropdownProps
 
 export interface UseMultipleSelectionPropGetters<Item> {
-  getDropdownProps: (options?: UseMultipleSelectionGetDropdownProps) => any
+  getDropdownProps: (
+    options?: UseMultipleSelectionGetDropdownProps,
+    extraOptions?: GetPropsCommonOptions,
+  ) => any
   getSelectedItemProps: (
     options: UseMultipleSelectionGetSelectedItemPropsOptions<Item>,
   ) => any

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -154,7 +154,10 @@ export interface PropGetters<Item> {
     options?: GetMenuPropsOptions,
     otherOptions?: GetPropsCommonOptions,
   ) => any
-  getInputProps: <T>(options?: T) => T & GetInputPropsOptions
+  getInputProps: <T>(
+    options?: T,
+    otherOptions?: GetPropsCommonOptions,
+  ) => T & GetInputPropsOptions
   getItemProps: (options: GetItemPropsOptions<Item>) => any
 }
 
@@ -399,7 +402,7 @@ export enum UseComboboxStateChangeTypes {
   FunctionSelectItem = '__function_select_item__',
   FunctionSetInputValue = '__function_set_input_value__',
   FunctionReset = '__function_reset__',
-  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__'
+  ControlledPropUpdatedSelectedItem = '__controlled_prop_updated_selected_item__',
 }
 
 export interface UseComboboxProps<Item> {
@@ -471,9 +474,15 @@ export interface UseComboboxPropGetters<Item> {
     options?: UseComboboxGetToggleButtonPropsOptions,
   ) => any
   getLabelProps: (options?: UseComboboxGetLabelPropsOptions) => any
-  getMenuProps: (options?: UseComboboxGetMenuPropsOptions) => any
+  getMenuProps: (
+    options?: UseComboboxGetMenuPropsOptions,
+    extraOptions?: GetPropsCommonOptions,
+  ) => any
   getItemProps: (options: UseComboboxGetItemPropsOptions<Item>) => any
-  getInputProps: (options?: UseComboboxGetInputPropsOptions) => any
+  getInputProps: (
+    options?: UseComboboxGetInputPropsOptions,
+    extraOptions?: GetPropsCommonOptions,
+  ) => any
   getComboboxProps: (options?: UseComboboxGetComboboxPropsOptions) => any
 }
 
@@ -589,7 +598,8 @@ export interface A11yRemovalMessage<Item> {
 }
 
 export interface UseMultipleSelectionGetSelectedItemPropsOptions<Item>
-  extends React.HTMLProps<HTMLElement>, GetPropsWithRefKey {
+  extends React.HTMLProps<HTMLElement>,
+    GetPropsWithRefKey {
   index?: number
   selectedItem: Item
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Typings were missing for `getInputProps` and `getMenuProps`  while using `useCombobox` hook with Typescript
<!-- Why are these changes necessary? -->

**Why**:
To prevent compile time error from Typescript compiler
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation 
- [ ] Tests 
- [x] TypeScript Types
- [ ] Flow Types 
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
