### PR TITLE
Update docs: with Yarn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ harder to contribute to.
 
 ## Installation
 
-This module is distributed via [npm][npm] which is bundled with [node][node] and
+This module is distributed via [npm][npm]/[yarn][yarn] which is bundled with [node][node] and
 should be installed as one of your project's `dependencies`:
 
 ```
@@ -1494,3 +1494,5 @@ MIT
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/downshift/ordered-examples/00-get-root-props-example.js
 [code-sandbox-no-get-root-props]:
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/downshift/ordered-examples/01-basic-autocomplete.js
+[yarn]:
+  https://yarnpkg.com/package/downshift


### PR DESCRIPTION
**What is this PR?**:

* I noticed that downshift is accessible via Yarn, in addition to NPM. This update is a minor change reflecting this. I have also added the link to yarn.

**Why**:

* Some might prefer to use yarn over npm.

**Checklist**:

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged

