### PR TITLE
fix(useSelect): clear debounced keysSoFar callback on unmount

### DIFF
--- a/src/hooks/useSelect/__tests__/getMenuProps.test.js
+++ b/src/hooks/useSelect/__tests__/getMenuProps.test.js
@@ -397,6 +397,22 @@ describe('getMenuProps', () => {
           // highlight should stay on the first item starting with 'C'
           expect(menu).toHaveAttribute('aria-activedescendant', expectedIndex)
         })
+
+        test('should not attempt update after unmount', () => {
+          const consoleErrorSpy = jest.spyOn(console, 'error')
+          const char = 'c'
+          const {keyDownOnMenu, unmount} = renderSelect({
+            isOpen: true,
+          })
+
+          // Enter key twice to queue up debounced call
+          keyDownOnMenu(char)
+          keyDownOnMenu(char)
+          unmount()
+          jest.runAllTimers()
+
+          expect(consoleErrorSpy).not.toHaveBeenCalled()
+        })
       })
 
       describe('arrow up', () => {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -108,23 +108,32 @@ function useSelect(userProps = {}) {
     scrollIntoView,
     getItemNodeFromIndex,
   })
-  // Sets cleanup for the keysSoFar after 500ms.
+
+  // Sets cleanup for the keysSoFar callback, debounded after 500ms.
   useEffect(() => {
     // init the clean function here as we need access to dispatch.
-    if (isInitialMountRef.current) {
-      clearTimeoutRef.current = debounce(outerDispatch => {
-        outerDispatch({
-          type: stateChangeTypes.FunctionSetInputValue,
-          inputValue: '',
-        })
-      }, 500)
-    }
+    clearTimeoutRef.current = debounce(outerDispatch => {
+      outerDispatch({
+        type: stateChangeTypes.FunctionSetInputValue,
+        inputValue: '',
+      })
+    }, 500)
 
+    // Cancel any pending debounced calls on mount
+    return () => {
+      clearTimeoutRef.current.cancel()
+    }
+  }, [])
+
+  // Invokes the keysSoFar callback set up above.
+  useEffect(() => {
     if (!inputValue) {
       return
     }
+
     clearTimeoutRef.current(dispatch)
   }, [dispatch, inputValue])
+
   useControlPropsValidator({
     isInitialMount: isInitialMountRef.current,
     props,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes https://github.com/downshift-js/downshift/issues/1226
Addresses dangling callback outlined in the issue above.

**Why**:

Because callbacks should be cleared on unmount.

**How**:

Cancelling the debounced function in the cleanup function of `useEffect`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests
- [x] TypeScript Types N/A
- [x] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

This still needs a test! Hoping for a pointer on the best approach test test this within the test suite.

<!-- feel free to add additional comments -->
