### PR TITLE
Always scroll to highlighted item on open

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -152,6 +152,11 @@ function useCombobox(userProps = {}) {
   }, [highlightedIndex])
   // Controls the focus on the menu or the toggle button.
   useEffect(() => {
+    // Always scroll to selected item on open
+    if (isOpen) {
+      shouldScrollRef.current = true
+    }
+    
     // Don't focus menu on first render.
     if (isInitialMountRef.current) {
       // Unless it was initialised as open.

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -156,6 +156,11 @@ function useSelect(userProps = {}) {
   }, [inputValue])
   /* Controls the focus on the menu or the toggle button. */
   useEffect(() => {
+    // Always scroll to selected item on open
+    if (isOpen) {
+      shouldScrollRef.current = true
+    }
+    
     // Don't focus menu on first render.
     if (isInitialMountRef.current) {
       // Unless it was initialised as open.


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Ensure that list will scrolled to highlighted item on drop down open.

<!-- Why are these changes necessary? -->

**Why**: shouldScrollRef == false could prevent list from scrolling to highlighted item on list open.

<!-- How were these changes implemented? -->

**How**: Reset shouldScrollRef to true on list open state changes.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
