### PR TITLE
fix: UseComboboxGetComboboxPropsOptions typing

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -500,7 +500,7 @@ export interface UseComboboxGetInputPropsOptions
     GetPropsWithRefKey {}
 
 export interface UseComboboxGetComboboxPropsOptions
-  extends React.HTMLProps<HTMLLabelElement> {}
+  extends React.HTMLProps<HTMLDivElement> {}
 
 export interface UseComboboxPropGetters<Item> {
   getToggleButtonProps: (


### PR DESCRIPTION
**What**:

I fixed the wrong typing of the `UseComboboxGetComboboxPropsOptions` interface. The generic type of the `HTMLProps` extend was `HTMLLabelElement` instead of `HTMLDivElement`.

**Why**:

From the related documentation (https://www.downshift-js.com/use-combobox), the DOM element where the `getComboboxProps` should be spread is `div`.

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
