### PR TITLE
useMultipleSelection: Prevent browser navigation when pressing `Backspace`.

### DIFF
--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -121,7 +121,9 @@ function useMultipleSelection(userProps = {}) {
           type: stateChangeTypes.SelectedItemKeyDownDelete,
         })
       },
-      Backspace() {
+      Backspace(event) {
+        // Prevent browser navigation when pressing `Backspace`.
+        event.preventDefault()
         dispatch({
           type: stateChangeTypes.SelectedItemKeyDownBackspace,
         })


### PR DESCRIPTION
Closes #1160.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

`useMultipleSelection`: Prevent browser navigation when pressing `Backspace`.

**Why**:

Prevents unexpected browser navigations on when items are selected.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation N/A
- [ ] Tests
- [X] TypeScript Types N/A
- [X] Flow Types N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
