### PR TITLE
Fix typeing: Allow for null value in combobox selectItem type.

### DIFF
--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -833,7 +833,7 @@ These are functions you can call to change the state of the downshift
 | --------------------- | ------------------------- | ----------------------------------------------------- |
 | `closeMenu`           | `function()`              | closes the menu                                       |
 | `openMenu`            | `function()`              | opens the menu                                        |
-| `selectItem`          | `function(item: any)`     | selects the given item                                |
+| `selectItem`          | `function(item: any)`     | selects the given item or `null`                      |
 | `setHighlightedIndex` | `function(index: number)` | call to set a new highlighted index                   |
 | `setInputValue`       | `function(value: string)` | call to set a new value in the input                  |
 | `toggleMenu`          | `function()`              | toggle the menu open state                            |

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -527,7 +527,7 @@ export interface UseComboboxActions<Item> {
   openMenu: () => void
   closeMenu: () => void
   toggleMenu: () => void
-  selectItem: (item: Item) => void
+  selectItem: (item: Item | null) => void
   setHighlightedIndex: (index: number) => void
   setInputValue: (inputValue: string) => void
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:  Update the types file to allow the `item` passed into selectItem (returned from useCombobox) to be null.

<!-- Why are these changes necessary? -->

**Why**: Without this, you can't `selectItem(null)` using typescript.  This is done in the useMultiselect example in the docs, but currently not allowed by typescript types.  (See the example from the docs here: https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useMultipleSelection/combobox.js:1466-1495 )

<!-- How were these changes implemented? -->

**How**:
I added `| null` to the item parameter's type.    


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests n/a
- [x] TypeScript Types
- [x] Flow Types n/a
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I tried to update flow types as well, but couldn't find the relevant flow types.  I'm not too familiar with flow, so it might just be a case of I me not knowing what I'm doing.

I tried to run tests before opening the PR, but `npm install` is currently failing with react version mismatches in dependencies and I really doubt this will break any tests.  If you have a way to get tests working, I'll be happy to run them.

Error from `npm install`:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: downshift@0.0.0-semantically-released
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   dev react@"^17.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.0" from docz@2.3.1
npm ERR! node_modules/docz
npm ERR!   dev docz@"^2.3.1" from the root project
npm ERR! 
```