### PR TITLE
Fix #1257 and some lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,15 +126,13 @@
         "error",
         12
       ],
-      
-      "no-unsafe-optional-chaining" : "off",
-      "no-loss-of-precision" : "off",
+      "no-unsafe-optional-chaining": "off",
+      "no-loss-of-precision": "off",
       "no-unreachable-loop": "off",
       "no-useless-backreference": "off",
       "default-case-last": "off",
-      "no-nonoctal-decimal-escape" : "off",
+      "no-nonoctal-decimal-escape": "off",
       "id-denylist": "off",
-
       "testing-library/prefer-user-event": "off",
       "testing-library/no-node-access": "off",
       "testing-library/no-container": "off",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 const commonjs = require('@rollup/plugin-commonjs')
 const babel = require('rollup-plugin-babel')
+// eslint-disable-next-line import/extensions
 const config = require('kcd-scripts/dist/config/rollup.config.js')
 const babelPluginIndex = config.plugins.findIndex(
   plugin => plugin.name === 'babel',

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -16,7 +16,7 @@ import {
   noop,
 } from '../utils'
 import setStatus from '../set-a11y-status'
-
+import {isReactNative} from '../is.macro'
 const dropdownDefaultStateValues = {
   highlightedIndex: -1,
   isOpen: false,
@@ -451,7 +451,7 @@ function useA11yMessageSetter(
 ) {
   // Sets a11y status message on changes in state.
   useEffect(() => {
-    if (isInitialMount) {
+    if (isInitialMount || isReactNative) {
       return
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

This fixes the bug with rendering in react-native as described in issue document #1257 

Closes https://github.com/downshift-js/downshift/issues/1257

<!-- Why are these changes necessary? -->

This will allow the react-native version of useCombobox and useSelect to work instead of crashing.

<!-- How were these changes implemented? -->

I emulated similar code in in the main downshift component (downshift.js line 1171) by pulling in
`import {isReactNative} from '../is.macro'`
and then avoiding the `updateA11yStatus` method (which manipulates the DOM and will not work in react-native).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x ] Ready to be merged 
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
Yes
<!-- feel free to add additional comments -->
This is a very small change which emulates similar code already existing in this repository (downshift.js line 1171).