### PR TITLE
Scroll list to highlighted item regadless of list open state.

### DIFF
--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -186,7 +186,6 @@ function useSelect(userProps = {}) {
   useEffect(() => {
     if (
       highlightedIndex < 0 ||
-      !isOpen ||
       !Object.keys(itemRefs.current).length
     ) {
       return


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Scroll list to highlighted item regadless of list open state.

<!-- Why are these changes necessary? -->

**Why**: I use async list opening with @kunukn/react-collapse animation library so I need to scroll to highlighted item BEFORE list opens. I need this on list open starts.

<!-- How were these changes implemented? -->

**How**: I've removed isOpen check which scrolls list to highlighed item.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
