### PR TITLE
fix(useCombobox): dispatch on Enter keydown event

### DIFF
--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -148,7 +148,7 @@ equialent of each item object.
   {() => {
     // import React from 'react'
     // import { useSelect } from 'downshift'
-    // import { items, useStyles } from './utils'
+    // import { itemsAsObjects, useStyles } from './utils'
     // import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
     // import {Button, FormLabel, List, ListItem, ListItemText } from '@material-ui/core'
     function MaterialDropdownSelect() {
@@ -162,7 +162,7 @@ equialent of each item object.
         getMenuProps,
         highlightedIndex,
         getItemProps,
-      } = useSelect({items, itemToString})
+      } = useSelect({itemsAsObjects, itemToString})
       return (
         <div>
           <FormLabel {...getLabelProps()}>Choose an employee:</FormLabel>

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -162,7 +162,7 @@ equialent of each item object.
         getMenuProps,
         highlightedIndex,
         getItemProps,
-      } = useSelect({itemsAsObjects, itemToString})
+      } = useSelect({items: itemsAsObjects, itemToString})
       return (
         <div>
           <FormLabel {...getLabelProps()}>Choose an employee:</FormLabel>

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -744,22 +744,26 @@ describe('getInputProps', () => {
       })
 
       test('enter on an input with a closed menu does nothing', () => {
-        const {keyDownOnInput, renderSpy} = renderCombobox({
+        const {keyDownOnInput, getItems, input} = renderCombobox({
           initialHighlightedIndex: 2,
           initialIsOpen: false,
         })
-        expect(renderSpy).toHaveBeenCalledTimes(1)
+
         keyDownOnInput('Enter')
-        expect(renderSpy).toHaveBeenCalledTimes(1)
+
+        expect(getItems()).toHaveLength(0)
+        expect(input).not.toHaveValue()
       })
 
       test('enter on an input with an open menu does nothing without a highlightedIndex', () => {
-        const {keyDownOnInput, renderSpy} = renderCombobox({
+        const {keyDownOnInput, getItems, input} = renderCombobox({
           initialIsOpen: true,
         })
-        expect(renderSpy).toHaveBeenCalledTimes(1)
+
         keyDownOnInput('Enter')
-        expect(renderSpy).toHaveBeenCalledTimes(1)
+
+        expect(getItems()).toHaveLength(items.length)
+        expect(input).not.toHaveValue()
       })
 
       test('tab it closes the menu and selects highlighted item', () => {

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -298,7 +298,12 @@ describe('props', () => {
     test('is called when isOpen, highlightedIndex, inputValue or items change', async () => {
       const getA11yStatusMessage = jest.fn()
       const inputItems = ['aaa', 'bbb']
-      const {clickOnToggleButton, rerender, keyDownOnInput, changeInputValue} = renderCombobox({
+      const {
+        clickOnToggleButton,
+        rerender,
+        keyDownOnInput,
+        changeInputValue,
+      } = renderCombobox({
         getA11yStatusMessage,
         items,
       })
@@ -316,25 +321,33 @@ describe('props', () => {
       rerender({getA11yStatusMessage, items: inputItems})
       waitForDebouncedA11yStatusUpdate()
 
-      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({resultCount: inputItems.length}))
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(
+        expect.objectContaining({resultCount: inputItems.length}),
+      )
       expect(getA11yStatusMessage).toHaveBeenCalledTimes(1)
 
       clickOnToggleButton()
       waitForDebouncedA11yStatusUpdate()
-      
-      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({isOpen: true}))
+
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(
+        expect.objectContaining({isOpen: true}),
+      )
       expect(getA11yStatusMessage).toHaveBeenCalledTimes(2)
-      
+
       await changeInputValue('b')
       waitForDebouncedA11yStatusUpdate()
-      
-      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({inputValue: 'b'}))
+
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(
+        expect.objectContaining({inputValue: 'b'}),
+      )
       expect(getA11yStatusMessage).toHaveBeenCalledTimes(3)
 
       keyDownOnInput('ArrowDown')
       waitForDebouncedA11yStatusUpdate()
-      
-      expect(getA11yStatusMessage).toHaveBeenCalledWith(expect.objectContaining({highlightedIndex: 0}))
+
+      expect(getA11yStatusMessage).toHaveBeenCalledWith(
+        expect.objectContaining({highlightedIndex: 0}),
+      )
       expect(getA11yStatusMessage).toHaveBeenCalledTimes(4)
     })
   })
@@ -712,9 +725,30 @@ describe('props', () => {
         }),
       )
 
-      keyDownOnInput('ArrowUp')
+      keyDownOnInput('Escape')
 
       expect(stateReducer).toHaveBeenCalledTimes(11)
+      expect(stateReducer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: -1,
+          isOpen: false,
+          selectedItem: null,
+          inputValue: '',
+        }),
+        expect.objectContaining({
+          changes: expect.objectContaining({
+            selectedItem: null,
+            inputValue: '',
+            isOpen: false,
+            highlightedIndex: -1,
+          }),
+          type: stateChangeTypes.InputKeyDownEscape,
+        }),
+      )
+
+      keyDownOnInput('ArrowUp')
+
+      expect(stateReducer).toHaveBeenCalledTimes(12)
       expect(stateReducer).toHaveBeenLastCalledWith(
         expect.objectContaining({
           isOpen: false,
@@ -731,7 +765,7 @@ describe('props', () => {
 
       blurInput()
 
-      expect(stateReducer).toHaveBeenCalledTimes(12)
+      expect(stateReducer).toHaveBeenCalledTimes(13)
       expect(stateReducer).toHaveBeenLastCalledWith(
         expect.objectContaining({
           highlightedIndex: items.length - 1,
@@ -745,6 +779,69 @@ describe('props', () => {
             highlightedIndex: -1,
           }),
           type: stateChangeTypes.InputBlur,
+        }),
+      )
+
+      keyDownOnInput('Home')
+
+      expect(stateReducer).toHaveBeenCalledTimes(14)
+      expect(stateReducer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: -1,
+          isOpen: false,
+          selectedItem: items[items.length - 1],
+          inputValue: items[items.length - 1],
+        }),
+        expect.objectContaining({
+          changes: expect.objectContaining({
+            selectedItem: items[items.length - 1],
+            inputValue: items[items.length - 1],
+            isOpen: false,
+            highlightedIndex: -1,
+          }),
+          type: stateChangeTypes.InputKeyDownHome,
+        }),
+      )
+
+      keyDownOnInput('End')
+
+      expect(stateReducer).toHaveBeenCalledTimes(15)
+      expect(stateReducer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: -1,
+          isOpen: false,
+          selectedItem: items[items.length - 1],
+          inputValue: items[items.length - 1],
+        }),
+        expect.objectContaining({
+          changes: expect.objectContaining({
+            selectedItem: items[items.length - 1],
+            inputValue: items[items.length - 1],
+            isOpen: false,
+            highlightedIndex: -1,
+          }),
+          type: stateChangeTypes.InputKeyDownEnd,
+        }),
+      )
+
+      keyDownOnInput('Enter')
+
+      expect(stateReducer).toHaveBeenCalledTimes(16)
+      expect(stateReducer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          highlightedIndex: -1,
+          isOpen: false,
+          selectedItem: items[items.length - 1],
+          inputValue: items[items.length - 1],
+        }),
+        expect.objectContaining({
+          changes: expect.objectContaining({
+            selectedItem: items[items.length - 1],
+            inputValue: items[items.length - 1],
+            isOpen: false,
+            highlightedIndex: -1,
+          }),
+          type: stateChangeTypes.InputKeyDownEnter,
         }),
       )
     })

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -244,7 +244,7 @@ function useCombobox(userProps = {}) {
         }
         const latestState = latest.current.state
 
-        if (latestState.isOpen && latestState.highlightedIndex > -1) {
+        if (latestState.isOpen) {
           event.preventDefault()
         }
 

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -246,11 +246,12 @@ function useCombobox(userProps = {}) {
 
         if (latestState.isOpen && latestState.highlightedIndex > -1) {
           event.preventDefault()
-          dispatch({
-            type: stateChangeTypes.InputKeyDownEnter,
-            getItemNodeFromIndex,
-          })
         }
+
+        dispatch({
+          type: stateChangeTypes.InputKeyDownEnter,
+          getItemNodeFromIndex,
+        })
       },
     }),
     [dispatch, latest],

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -69,12 +69,13 @@ export default function downshiftUseComboboxReducer(state, action) {
       break
     case stateChangeTypes.InputKeyDownEnter:
       changes = {
-        ...(state.highlightedIndex >= 0 && {
-          selectedItem: props.items[state.highlightedIndex],
-          isOpen: getDefaultValue(props, 'isOpen'),
-          highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
-          inputValue: props.itemToString(props.items[state.highlightedIndex]),
-        }),
+        ...(state.isOpen &&
+          state.highlightedIndex >= 0 && {
+            selectedItem: props.items[state.highlightedIndex],
+            isOpen: getDefaultValue(props, 'isOpen'),
+            highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
+            inputValue: props.itemToString(props.items[state.highlightedIndex]),
+          }),
       }
       break
     case stateChangeTypes.InputKeyDownEscape:
@@ -89,24 +90,28 @@ export default function downshiftUseComboboxReducer(state, action) {
       break
     case stateChangeTypes.InputKeyDownHome:
       changes = {
-        highlightedIndex: getNextNonDisabledIndex(
-          1,
-          0,
-          props.items.length,
-          action.getItemNodeFromIndex,
-          false,
-        ),
+        ...(state.isOpen && {
+          highlightedIndex: getNextNonDisabledIndex(
+            1,
+            0,
+            props.items.length,
+            action.getItemNodeFromIndex,
+            false,
+          ),
+        }),
       }
       break
     case stateChangeTypes.InputKeyDownEnd:
       changes = {
-        highlightedIndex: getNextNonDisabledIndex(
-          -1,
-          props.items.length - 1,
-          props.items.length,
-          action.getItemNodeFromIndex,
-          false,
-        ),
+        ...(state.isOpen && {
+          highlightedIndex: getNextNonDisabledIndex(
+            -1,
+            props.items.length - 1,
+            props.items.length,
+            action.getItemNodeFromIndex,
+            false,
+          ),
+        }),
       }
       break
     case stateChangeTypes.InputBlur:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Call dispatch on `Enter` keydown.
Prevent event default (form submission) if menu is open.
Do not return highlightedIndex from reducer if menu is closed.
Fix the MUI example for useSelect on the docsite.
<!-- Why are these changes necessary? -->

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1114.
Also to fix other potential issues.
<!-- How were these changes implemented? -->

**How**:
Fix the reducer for the `useCombobox` hook.
Add itemsAsObjects to the MUI example useCombobox hook.
Check state.isOpen before returning a `highlightedIndex` in the Home/End actions.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
