### PR TITLE
feat(hooks): dispatch changes only when needed

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "downshift.cjs.js": {
-    "bundled": 148289,
-    "minified": 68373,
-    "gzipped": 14410
+    "bundled": 148721,
+    "minified": 68507,
+    "gzipped": 14453
   },
   "downshift.umd.min.js": {
-    "bundled": 156069,
-    "minified": 51613,
-    "gzipped": 14058
+    "bundled": 156563,
+    "minified": 51795,
+    "gzipped": 14102
   },
   "downshift.umd.js": {
-    "bundled": 200681,
-    "minified": 69912,
-    "gzipped": 18283
+    "bundled": 201175,
+    "minified": 70094,
+    "gzipped": 18317
   },
   "downshift.esm.js": {
-    "bundled": 143545,
-    "minified": 64317,
-    "gzipped": 14173,
+    "bundled": 145342,
+    "minified": 65553,
+    "gzipped": 14304,
     "treeshaked": {
       "rollup": {
-        "code": 2275,
-        "import_statements": 318
+        "code": 2274,
+        "import_statements": 317
       },
       "webpack": {
-        "code": 4626
+        "code": 4625
       }
     }
   }

--- a/src/__tests__/downshift.get-input-props.js
+++ b/src/__tests__/downshift.get-input-props.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {render, fireEvent, screen} from '@testing-library/react'
+import {render, fireEvent, screen, createEvent} from '@testing-library/react'
 import Downshift from '../'
 
 jest.useFakeTimers()
@@ -365,6 +365,32 @@ test('home and end keys should not call highlighting method when menu is closed'
   expect(childrenSpy).toHaveBeenLastCalledWith(
     expect.objectContaining({isOpen: false, highlightedIndex: null}),
   )
+})
+
+test('home and end keys should not prevent event default when menu is closed', () => {
+  const {input} = renderDownshift()
+  const homeKeyDownEvent = createEvent.keyDown(input, {key: 'Home'})
+  const endKeyDownEvent = createEvent.keyDown(input, {key: 'End'})
+  // home
+  fireEvent(input, homeKeyDownEvent)
+  expect(homeKeyDownEvent.defaultPrevented).toBe(false)
+
+  // end
+  fireEvent(input, endKeyDownEvent)
+  expect(endKeyDownEvent.defaultPrevented).toBe(false)
+})
+
+test('home and end keys should prevent event default when menu is open', () => {
+  const {input} = renderDownshift({props: {defaultIsOpen: true}})
+  const homeKeyDownEvent = createEvent.keyDown(input, {key: 'Home'})
+  const endKeyDownEvent = createEvent.keyDown(input, {key: 'End'})
+  // home
+  fireEvent(input, homeKeyDownEvent)
+  expect(homeKeyDownEvent.defaultPrevented).toBe(true)
+
+  // end
+  fireEvent(input, endKeyDownEvent)
+  expect(endKeyDownEvent.defaultPrevented).toBe(true)
 })
 
 test('enter on an input with a closed menu does nothing', () => {

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -616,10 +616,15 @@ class Downshift extends Component {
   inputKeyDownHandlers = {
     ...this.keyDownHandlers,
     Home(event) {
+      const {isOpen} = this.getState()
+
+      if (!isOpen) {
+        return
+      }
+
       event.preventDefault()
 
       const itemCount = this.getItemCount()
-      const {isOpen} = this.getState()
 
       if (itemCount <= 0 || !isOpen) {
         return
@@ -640,10 +645,15 @@ class Downshift extends Component {
     },
 
     End(event) {
+      const {isOpen} = this.getState()
+
+      if (!isOpen) {
+        return
+      }
+
       event.preventDefault()
 
       const itemCount = this.getItemCount()
-      const {isOpen} = this.getState()
 
       if (itemCount <= 0 || !isOpen) {
         return

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -549,7 +549,6 @@ describe('props', () => {
       )
     })
 
-    // eslint-disable-next-line max-statements
     test('is called at each state change with the appropriate change type', () => {
       const stateReducer = jest.fn((s, a) => a.changes)
       const {
@@ -561,289 +560,191 @@ describe('props', () => {
         keyDownOnInput,
         blurInput,
       } = renderCombobox({stateReducer})
+      const initialState = {
+        isOpen: false,
+        highlightedIndex: -1,
+        inputValue: '',
+        selectedItem: null,
+      }
+      const testCases = [
+        {
+          step: clickOnToggleButton,
+          state: {
+            isOpen: true,
+            highlightedIndex: -1,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.ToggleButtonClick,
+        },
+        {
+          step: mouseMoveItemAtIndex,
+          args: 2,
+          state: {
+            isOpen: true,
+            highlightedIndex: 2,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.ItemMouseMove,
+        },
+        {
+          step: mouseLeaveMenu,
+          state: {
+            isOpen: true,
+            highlightedIndex: -1,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.MenuMouseLeave,
+        },
+        {
+          step: blurInput,
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputBlur,
+        },
+        {
+          step: changeInputValue,
+          args: 'c',
+          state: {
+            isOpen: true,
+            highlightedIndex: -1,
+            inputValue: 'c',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputChange,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'ArrowDown',
+          state: {
+            isOpen: true,
+            highlightedIndex: 0,
+            inputValue: 'c',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputKeyDownArrowDown,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'Enter',
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: items[0],
+            selectedItem: items[0],
+          },
+          type: stateChangeTypes.InputKeyDownEnter,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'Escape',
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputKeyDownEscape,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'ArrowDown',
+          state: {
+            isOpen: true,
+            highlightedIndex: 0,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputKeyDownArrowDown,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'ArrowUp',
+          state: {
+            isOpen: true,
+            highlightedIndex: items.length - 1,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputKeyDownArrowUp,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'Home',
+          state: {
+            isOpen: true,
+            highlightedIndex: 0,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputKeyDownHome,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'End',
+          state: {
+            isOpen: true,
+            highlightedIndex: items.length - 1,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.InputKeyDownEnd,
+        },
+        {
+          step: clickOnItemAtIndex,
+          args: 3,
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: items[3],
+            selectedItem: items[3],
+          },
+          type: stateChangeTypes.ItemClick,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'ArrowUp',
+          state: {
+            isOpen: true,
+            highlightedIndex: 2,
+            inputValue: items[3],
+            selectedItem: items[3],
+          },
+          type: stateChangeTypes.InputKeyDownArrowUp,
+        },
+        {
+          step: keyDownOnInput,
+          args: 'Escape',
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: items[3],
+            selectedItem: items[3],
+          },
+          type: stateChangeTypes.InputKeyDownEscape,
+        },
+      ]
 
       expect(stateReducer).not.toHaveBeenCalled()
 
-      clickOnToggleButton()
+      for (let index = 0; index < testCases.length; index++) {
+        const {step, state, args, type} = testCases[index]
+        const previousState = testCases[index - 1]?.state ?? initialState
 
-      expect(stateReducer).toHaveBeenCalledTimes(1)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({isOpen: false}),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            isOpen: true,
-          }),
-          type: stateChangeTypes.ToggleButtonClick,
-        }),
-      )
+        step(args)
 
-      changeInputValue('c')
-
-      expect(stateReducer).toHaveBeenCalledTimes(2)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          inputValue: '',
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            inputValue: 'c',
-          }),
-          type: stateChangeTypes.InputChange,
-        }),
-      )
-
-      mouseMoveItemAtIndex(1)
-
-      expect(stateReducer).toHaveBeenCalledTimes(3)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: 1,
-          }),
-          type: stateChangeTypes.ItemMouseMove,
-        }),
-      )
-
-      clickOnItemAtIndex(1)
-
-      expect(stateReducer).toHaveBeenCalledTimes(4)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 1,
-          isOpen: true,
-          selectedItem: null,
-          inputValue: 'c',
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            isOpen: false,
-            highlightedIndex: -1,
-            selectedItem: items[1],
-            inputValue: items[1],
-          }),
-          type: stateChangeTypes.ItemClick,
-        }),
-      )
-
-      keyDownOnInput('ArrowDown')
-
-      expect(stateReducer).toHaveBeenCalledTimes(5)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          isOpen: false,
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({isOpen: true, highlightedIndex: 2}),
-          type: stateChangeTypes.InputKeyDownArrowDown,
-        }),
-      )
-
-      keyDownOnInput('End')
-
-      expect(stateReducer).toHaveBeenCalledTimes(6)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 2,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: items.length - 1,
-          }),
-          type: stateChangeTypes.InputKeyDownEnd,
-        }),
-      )
-
-      mouseLeaveMenu()
-
-      expect(stateReducer).toHaveBeenCalledTimes(7)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: items.length - 1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.MenuMouseLeave,
-        }),
-      )
-
-      keyDownOnInput('Home')
-
-      expect(stateReducer).toHaveBeenCalledTimes(8)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: 0,
-          }),
-          type: stateChangeTypes.InputKeyDownHome,
-        }),
-      )
-
-      keyDownOnInput('Enter')
-
-      expect(stateReducer).toHaveBeenCalledTimes(9)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 0,
-          selectedItem: items[1],
-          isOpen: true,
-          inputValue: items[1],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: -1,
-            isOpen: false,
-            inputValue: items[0],
-            selectedItem: items[0],
-          }),
-          type: stateChangeTypes.InputKeyDownEnter,
-        }),
-      )
-
-      keyDownOnInput('Escape')
-
-      expect(stateReducer).toHaveBeenCalledTimes(10)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          inputValue: items[0],
-          selectedItem: items[0],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            inputValue: '',
-            selectedItem: null,
-          }),
-          type: stateChangeTypes.InputKeyDownEscape,
-        }),
-      )
-
-      keyDownOnInput('Escape')
-
-      expect(stateReducer).toHaveBeenCalledTimes(11)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-          isOpen: false,
-          selectedItem: null,
-          inputValue: '',
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: null,
-            inputValue: '',
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.InputKeyDownEscape,
-        }),
-      )
-
-      keyDownOnInput('ArrowUp')
-
-      expect(stateReducer).toHaveBeenCalledTimes(12)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          isOpen: false,
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: items.length - 1,
-            isOpen: true,
-          }),
-          type: stateChangeTypes.InputKeyDownArrowUp,
-        }),
-      )
-
-      blurInput()
-
-      expect(stateReducer).toHaveBeenCalledTimes(13)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: items.length - 1,
-          isOpen: true,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[items.length - 1],
-            inputValue: items[items.length - 1],
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.InputBlur,
-        }),
-      )
-
-      keyDownOnInput('Home')
-
-      expect(stateReducer).toHaveBeenCalledTimes(14)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-          isOpen: false,
-          selectedItem: items[items.length - 1],
-          inputValue: items[items.length - 1],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[items.length - 1],
-            inputValue: items[items.length - 1],
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.InputKeyDownHome,
-        }),
-      )
-
-      keyDownOnInput('End')
-
-      expect(stateReducer).toHaveBeenCalledTimes(15)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-          isOpen: false,
-          selectedItem: items[items.length - 1],
-          inputValue: items[items.length - 1],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[items.length - 1],
-            inputValue: items[items.length - 1],
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.InputKeyDownEnd,
-        }),
-      )
-
-      keyDownOnInput('Enter')
-
-      expect(stateReducer).toHaveBeenCalledTimes(16)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-          isOpen: false,
-          selectedItem: items[items.length - 1],
-          inputValue: items[items.length - 1],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[items.length - 1],
-            inputValue: items[items.length - 1],
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.InputKeyDownEnter,
-        }),
-      )
+        expect(stateReducer).toHaveBeenCalledTimes(index + 1)
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          previousState,
+          expect.objectContaining({changes: state, type}),
+        )
+      }
     })
 
     test('replaces prop values with user defined', () => {

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -169,6 +169,10 @@ function useCombobox(userProps = {}) {
         })
       },
       Home(event) {
+        if (!latest.current.state.isOpen) {
+          return
+        }
+
         event.preventDefault()
         dispatch({
           type: stateChangeTypes.InputKeyDownHome,
@@ -176,6 +180,10 @@ function useCombobox(userProps = {}) {
         })
       },
       End(event) {
+        if (!latest.current.state.isOpen) {
+          return
+        }
+
         event.preventDefault()
         dispatch({
           type: stateChangeTypes.InputKeyDownEnd,
@@ -183,21 +191,30 @@ function useCombobox(userProps = {}) {
         })
       },
       Escape() {
-        dispatch({
-          type: stateChangeTypes.InputKeyDownEscape,
-        })
+        const latestState = latest.current.state
+        if (
+          latestState.isOpen ||
+          latestState.inputValue ||
+          latestState.selectedItem ||
+          latestState.highlightedIndex > -1
+        ) {
+          dispatch({
+            type: stateChangeTypes.InputKeyDownEscape,
+          })
+        }
       },
       Enter(event) {
-        // if IME composing, wait for next Enter keydown event.
-        if (event.which === 229) {
+        const latestState = latest.current.state
+        // if closed or no highlighted index, do nothing.
+        if (
+          !latestState.isOpen ||
+          latestState.highlightedIndex < 0 ||
+          event.which === 229 // if IME composing, wait for next Enter keydown event.
+        ) {
           return
         }
-        const latestState = latest.current.state
 
-        if (latestState.isOpen) {
-          event.preventDefault()
-        }
-
+        event.preventDefault()
         dispatch({
           type: stateChangeTypes.InputKeyDownEnter,
           getItemNodeFromIndex,
@@ -372,7 +389,7 @@ function useCombobox(userProps = {}) {
       }
       const inputHandleBlur = () => {
         /* istanbul ignore else */
-        if (!mouseAndTouchTrackersRef.current.isMouseDown) {
+        if (latestState.isOpen && !mouseAndTouchTrackersRef.current.isMouseDown) {
           dispatch({
             type: stateChangeTypes.InputBlur,
             selectItem: true,

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -36,7 +36,7 @@ export default function downshiftUseComboboxReducer(state, action) {
             1,
             action.getItemNodeFromIndex,
           ),
-          isOpen: true,
+          isOpen: props.items.length >= 0,
         }
       }
       break
@@ -59,7 +59,7 @@ export default function downshiftUseComboboxReducer(state, action) {
             -1,
             action.getItemNodeFromIndex,
           ),
-          isOpen: true,
+          isOpen: props.items.length >= 0,
         }
       }
       break
@@ -86,43 +86,35 @@ export default function downshiftUseComboboxReducer(state, action) {
       break
     case stateChangeTypes.InputKeyDownHome:
       changes = {
-        ...(state.isOpen && {
-          highlightedIndex: getNextNonDisabledIndex(
-            1,
-            0,
-            props.items.length,
-            action.getItemNodeFromIndex,
-            false,
-          ),
-        }),
+        highlightedIndex: getNextNonDisabledIndex(
+          1,
+          0,
+          props.items.length,
+          action.getItemNodeFromIndex,
+          false,
+        ),
       }
       break
     case stateChangeTypes.InputKeyDownEnd:
       changes = {
-        ...(state.isOpen && {
-          highlightedIndex: getNextNonDisabledIndex(
-            -1,
-            props.items.length - 1,
-            props.items.length,
-            action.getItemNodeFromIndex,
-            false,
-          ),
-        }),
+        highlightedIndex: getNextNonDisabledIndex(
+          -1,
+          props.items.length - 1,
+          props.items.length,
+          action.getItemNodeFromIndex,
+          false,
+        ),
       }
       break
     case stateChangeTypes.InputBlur:
-      if (state.isOpen) {
-        changes = {
-          isOpen: false,
-          highlightedIndex: -1,
-          ...(state.highlightedIndex >= 0 &&
-            action.selectItem && {
-              selectedItem: props.items[state.highlightedIndex],
-              inputValue: props.itemToString(
-                props.items[state.highlightedIndex],
-              ),
-            }),
-        }
+      changes = {
+        isOpen: false,
+        highlightedIndex: -1,
+        ...(state.highlightedIndex >= 0 &&
+          action.selectItem && {
+            selectedItem: props.items[state.highlightedIndex],
+            inputValue: props.itemToString(props.items[state.highlightedIndex]),
+          }),
       }
       break
     case stateChangeTypes.InputChange:

--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -1,7 +1,12 @@
 /* eslint-disable jest/no-disabled-tests */
 import * as React from 'react'
 import {act, renderHook} from '@testing-library/react-hooks'
-import {act as reactAct, fireEvent, screen} from '@testing-library/react'
+import {
+  act as reactAct,
+  fireEvent,
+  screen,
+  createEvent,
+} from '@testing-library/react'
 import {renderUseSelect, renderSelect} from '../testUtils'
 import {defaultIds, items} from '../../testUtils'
 import * as stateChangeTypes from '../stateChangeTypes'
@@ -403,6 +408,15 @@ describe('getMenuProps', () => {
       })
 
       describe('arrow up', () => {
+        test('it prevents the default event behavior', () => {
+          const {menu} = renderSelect()
+          const keyDownEvent = createEvent.keyDown(menu, {key: 'ArrowUp'})
+
+          fireEvent(menu, keyDownEvent)
+
+          expect(keyDownEvent.defaultPrevented).toBe(true)
+        })
+
         test('it does not highlight anything if there are no options', () => {
           const {keyDownOnMenu, menu, getItems} = renderSelect({
             isOpen: true,
@@ -504,6 +518,15 @@ describe('getMenuProps', () => {
       })
 
       describe('arrow down', () => {
+        test('it prevents the default event behavior', () => {
+          const {menu} = renderSelect()
+          const keyDownEvent = createEvent.keyDown(menu, {key: 'ArrowDown'})
+
+          fireEvent(menu, keyDownEvent)
+
+          expect(keyDownEvent.defaultPrevented).toBe(true)
+        })
+
         test('it does not highlight anything if there are no options', () => {
           const {keyDownOnMenu, menu, getItems} = renderSelect({
             isOpen: true,
@@ -619,6 +642,15 @@ describe('getMenuProps', () => {
         )
       })
 
+      test('end it prevents the default event behavior', () => {
+        const {menu} = renderSelect()
+        const keyDownEvent = createEvent.keyDown(menu, {key: 'End'})
+
+        fireEvent(menu, keyDownEvent)
+
+        expect(keyDownEvent.defaultPrevented).toBe(true)
+      })
+
       test('home it highlights the first option number', () => {
         const {keyDownOnMenu, menu} = renderSelect({
           isOpen: true,
@@ -631,6 +663,15 @@ describe('getMenuProps', () => {
           'aria-activedescendant',
           defaultIds.getItemId(0),
         )
+      })
+
+      test('home it prevents the default event behavior', () => {
+        const {menu} = renderSelect()
+        const keyDownEvent = createEvent.keyDown(menu, {key: 'Home'})
+
+        fireEvent(menu, keyDownEvent)
+
+        expect(keyDownEvent.defaultPrevented).toBe(true)
       })
 
       test('escape it has the menu closed', () => {
@@ -693,6 +734,15 @@ describe('getMenuProps', () => {
         expect(toggleButton).toHaveFocus()
       })
 
+      test('enter it prevents the default event behavior', () => {
+        const {menu} = renderSelect()
+        const keyDownEvent = createEvent.keyDown(menu, {key: 'Enter'})
+
+        fireEvent(menu, keyDownEvent)
+
+        expect(keyDownEvent.defaultPrevented).toBe(true)
+      })
+
       test('space it closes the menu and selects highlighted item', () => {
         const initialHighlightedIndex = 2
         const {keyDownOnMenu, toggleButton, getItems} = renderSelect({
@@ -731,6 +781,15 @@ describe('getMenuProps', () => {
         keyDownOnMenu(' ')
 
         expect(toggleButton).toHaveFocus()
+      })
+
+      test('space it prevents the default event behavior', () => {
+        const {menu} = renderSelect()
+        const keyDownEvent = createEvent.keyDown(menu, {key: ' '})
+
+        fireEvent(menu, keyDownEvent)
+
+        expect(keyDownEvent.defaultPrevented).toBe(true)
       })
 
       test('tab it closes the menu and does not select highlighted item', () => {

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-disabled-tests */
-import {act as reactAct} from '@testing-library/react'
+import {act as reactAct, createEvent, fireEvent} from '@testing-library/react'
 import {act as reactHooksAct, renderHook} from '@testing-library/react-hooks'
 import {noop} from '../../../utils'
 import {renderUseSelect, renderSelect} from '../testUtils'
@@ -426,6 +426,15 @@ describe('getToggleButtonProps', () => {
       })
 
       describe('arrow up', () => {
+        test('it prevents the default event behavior', () => {
+          const {toggleButton} = renderSelect()
+          const keyDownEvent = createEvent.keyDown(toggleButton, {key: 'ArrowUp'})
+
+          fireEvent(toggleButton, keyDownEvent)
+
+          expect(keyDownEvent.defaultPrevented).toBe(true)
+        })
+
         test('it does not open or highlight anything if there are no options', () => {
           const {keyDownOnToggleButton, menu, getItems} = renderSelect({
             items: [],
@@ -525,6 +534,15 @@ describe('getToggleButtonProps', () => {
       })
 
       describe('arrow down', () => {
+        test('it prevents the default event behavior', () => {
+          const {toggleButton} = renderSelect()
+          const keyDownEvent = createEvent.keyDown(toggleButton, {key: 'ArrowDown'})
+
+          fireEvent(toggleButton, keyDownEvent)
+
+          expect(keyDownEvent.defaultPrevented).toBe(true)
+        })
+
         test('it does not open or highlight anything if there are no options', () => {
           const {keyDownOnToggleButton, menu, getItems} = renderSelect({
             items: [],

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -543,7 +543,7 @@ describe('props', () => {
         expect.objectContaining({type: stateChangeTypes.FunctionSetInputValue}),
       )
     })
-    // eslint-disable-next-line max-statements
+
     test('is called at each state change with the appropriate change type', () => {
       const stateReducer = jest.fn((s, a) => a.changes)
       const {
@@ -554,277 +554,213 @@ describe('props', () => {
         keyDownOnMenu,
         mouseMoveItemAtIndex,
         clickOnItemAtIndex,
-        rerender,
-      } = renderSelect({stateReducer, isOpen: true})
+      } = renderSelect({stateReducer})
+      const initialState = {
+        isOpen: false,
+        highlightedIndex: -1,
+        selectedItem: null,
+        inputValue: '',
+      }
+      const testCases = [
+        {
+          step: clickOnToggleButton,
+          state: {
+            isOpen: true,
+            highlightedIndex: -1,
+            inputValue: '',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.ToggleButtonClick,
+        },
+        {
+          step: keyDownOnMenu,
+          args: 'c',
+          state: {
+            isOpen: true,
+            highlightedIndex: 3,
+            inputValue: 'c',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.MenuKeyDownCharacter,
+        },
+        {
+          step: keyDownOnMenu,
+          args: 'ArrowDown',
+          state: {
+            isOpen: true,
+            highlightedIndex: 4,
+            inputValue: 'c',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.MenuKeyDownArrowDown,
+        },
+        {
+          step: keyDownOnMenu,
+          args: 'ArrowUp',
+          state: {
+            isOpen: true,
+            highlightedIndex: 3,
+            inputValue: 'c',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.MenuKeyDownArrowUp,
+        },
+        {
+          step: keyDownOnMenu,
+          args: 'End',
+          state: {
+            isOpen: true,
+            highlightedIndex: items.length - 1,
+            inputValue: 'c',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.MenuKeyDownEnd,
+        },
+        {
+          step: keyDownOnMenu,
+          args: 'Home',
+          state: {
+            isOpen: true,
+            highlightedIndex: 0,
+            inputValue: 'c',
+            selectedItem: null,
+          },
+          type: stateChangeTypes.MenuKeyDownHome,
+        },
+        {
+          step: keyDownOnMenu,
+          args: 'Enter',
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: 'c',
+            selectedItem: items[0],
+          },
+          type: stateChangeTypes.MenuKeyDownEnter,
+        },
+        {
+          step: keyDownOnToggleButton,
+          args: 'o',
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: 'co',
+            selectedItem: items[19],
+          },
+          type: stateChangeTypes.ToggleButtonKeyDownCharacter,
+        },
+        {
+          step: keyDownOnToggleButton,
+          args: 'ArrowDown',
+          state: {
+            isOpen: true,
+            highlightedIndex: 20,
+            inputValue: 'co',
+            selectedItem: items[19],
+          },
+          type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
+        },
+        {
+          step: clickOnItemAtIndex,
+          args: 10,
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: 'co',
+            selectedItem: items[10],
+          },
+          type: stateChangeTypes.ItemClick,
+        },
+        {
+          step: keyDownOnToggleButton,
+          args: 'ArrowUp',
+          state: {
+            isOpen: true,
+            highlightedIndex: 9,
+            inputValue: 'co',
+            selectedItem: items[10],
+          },
+          type: stateChangeTypes.ToggleButtonKeyDownArrowUp,
+        },
+        {
+          step: mouseMoveItemAtIndex,
+          args: 6,
+          state: {
+            isOpen: true,
+            highlightedIndex: 6,
+            inputValue: 'co',
+            selectedItem: items[10],
+          },
+          type: stateChangeTypes.ItemMouseMove,
+        },
+        {
+          step: mouseLeaveMenu,
+          state: {
+            isOpen: true,
+            highlightedIndex: -1,
+            inputValue: 'co',
+            selectedItem: items[10],
+          },
+          type: stateChangeTypes.MenuMouseLeave,
+        },
+        {
+          step: blurMenu,
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: 'co',
+            selectedItem: items[10],
+          },
+          type: stateChangeTypes.MenuBlur,
+        },
+        {
+          step: keyDownOnToggleButton,
+          args: 'ArrowUp',
+          state: {
+            isOpen: true,
+            highlightedIndex: 9,
+            inputValue: 'co',
+            selectedItem: items[10],
+          },
+          type: stateChangeTypes.ToggleButtonKeyDownArrowUp,
+        },
+        {
+          step: keyDownOnMenu,
+          args: ' ',
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: 'co',
+            selectedItem: items[9],
+          },
+          type: stateChangeTypes.MenuKeyDownSpaceButton,
+        },
+        {
+          step: jest.runAllTimers,
+          state: {
+            isOpen: false,
+            highlightedIndex: -1,
+            inputValue: '',
+            selectedItem: items[9],
+          },
+          type: stateChangeTypes.FunctionSetInputValue,
+        },
+      ]
 
       expect(stateReducer).not.toHaveBeenCalled()
 
-      clickOnToggleButton()
+      for (let index = 0; index < testCases.length; index++) {
+        const {step, state, args, type} = testCases[index]
+        const previousState = testCases[index - 1]?.state ?? initialState
 
-      expect(stateReducer).toHaveBeenCalledTimes(1)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          isOpen: true,
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.ToggleButtonClick,
-        }),
-      )
+        step(args)
 
-      keyDownOnMenu('c')
-
-      expect(stateReducer).toHaveBeenCalledTimes(2)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: 3,
-          }),
-          type: stateChangeTypes.MenuKeyDownCharacter,
-        }),
-      )
-
-      keyDownOnMenu('ArrowDown')
-
-      expect(stateReducer).toHaveBeenCalledTimes(3)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 3,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: 4,
-          }),
-          type: stateChangeTypes.MenuKeyDownArrowDown,
-        }),
-      )
-
-      keyDownOnMenu('ArrowUp')
-
-      expect(stateReducer).toHaveBeenCalledTimes(4)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 4,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: 3,
-          }),
-          type: stateChangeTypes.MenuKeyDownArrowUp,
-        }),
-      )
-
-      keyDownOnMenu('End')
-
-      expect(stateReducer).toHaveBeenCalledTimes(5)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 3,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: items.length - 1,
-          }),
-          type: stateChangeTypes.MenuKeyDownEnd,
-        }),
-      )
-
-      keyDownOnMenu('Home')
-
-      expect(stateReducer).toHaveBeenCalledTimes(6)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: items.length - 1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: 0,
-          }),
-          type: stateChangeTypes.MenuKeyDownHome,
-        }),
-      )
-
-      keyDownOnMenu('Enter')
-
-      expect(stateReducer).toHaveBeenCalledTimes(7)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 0,
-          selectedItem: null,
-          isOpen: true,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[0],
-            highlightedIndex: -1,
-            isOpen: false,
-          }),
-          type: stateChangeTypes.MenuKeyDownEnter,
-        }),
-      )
-
-      keyDownOnMenu('Escape')
-
-      expect(stateReducer).toHaveBeenCalledTimes(8)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          isOpen: true,
-          selectedItem: items[0],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            isOpen: false,
-            selectedItem: items[0],
-          }),
-          type: stateChangeTypes.MenuKeyDownEscape,
-        }),
-      )
-
-      blurMenu()
-
-      expect(stateReducer).toHaveBeenCalledTimes(9)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          isOpen: true,
-          selectedItem: items[0],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            isOpen: false,
-            selectedItem: items[0],
-          }),
-          type: stateChangeTypes.MenuBlur,
-        }),
-      )
-
-      mouseMoveItemAtIndex(5)
-
-      expect(stateReducer).toHaveBeenCalledTimes(10)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: 5,
-          }),
-          type: stateChangeTypes.ItemMouseMove,
-        }),
-      )
-
-      keyDownOnMenu(' ')
-
-      expect(stateReducer).toHaveBeenCalledTimes(11)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: 5,
-          isOpen: true,
-          selectedItem: items[0],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[5],
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.MenuKeyDownSpaceButton,
-        }),
-      )
-
-      mouseLeaveMenu()
-
-      expect(stateReducer).toHaveBeenCalledTimes(12)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({highlightedIndex: -1}),
-        expect.objectContaining({
-          changes: expect.objectContaining({highlightedIndex: -1}),
-          type: stateChangeTypes.MenuMouseLeave,
-        }),
-      )
-
-      clickOnItemAtIndex(3)
-
-      expect(stateReducer).toHaveBeenCalledTimes(13)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          highlightedIndex: -1,
-          isOpen: true,
-          selectedItem: items[5],
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            highlightedIndex: -1,
-            isOpen: false,
-            selectedItem: items[3],
-          }),
-          type: stateChangeTypes.ItemClick,
-        }),
-      )
-
-      rerender({stateReducer, isOpen: false, highlightedIndex: -1})
-      keyDownOnToggleButton('ArrowDown')
-
-      expect(stateReducer).toHaveBeenCalledTimes(14)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          isOpen: false,
-          selectedItem: items[3],
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            isOpen: true,
-            selectedItem: items[3],
-            highlightedIndex: 4,
-          }),
-          type: stateChangeTypes.ToggleButtonKeyDownArrowDown,
-        }),
-      )
-
-      keyDownOnToggleButton('ArrowUp')
-
-      expect(stateReducer).toHaveBeenCalledTimes(15)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          selectedItem: items[3],
-          isOpen: false,
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[3],
-            isOpen: true,
-            highlightedIndex: 2,
-          }),
-          type: stateChangeTypes.ToggleButtonKeyDownArrowUp,
-        }),
-      )
-
-      keyDownOnToggleButton('a')
-
-      expect(stateReducer).toHaveBeenCalledTimes(16)
-      expect(stateReducer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          selectedItem: items[3],
-          isOpen: false,
-          highlightedIndex: -1,
-        }),
-        expect.objectContaining({
-          changes: expect.objectContaining({
-            selectedItem: items[5],
-            isOpen: false,
-            highlightedIndex: -1,
-          }),
-          type: stateChangeTypes.ToggleButtonKeyDownCharacter,
-        }),
-      )
+        expect(stateReducer).toHaveBeenCalledTimes(index + 1)
+        expect(stateReducer).toHaveBeenLastCalledWith(
+          previousState,
+          expect.objectContaining({changes: state, type}),
+        )
+      }
     })
 
     test('receives state, changes and type', () => {

--- a/src/hooks/useSelect/testUtils.js
+++ b/src/hooks/useSelect/testUtils.js
@@ -71,6 +71,7 @@ const renderSelect = (props, uiCallback) => {
 
   return {
     ...wrapper,
+    renderSpy,
     rerender,
     label,
     menu,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Only trigger `dispatch` when state can change.
Also update the tests and add more tests to check rerenders and event `preventDefault` logic.

Fixes https://github.com/downshift-js/downshift/issues/1097

**Why**:
To prevent unnecessary rerenders and `event.preventDefault`.

**How**:

- Remove the conditions from the reducers and add them to the hooks instead.
- If conditions are not met, do not `dispatch`, do not `preventDefault`.
- Add tests to check events and rerenders.
- Refactor the stateReducer tests.

<!-- Have you done all of these things?  -->

**Breaking behaviors:**

- stateReducer is now called only when the state is about to change, as we already mention in the documentation. This means that if you hit Home/End in an input that has a menu closed, there will be no state change.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
