### PR TITLE
fix(TS): revert changes in typings index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "downshift",
-  "version": "6.1.5-alpha.0",
+  "version": "0.0.0-semantically-released",
   "description": "🏎 A set of primitives to build simple, flexible, WAI-ARIA compliant React autocomplete, combobox or select dropdown components.",
   "main": "dist/downshift.cjs.js",
   "react-native": "dist/downshift.native.cjs.js",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,5 @@
 import * as React from 'react'
 
-export {A11yStatusMessageOptions} from '../src/types'
-
 type Callback = () => void
 
 export interface DownshiftState<Item> {
@@ -84,6 +82,17 @@ export interface Environment {
   addEventListener: typeof window.addEventListener
   removeEventListener: typeof window.removeEventListener
   document: Document
+}
+
+export interface A11yStatusMessageOptions<Item> {
+  highlightedIndex: number | null
+  inputValue: string
+  isOpen: boolean
+  itemToString: (item: Item | null) => string
+  previousResultCount: number
+  resultCount: number
+  highlightedItem: Item
+  selectedItem: Item | null
 }
 
 export interface StateChangeOptions<Item>


### PR DESCRIPTION
**What**:

Fixes https://github.com/downshift-js/downshift/issues/1307.
Change back to `0.0.0-semantically-released` in package json.

**Why**:

Typings are broken, we will have both the manual d.ts and generated in parallel until full migration.

**How**:

Revert the `A11yStatusMessageOptions` change.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
