### PR TITLE
add isItemDisabledProp

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,26 +1,31 @@
 {
   "downshift.umd.min.js": {
-    "bundled": 158031,
-    "minified": 50884,
-    "gzipped": 13945
+    "bundled": 151570,
+    "minified": 50363,
+    "gzipped": 13556
   },
   "downshift.umd.js": {
-    "bundled": 194611,
-    "minified": 67329,
-    "gzipped": 17530
+    "bundled": 190516,
+    "minified": 67392,
+    "gzipped": 17672
   },
   "downshift.esm.js": {
-    "bundled": 143881,
-    "minified": 64857,
-    "gzipped": 14134,
+    "bundled": 144068,
+    "minified": 64948,
+    "gzipped": 14261,
     "treeshaked": {
       "rollup": {
-        "code": 2275,
+        "code": 2311,
         "import_statements": 318
       },
       "webpack": {
-        "code": 4496
+        "code": 4532
       }
     }
+  },
+  "downshift.cjs.js": {
+    "bundled": 148801,
+    "minified": 68992,
+    "gzipped": 14484
   }
 }

--- a/src/hooks/useCombobox/testUtils.js
+++ b/src/hooks/useCombobox/testUtils.js
@@ -54,8 +54,8 @@ const renderCombobox = (props, uiCallback) => {
   const mouseLeaveMenu = () => {
     fireEvent.mouseLeave(menu)
   }
-  const changeInputValue = async inputValue => {
-    await userEvent.type(input, inputValue)
+  const changeInputValue = inputValue => {
+    userEvent.type(input, inputValue)
   }
   const focusInput = () => {
     fireEvent.focus(input)

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -59,6 +59,14 @@ describe('getItemProps', () => {
       // eslint-disable-next-line jest-dom/prefer-enabled-disabled
       expect(itemProps.disabled).toBe(true)
     })
+
+    test('omit event handlers when isItemDisabled it true', () => {
+      const {result} = renderUseSelect({isItemDisabled: () => true})
+
+      const itemProps = result.current.getItemProps({index: 0})
+      expect(itemProps.onMouseMove).toBeUndefined()
+      expect(itemProps.onClick).toBeUndefined()
+    })
   })
 
   describe('user props', () => {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -47,6 +47,7 @@ function useSelect(userProps = {}) {
     environment,
     initialIsOpen,
     defaultIsOpen,
+    isItemDisabled,
     itemToString,
     getA11ySelectionMessage,
     getA11yStatusMessage,
@@ -501,7 +502,8 @@ function useSelect(userProps = {}) {
         ...rest,
       }
 
-      if (!rest.disabled) {
+      const notDisabled = !rest.disabled && !isItemDisabled(item)
+      if (notDisabled) {
         itemProps.onMouseMove = callAllEventHandlers(
           onMouseMove,
           itemHandleMouseMove,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -110,6 +110,10 @@ function itemToString(item) {
   return item ? String(item) : ''
 }
 
+function isItemDisabled() {
+  return false
+}
+
 export function getPropTypesValidator(caller, propTypes) {
   // istanbul ignore next
   return function validate(options = {}) {
@@ -202,6 +206,7 @@ export function useControlledReducer(reducer, initialState, props) {
 }
 
 export const defaultProps = {
+  isItemDisabled,
   itemToString,
   stateReducer,
   getA11ySelectionMessage,


### PR DESCRIPTION
**What**:
Adding the ability to pass an `isDisabled` prop to `useSelect`
<!-- Why are these changes necessary? -->

**Why**:
This will allow disabling individual items much easier for users of this hook.

**How**:
By adding a defaultProp of `isItemDisabled` that will always be false unless the user specifies it.

**Checklist**:

- [ ] Documentation
- [x ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged

I'm new to Open source so if I have made annoying mistakes I want to apologize in advance 😬 