### PR TITLE
perf(scroll): replace useEffect with useLayoutEffect

### DIFF
--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -1,5 +1,11 @@
 import PropTypes from 'prop-types'
-import {useRef, useCallback, useReducer, useEffect} from 'react'
+import {
+  useRef,
+  useCallback,
+  useReducer,
+  useEffect,
+  useLayoutEffect,
+} from 'react'
 import {
   scrollIntoView,
   getNextWrappingIndex,
@@ -487,7 +493,7 @@ export function useScrollIntoView({
   // used not to scroll on highlight by mouse.
   const shouldScrollRef = useRef(true)
   // Scroll on highlighted item if change comes from keyboard.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (
       highlightedIndex < 0 ||
       !isOpen ||


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Replace `useEffect` with `useLayoutEffect` in `useScrollIntoView`.

**Why**:
Prevent an unnecessary double paint.
<!-- How were these changes implemented? -->

**How**:
Replace the `useEffect` with `useLayoutEffect`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
