### PR TITLE
fix(types): props optional for useMultipleSelect

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "downshift.umd.min.js": {
-    "bundled": 159043,
-    "minified": 52711,
-    "gzipped": 14331
+    "bundled": 159068,
+    "minified": 52730,
+    "gzipped": 14338
   },
   "downshift.umd.js": {
-    "bundled": 201021,
-    "minified": 70419,
-    "gzipped": 18265
+    "bundled": 201046,
+    "minified": 70438,
+    "gzipped": 18269
   },
   "downshift.esm.js": {
-    "bundled": 143881,
-    "minified": 64857,
-    "gzipped": 14134,
+    "bundled": 143906,
+    "minified": 64876,
+    "gzipped": 14145,
     "treeshaked": {
       "rollup": {
         "code": 2275,
@@ -24,8 +24,8 @@
     }
   },
   "downshift.cjs.js": {
-    "bundled": 148614,
-    "minified": 68901,
-    "gzipped": 14351
+    "bundled": 148639,
+    "minified": 68920,
+    "gzipped": 14361
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -677,15 +677,15 @@ export interface UseMultipleSelectionActions<Item> {
   setActiveIndex: (index: number) => void
 }
 
-export type UseMultipleSelectionReturnValue<Item> = UseMultipleSelectionState<
+export type UseMultipleSelectionReturnValue<
   Item
-> &
+> = UseMultipleSelectionState<Item> &
   UseMultipleSelectionPropGetters<Item> &
   UseMultipleSelectionActions<Item>
 
 export interface UseMultipleSelectionInterface {
   <Item>(
-    props: UseMultipleSelectionProps<Item>,
+    props?: UseMultipleSelectionProps<Item>,
   ): UseMultipleSelectionReturnValue<Item>
   stateChangeTypes: {
     SelectedItemClick: UseMultipleSelectionStateChangeTypes.SelectedItemClick


### PR DESCRIPTION
**What**:

Make `props` optional for useMultipleSelection in TS.

**Why**:

You don't need to pass `props` for this hook.

**How**:

`props?`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
