### PR TITLE
fix(tsconfig): revert target es2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "downshift",
-  "version": "0.0.0-semantically-released",
+  "version": "6.1.5-alpha.0",
   "description": "🏎 A set of primitives to build simple, flexible, WAI-ARIA compliant React autocomplete, combobox or select dropdown components.",
   "main": "dist/downshift.cjs.js",
   "react-native": "dist/downshift.native.cjs.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "esModuleInterop": true,
     "jsx": "react",
     "moduleResolution": "node",
-    "target": "es2020",
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Remove es2020 value from tsconfig target.
Fixes https://github.com/downshift-js/downshift/issues/1303.

<!-- Why are these changes necessary? -->

**Why**:

Breaking builds.

<!-- How were these changes implemented? -->

**How**:

Remove line to go back to es3 default.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
