### PR TITLE
fix(environment): use Node variable within the provided window context

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1065,7 +1065,7 @@ class Downshift extends Component {
         const contextWithinDownshift = targetWithinDownshift(
           event.target,
           [this._rootNode, this._menuNode],
-          this.props.environment.document,
+          this.props.environment,
         )
         if (!contextWithinDownshift && this.getState().isOpen) {
           this.reset({type: stateChangeTypes.mouseUp}, () =>
@@ -1091,7 +1091,7 @@ class Downshift extends Component {
         const contextWithinDownshift = targetWithinDownshift(
           event.target,
           [this._rootNode, this._menuNode],
-          this.props.environment.document,
+          this.props.environment,
           false,
         )
         if (

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -337,7 +337,7 @@ function useMouseAndTouchTracker(
         !targetWithinDownshift(
           event.target,
           downshiftElementRefs.map(ref => ref.current),
-          environment.document,
+          environment,
         )
       ) {
         handleBlur()
@@ -356,7 +356,7 @@ function useMouseAndTouchTracker(
         !targetWithinDownshift(
           event.target,
           downshiftElementRefs.map(ref => ref.current),
-          environment.document,
+          environment,
           false,
         )
       ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,13 +41,16 @@ function scrollIntoView(node, menuNode) {
 /**
  * @param {HTMLElement} parent the parent node
  * @param {HTMLElement} child the child node
+ * @param {Window} environment The window context where downshift renders.
  * @return {Boolean} whether the parent is the child or the child is in the parent
  */
-function isOrContainsNode(parent, child) {
-  return (
+function isOrContainsNode(parent, child, environment) {
+  const result =
     parent === child ||
-    (child instanceof Node && parent.contains && parent.contains(child))
-  )
+    (child instanceof environment.Node &&
+      parent.contains &&
+      parent.contains(child))
+  return result
 }
 
 /**
@@ -408,7 +411,7 @@ function getNextNonDisabledIndex(
  *
  * @param {EventTarget} target Target to check.
  * @param {HTMLElement[]} downshiftElements The elements that form downshift (list, toggle button etc).
- * @param {Document} document The document.
+ * @param {Window} environment The window context where downshift renders.
  * @param {boolean} checkActiveElement Whether to also check activeElement.
  *
  * @returns {boolean} Whether or not the target is within downshift elements.
@@ -416,22 +419,26 @@ function getNextNonDisabledIndex(
 function targetWithinDownshift(
   target,
   downshiftElements,
-  document,
+  environment,
   checkActiveElement = true,
 ) {
   return downshiftElements.some(
     contextNode =>
       contextNode &&
-      (isOrContainsNode(contextNode, target) ||
+      (isOrContainsNode(contextNode, target, environment) ||
         (checkActiveElement &&
-          isOrContainsNode(contextNode, document.activeElement))),
+          isOrContainsNode(
+            contextNode,
+            environment.document.activeElement,
+            environment,
+          ))),
   )
 }
 
 // eslint-disable-next-line import/no-mutable-exports
 let validateControlledUnchanged = noop
 /* istanbul ignore next */
-if (process.env.NODE_ENV  !== 'production') {
+if (process.env.NODE_ENV !== 'production') {
   validateControlledUnchanged = (state, prevProps, nextProps) => {
     const warningDescription = `This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props`
 
@@ -480,5 +487,5 @@ export {
   targetWithinDownshift,
   getState,
   isControlledProp,
-  validateControlledUnchanged
+  validateControlledUnchanged,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This change is made to address an issue being described in [Issue-1225](https://github.com/downshift-js/downshift/issues/1255)

<!-- Why are these changes necessary? -->

**Why**: otherwise `downshift` does not work properly when rendering from an iframe to the parent window using React Portal

<!-- How were these changes implemented? -->

**How**: replace `instanceof Node` with `instanceof environment.Node`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
