### PR TITLE
chore: Add type for GetLabelPropsReturnValue, to reduce usage of :any

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -116,6 +116,11 @@ export interface GetInputPropsOptions
 export interface GetLabelPropsOptions
   extends React.HTMLProps<HTMLLabelElement> {}
 
+export interface GetLabelPropsReturnValue  {
+  htmlFor: string;
+  id: string;
+}
+
 export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {
   disabled?: boolean
@@ -149,7 +154,7 @@ export interface PropGetters<Item> {
     otherOptions?: GetPropsCommonOptions,
   ) => any
   getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
-  getLabelProps: (options?: GetLabelPropsOptions) => any
+  getLabelProps: (options?: GetLabelPropsOptions) => GetLabelPropsReturnValue
   getMenuProps: (
     options?: GetMenuPropsOptions,
     otherOptions?: GetPropsCommonOptions,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adding an interface to replace the `any` typing used for `getLabelProps` prop-getter return value. 

<!-- Why are these changes necessary? -->

**Why**: 
To provide a more robust type system for downshift usage in typescript. 
<!-- How were these changes implemented? -->

**How**:
I essentially reused the interface from the flow type definition.                                             

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~~Documentation~~ N/A
- [ ] ~~Tests~~ N/A
- [x] TypeScript~~ Types 
- [ ] ~~Flow Types~~ N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
