### PR TITLE
docs: update stateChangeTypes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,8 @@ and is as follows:
 - `Downshift.stateChangeTypes.keyDownArrowDown`
 - `Downshift.stateChangeTypes.keyDownEscape`
 - `Downshift.stateChangeTypes.keyDownEnter`
+- `Downshift.stateChangeTypes.keyDownHome`
+- `Downshift.stateChangeTypes.keyDownEnd`
 - `Downshift.stateChangeTypes.clickItem`
 - `Downshift.stateChangeTypes.blurInput`
 - `Downshift.stateChangeTypes.changeInput`


### PR DESCRIPTION
Prior to this PR, the stateChangeTypes as listed in the README were not in sync with those defined in the code.