### PR TITLE
docs(useMultipleSelection): fix syntax error in README example

### DIFF
--- a/src/hooks/useMultipleSelection/README.md
+++ b/src/hooks/useMultipleSelection/README.md
@@ -172,7 +172,7 @@ const DropdownMultipleCombobox = () => {
             </li>
           ))}
       </ul>
-    <div/>
+    </div>
   )
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I've fixed the syntax error in useMultipleSelection README example.

<!-- Why are these changes necessary? -->

**Why**:

It's always great to have a README example which is ready to be copied/pasted.

<!-- How were these changes implemented? -->

**How**:

Just a README update.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Hi!

Thank you for great work on downshift.

Best regards.