### PR TITLE
chore: revert react update from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=17.0.2"
+    "react": ">=16.12.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.14.8",


### PR DESCRIPTION
**What**:

Revert react update version from peerDependencies since it is considered a breaking change.

**Why**:

Breaking Change without any major release.

**How**:

Revert to 16.12.0

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
