### PR TITLE
Add `Node` to `Environment` TS type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,6 +79,7 @@ export interface DownshiftProps<Item> {
 }
 
 export interface Environment {
+  Node: typeof window.Node
   addEventListener: typeof window.addEventListener
   removeEventListener: typeof window.removeEventListener
   document: Document


### PR DESCRIPTION
**What**:

Fix the `Environment` TypeScript type.

**Why**:

#1264 introduced the usage of `environment.Node`, so environments need to have this for Downshift to work correctly.

**How**:

Adds `Node` to the `Environment` TypeScript type.

**Checklist**:

- [ ] Documentation N/A?
- [ ] Tests N/A?
- [x] TypeScript Types
- [ ] Flow Types N/A?
- [x] Ready to be merged