### PR TITLE
fix(typings): make item optional in GetItemPropsOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -138,7 +138,7 @@ export interface GetPropsWithRefKey {
 export interface GetItemPropsOptions<Item>
   extends React.HTMLProps<HTMLElement> {
   index?: number
-  item: Item
+  item?: Item
   isSelected?: boolean
   disabled?: boolean
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Making `item` optional in `GetItemPropsOptions`

<!-- Why are these changes necessary? -->

**Why**: The runtime works just fine with only an `index` value provided, but the typings _require_ an `item` to be provided.

<!-- How were these changes implemented? -->

**How**: vim

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] TypeScript Types
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

It may be worth looking into using `RequireAtLeastOne` from `type-fest`. I briefly attempted to use it for this library but it was proving difficult to test properly: https://github.com/sindresorhus/type-fest/blob/4c9835b3c42d7a9f1d10bae19c334ce1d8e8c8a4/source/require-at-least-one.d.ts