### PR TITLE
Add ARIA W3 page link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ autocomplete, combobox or select dropdown components.</p>
 
 You need an autocomplete, a combobox or a select experience in your application
 and you want it to be accessible. You also want it to be simple and flexible to
-account for your use cases. Finally, it should follow the ARIA design pattern
+account for your use cases. Finally, it should follow the [ARIA][aria] design pattern
 for a [combobox][combobox-aria] or a [select][select-aria], depending on your
 use case.
 
@@ -1480,6 +1480,8 @@ MIT
 [multiple-selection-readme]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection
 [bundle-phobia-link]: https://bundlephobia.com/result?p=downshift@3.4.8
+[aria]:
+  https://www.w3.org/TR/wai-aria-practices/
 [combobox-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
 [select-aria]:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: this PR adds a link to the W3.org [page](https://www.w3.org/TR/wai-aria-practices/) about ARIA.

<!-- Why are these changes necessary? -->

**Why**: I was reading the README but didn't know what ARIA was, so I figured this might be useful for newcomers, specially noting that when combobox and select are mentioned in the same page, they have links to their respective sections in W3's ARIA specification.

<!-- How were these changes implemented? -->

**How**: A link was added to ARIA'S first mention in the "The Problem" README section.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
