### PR TITLE
Fix: added custom aria-controls tag to Downshift component

### DIFF
--- a/src/__tests__/__snapshots__/downshift.aria.js.snap
+++ b/src/__tests__/__snapshots__/downshift.aria.js.snap
@@ -2,6 +2,7 @@
 
 exports[`basic snapshot 1`] = `
 <div
+  aria-controls=downshift-0
   aria-expanded=false
   aria-haspopup=listbox
   aria-labelledby=downshift-0-label
@@ -16,6 +17,7 @@ exports[`basic snapshot 1`] = `
   </label>
   <input
     aria-autocomplete=list
+    aria-controls=downshift-0
     aria-labelledby=downshift-0-label
     autocomplete=off
     data-testid=input
@@ -50,6 +52,7 @@ exports[`basic snapshot 1`] = `
 
 exports[`can override the ids 1`] = `
 <div
+  aria-controls=downshift-0
   aria-expanded=false
   aria-haspopup=listbox
   aria-labelledby=custom-label-id
@@ -64,6 +67,7 @@ exports[`can override the ids 1`] = `
   </label>
   <input
     aria-autocomplete=list
+    aria-controls=downshift-0
     aria-labelledby=custom-label-id
     autocomplete=off
     data-testid=input

--- a/src/__tests__/__snapshots__/downshift.get-item-props.js.snap
+++ b/src/__tests__/__snapshots__/downshift.get-item-props.js.snap
@@ -2,6 +2,7 @@
 
 exports[`getItemProps defaults the index when no index is given 1`] = `
 <div
+  aria-controls=downshift-1
   aria-expanded=false
   aria-haspopup=listbox
   aria-labelledby=downshift-1-label

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -73,6 +73,7 @@ class Downshift extends Component {
     inputId: PropTypes.string,
     menuId: PropTypes.string,
     getItemId: PropTypes.func,
+    ariaControls: PropTypes.string,
     /* eslint-enable react/no-unused-prop-types */
   }
 
@@ -148,6 +149,7 @@ class Downshift extends Component {
   labelId = this.props.labelId || `${this.id}-label`
   inputId = this.props.inputId || `${this.id}-input`
   getItemId = this.props.getItemId || (index => `${this.id}-item-${index}`)
+  ariaControls = this.props.ariaControls || `${this.id}`
 
   input = null
   items = []
@@ -498,6 +500,9 @@ class Downshift extends Component {
       'aria-haspopup': 'listbox',
       'aria-owns': isOpen ? this.menuId : null,
       'aria-labelledby': this.labelId,
+      // Until cypress-axe fixes issue of trowing flag "aria-required-attr" on aria-expanded=true
+      // After fixed, use `isOpen ? this.ariaControls : null`
+      'aria-controls': this.ariaControls,
       ...rest,
     }
   }
@@ -821,7 +826,7 @@ class Downshift extends Component {
         isOpen && typeof highlightedIndex === 'number' && highlightedIndex >= 0
           ? this.getItemId(highlightedIndex)
           : null,
-      'aria-controls': isOpen ? this.menuId : null,
+      'aria-controls': this.ariaControls,
       'aria-labelledby': this.labelId,
       // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
       // revert back since autocomplete="nope" is ignored on latest Chrome and Opera

--- a/src/hooks/testUtils.js
+++ b/src/hooks/testUtils.js
@@ -36,6 +36,7 @@ const defaultIds = {
   getItemId: index => `downshift-test-id-item-${index}`,
   toggleButtonId: 'downshift-test-id-toggle-button',
   inputId: 'downshift-test-id-input',
+  ariaControls: 'downshift-test-id',
 }
 
 const waitForDebouncedA11yStatusUpdate = () =>

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -48,17 +48,18 @@ describe('getInputProps', () => {
       const {result} = renderUseCombobox()
       const inputProps = result.current.getInputProps()
 
-      expect(inputProps['aria-controls']).toEqual(`${defaultIds.menuId}`)
+      expect(inputProps['aria-controls']).toEqual(`${defaultIds.ariaControls}`)
     })
 
     test('assign custom value passed by user to aria-controls', () => {
       const props = {
         menuId: 'my-custom-menu-id',
+        ariaControls: 'downshift-test-id',
       }
       const {result} = renderUseCombobox(props)
       const inputProps = result.current.getInputProps()
 
-      expect(inputProps['aria-controls']).toEqual(`${props.menuId}`)
+      expect(inputProps['aria-controls']).toEqual(`${props.ariaControls}`)
     })
 
     test('assign id of highlighted item to aria-activedescendant if item is highlighted and menu is open', () => {

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -438,7 +438,7 @@ function useCombobox(userProps = {}) {
         }),
         id: elementIds.inputId,
         'aria-autocomplete': 'list',
-        'aria-controls': elementIds.menuId,
+        'aria-controls': elementIds.ariaControls,
         ...(latestState.isOpen &&
           latestState.highlightedIndex > -1 && {
             'aria-activedescendant': elementIds.getItemId(
@@ -480,6 +480,7 @@ function useCombobox(userProps = {}) {
         'aria-haspopup': 'listbox',
         'aria-owns': elementIds.menuId,
         'aria-expanded': latest.current.state.isOpen,
+        'aria-controls': elementIds.ariaControls,
         ...rest,
       }
     },

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -101,6 +101,7 @@ function useElementIds({
   getItemId,
   toggleButtonId,
   inputId,
+  ariaControls,
 }) {
   const elementIdsRef = useRef({
     labelId: labelId || `${id}-label`,
@@ -108,6 +109,7 @@ function useElementIds({
     getItemId: getItemId || (index => `${id}-item-${index}`),
     toggleButtonId: toggleButtonId || `${id}-toggle-button`,
     inputId: inputId || `${id}-input`,
+    ariaControls: ariaControls || `${id}`,
   })
 
   return elementIdsRef.current


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added prop `ariaControls : string` to `Dropshift` component

<!-- Why are these changes necessary? -->

**Why**: To pass Accessibility checks from [cypress-axe](https://www.npmjs.com/package/cypress-axe), specifically checkPageA11y() function

<!-- How were these changes implemented? -->

**How**: Added `ariaControls` prop as primitive `PropTypes.string` to `Dropshift` component props

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] TypeScript Types
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Just added another prop and updated tests to pass with the new prop defaults.
Fixes issue #1336.
