### PR TITLE
fix(hooks): do not add a11y status on react native

### DIFF
--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -5,6 +5,7 @@ import {
   useEffect,
   useLayoutEffect,
 } from 'react'
+import {isReactNative} from '../is.macro'
 import {
   scrollIntoView,
   getNextWrappingIndex,
@@ -450,7 +451,7 @@ function useA11yMessageSetter(
 ) {
   // Sets a11y status message on changes in state.
   useEffect(() => {
-    if (isInitialMount) {
+    if (isInitialMount || isReactNative) {
       return
     }
 


### PR DESCRIPTION
**What**:

Do not add a11y status on react native.
Closes https://github.com/downshift-js/downshift/issues/1257.

**Why**:

Not working and is breaking.

**How**:

Use `is.macro` as it is used in Downshift. Original PR https://github.com/downshift-js/downshift/pull/1278:

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
