### PR TITLE
fix(useMultipleSelect): removeSelectedItem adding duplicate items to selected items

### DIFF
--- a/src/hooks/useMultipleSelection/__tests__/returnProps.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/returnProps.test.js
@@ -60,6 +60,34 @@ describe('returnProps', () => {
       expect(result.current.activeIndex).toEqual(0)
     })
 
+    test('removeSelectedItem handles undefined item without modifying the selected array or the active index', () => {
+      const {result} = renderUseMultipleSelection({
+        initialSelectedItems: ['test', 'more test'],
+        initialActiveIndex: 1,
+      })
+
+      act(() => {
+        result.current.removeSelectedItem(undefined)
+      })
+
+      expect(result.current.selectedItems).toStrictEqual(['test', 'more test'])
+      expect(result.current.activeIndex).toEqual(1)
+    })
+
+    test('removeSelectedItem handles null item without modifying the selected array or the active index', () => {
+      const {result} = renderUseMultipleSelection({
+        initialSelectedItems: ['test', 'more test'],
+        initialActiveIndex: 1,
+      })
+
+      act(() => {
+        result.current.removeSelectedItem(null)
+      })
+
+      expect(result.current.selectedItems).toStrictEqual(['test', 'more test'])
+      expect(result.current.activeIndex).toEqual(1)
+    })
+
     test('setActiveIndex sets activeIndex', () => {
       const {result} = renderUseMultipleSelection()
 

--- a/src/hooks/useMultipleSelection/reducer.js
+++ b/src/hooks/useMultipleSelection/reducer.js
@@ -83,7 +83,7 @@ export default function downshiftMultipleSelectionReducer(state, action) {
             ...selectedItems.slice(0, selectedItemIndex),
             ...selectedItems.slice(selectedItemIndex + 1),
           ],
-          ...{activeIndex: newActiveIndex},
+          activeIndex: newActiveIndex,
         }
       }
       break

--- a/src/hooks/useMultipleSelection/reducer.js
+++ b/src/hooks/useMultipleSelection/reducer.js
@@ -71,18 +71,20 @@ export default function downshiftMultipleSelectionReducer(state, action) {
       let newActiveIndex = activeIndex
       const selectedItemIndex = selectedItems.indexOf(selectedItem)
 
-      if (selectedItems.length === 1) {
-        newActiveIndex = -1
-      } else if (selectedItemIndex === selectedItems.length - 1) {
-        newActiveIndex = selectedItems.length - 2
-      }
+      if (selectedItemIndex >= 0) {
+        if (selectedItems.length === 1) {
+          newActiveIndex = -1
+        } else if (selectedItemIndex === selectedItems.length - 1) {
+          newActiveIndex = selectedItems.length - 2
+        }
 
-      changes = {
-        selectedItems: [
-          ...selectedItems.slice(0, selectedItemIndex),
-          ...selectedItems.slice(selectedItemIndex + 1),
-        ],
-        ...{activeIndex: newActiveIndex},
+        changes = {
+          selectedItems: [
+            ...selectedItems.slice(0, selectedItemIndex),
+            ...selectedItems.slice(selectedItemIndex + 1),
+          ],
+          ...{activeIndex: newActiveIndex},
+        }
       }
       break
     }


### PR DESCRIPTION
fixes #1316

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixing the handling of undefined/null being provided to  `useMultipleSelection`'s `removeSelectedItem` function.

**Why**:

Currently when undefined/null is provided one of the items is duplicated in `selectedItems` 

**How**:

Only modifying the `selectedItems` and `activeIndex` if `selectedItemIndex` is greater than or equal to zero

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests
- [x] TypeScript Types N/A
- [x] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
