### PR TITLE
Edit typing of selectItem to allow to set null

### DIFF
--- a/flow-typed/npm/downshift_v2.x.x.js.flow
+++ b/flow-typed/npm/downshift_v2.x.x.js.flow
@@ -209,7 +209,7 @@ declare module downshift {
     openMenu: (cb?: Callback) => void;
     closeMenu: (cb?: Callback) => void;
     toggleMenu: (otherStateToSet?: {}, cb?: Callback) => void;
-    selectItem: (item: Item, otherStateToSet?: {}, cb?: Callback) => void;
+    selectItem: (item: ?Item, otherStateToSet?: {}, cb?: Callback) => void;
     selectItemAtIndex: (
       index: number,
       otherStateToSet?: {},

--- a/flow-typed/npm/downshift_v2.x.x.js.flow
+++ b/flow-typed/npm/downshift_v2.x.x.js.flow
@@ -45,7 +45,7 @@ declare module downshift {
     highlightedIndex: number | null;
     inputValue: string | null;
     isOpen: boolean;
-    selectedItem: Item;
+    selectedItem: Item | null;
   }
   declare export interface DownshiftProps<Item> {
     defaultSelectedItem?: Item;
@@ -209,7 +209,7 @@ declare module downshift {
     openMenu: (cb?: Callback) => void;
     closeMenu: (cb?: Callback) => void;
     toggleMenu: (otherStateToSet?: {}, cb?: Callback) => void;
-    selectItem: (item: ?Item, otherStateToSet?: {}, cb?: Callback) => void;
+    selectItem: (item: Item | null, otherStateToSet?: {}, cb?: Callback) => void;
     selectItemAtIndex: (
       index: number,
       otherStateToSet?: {},

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -170,7 +170,7 @@ export interface Actions<Item> {
     cb?: Callback,
   ) => void
   selectItem: (
-    item: Item,
+    item: Item | undefined,
     otherStateToSet?: Partial<StateChangeOptions<Item>>,
     cb?: Callback,
   ) => void

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -170,7 +170,7 @@ export interface Actions<Item> {
     cb?: Callback,
   ) => void
   selectItem: (
-    item: Item | undefined,
+    item: Item | null,
     otherStateToSet?: Partial<StateChangeOptions<Item>>,
     cb?: Callback,
   ) => void


### PR DESCRIPTION
**What**:

This PR enables to call `selectItem(null)` without having to typecast this at the call site in Typescript strict mode.

**Why**:

When `items` is a controlled prop, but `selectedItem` is not, it is necessary to manually reset the selectedItem after an action like `SelectedItemClick` has been executed. 

**How**:

Simple ;-)

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests - not sure if tests are necessary for a types-only change
- [x] TypeScript Types
- [x] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

In the example at https://www.downshift-js.com/use-combobox, `selectItem(null)` is used, so I added `null` and not `undefined`.