### PR TITLE
fix: update types for UseComboboxGetComboboxPropsOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -108,6 +108,9 @@ export interface GetRootPropsOptions {
   refKey: string
 }
 
+export interface GetComboboxPropsOptions
+  extends React.HTMLProps<HTMLDivElement> {}
+
 export interface GetInputPropsOptions
   extends React.HTMLProps<HTMLInputElement> {
   disabled?: boolean
@@ -500,7 +503,8 @@ export interface UseComboboxGetInputPropsOptions
     GetPropsWithRefKey {}
 
 export interface UseComboboxGetComboboxPropsOptions
-  extends React.HTMLProps<HTMLDivElement> {}
+  extends GetComboboxPropsOptions,
+    GetPropsWithRefKey {}
 
 export interface UseComboboxPropGetters<Item> {
   getToggleButtonProps: (
@@ -677,11 +681,10 @@ export interface UseMultipleSelectionActions<Item> {
   setActiveIndex: (index: number) => void
 }
 
-export type UseMultipleSelectionReturnValue<Item> = UseMultipleSelectionState<
-  Item
-> &
-  UseMultipleSelectionPropGetters<Item> &
-  UseMultipleSelectionActions<Item>
+export type UseMultipleSelectionReturnValue<Item> =
+  UseMultipleSelectionState<Item> &
+    UseMultipleSelectionPropGetters<Item> &
+    UseMultipleSelectionActions<Item>
 
 export interface UseMultipleSelectionInterface {
   <Item>(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Update types for `UseComboboxGetComboboxPropsOptions` to accept `refKey`

<!-- Why are these changes necessary? -->

**Why**:

Types were missing in `typings/index.d.ts` but are accepted in the `getComboboxProps` function
https://github.com/downshift-js/downshift/blob/master/src/hooks/useCombobox/index.js#L466-L467

<!-- How were these changes implemented? -->

**How**:

I replicated what has been done for `UseComboboxGetInputPropsOptions`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
