### PR TITLE
fix(TS): allow selectedItem to accept array

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -61,7 +61,7 @@ export interface DownshiftProps<Item> {
   highlightedIndex?: number | null
   inputValue?: string | null
   isOpen?: boolean
-  selectedItem?: Item | null
+  selectedItem?: Item | Item[] | null
   children?: ChildrenFunction<Item>
   id?: string
   inputId?: string


### PR DESCRIPTION
What:

Change DownshiftProps interface selectedItem property to accept an array
of Item generic.

Why:

This is necessary to support the Array(any) for selectedItem prop as
outlined in the readme
(https://github.com/downshift-js/downshift#selecteditem)

How:

Update the typings index file

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
