### PR TITLE
fix(scroll): use isomorphic effect for SSR

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "downshift.umd.min.js": {
-    "bundled": 159068,
-    "minified": 52730,
-    "gzipped": 14338
+    "bundled": 159308,
+    "minified": 52847,
+    "gzipped": 14370
   },
   "downshift.umd.js": {
-    "bundled": 201046,
-    "minified": 70438,
-    "gzipped": 18269
+    "bundled": 201286,
+    "minified": 70555,
+    "gzipped": 18310
   },
   "downshift.esm.js": {
-    "bundled": 143906,
-    "minified": 64876,
-    "gzipped": 14145,
+    "bundled": 144155,
+    "minified": 65053,
+    "gzipped": 14199,
     "treeshaked": {
       "rollup": {
         "code": 2275,
         "import_statements": 318
       },
       "webpack": {
-        "code": 4496
+        "code": 4623
       }
     }
   },
   "downshift.cjs.js": {
-    "bundled": 148639,
-    "minified": 68920,
-    "gzipped": 14361
+    "bundled": 148878,
+    "minified": 69088,
+    "gzipped": 14414
   }
 }

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -85,6 +85,15 @@ const updateA11yStatus = debounce((getA11yMessage, document) => {
   setStatus(getA11yMessage(), document)
 }, 200)
 
+
+// istanbul ignore next
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined'
+    ? useLayoutEffect
+    : useEffect
+
 export function getElementIds({
   id,
   labelId,
@@ -493,7 +502,7 @@ export function useScrollIntoView({
   // used not to scroll on highlight by mouse.
   const shouldScrollRef = useRef(true)
   // Scroll on highlighted item if change comes from keyboard.
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (
       highlightedIndex < 0 ||
       !isOpen ||


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix https://github.com/downshift-js/downshift/issues/1211

**Why**:

To avoid warnings and make scroll work on both SSR and CSR.

**How**:

If on a browser, call `useLayoutEffect`, otherwise `useEffect` in the scroll utility.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
