### PR TITLE
fix(Typescript): fix UseComboboxDispatchAction type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ harder to contribute to.
 `Downshift` proved to be a versatile component to create not only combobox
 inputs, but also custom select elements and even multiple selection experiences.
 However, additional code was needed to make these experiences fully accessible,
-so we decided to create a dedicated React hook for them. Each hook handles a
+so we decided to create dedicated React hooks for them. Each hook handles a
 specific dropdown variation and aims to make it fully accessible.
 
 You can check the progress in the [hooks page][hooks-readme]. The hooks

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "downshift",
   "version": "0.0.0-semantically-released",
-  "description": "A set of primitives to build simple, flexible, WAI-ARIA compliant React autocomplete components",
+  "description": "🏎 A set of primitives to build simple, flexible, WAI-ARIA compliant React autocomplete, combobox or select dropdown components.",
   "main": "dist/downshift.cjs.js",
   "react-native": "dist/downshift.native.cjs.js",
   "module": "dist/downshift.esm.js",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -460,7 +460,7 @@ export interface UseComboboxStateChangeOptions<Item>
 }
 
 export interface UseComboboxDispatchAction<Item> {
-  type: UseSelectStateChangeTypes
+  type: UseComboboxStateChangeTypes
   shiftKey?: boolean
   getItemNodeFromIndex?: (index: number) => HTMLElement
   inputValue?: string


### PR DESCRIPTION
**What**:

Change `UseComboboxDispatchAction` `type` parameter type from `UseSelectStateChangeTypes` to `UseComboboxStateChangeTypes`.

**Why**:

To reflect the correct state change types.
Fixes https://github.com/downshift-js/downshift/issues/1122.

**How**:

Change typings

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
