### PR TITLE
fix(useCombobox): prevent default on Escape when menu is visible or input has content

### DIFF
--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -170,7 +170,7 @@ describe('getInputProps', () => {
         result.current.toggleMenu()
       })
       act(() => {
-        onKeyDown({key: 'Escape', preventDefault: noop})
+        onKeyDown({key: 'Escape', preventDefault: noop, stopPropagation: noop})
       })
 
       expect(userOnKeyDown).toHaveBeenCalledTimes(1)
@@ -228,7 +228,7 @@ describe('getInputProps', () => {
 
         inputRef({focus: noop})
         result.current.toggleMenu()
-        onBlur({key: 'Escape', preventDefault: noop})
+        onBlur({preventDefault: noop})
       })
 
       expect(userOnBlur).toHaveBeenCalledTimes(1)
@@ -769,6 +769,25 @@ describe('getInputProps', () => {
         keyDownOnInput('Escape')
 
         expect(renderSpy).toHaveBeenCalledTimes(1) // re-render on key
+      })
+
+      test('escape stops propagation when it closes the menu or clears the input', () => {
+        const {input} = renderCombobox({
+          initialIsOpen: true,
+          initialSelectedItem: items[0],
+        })
+        const keyDownEvents = [
+          createEvent.keyDown(input, {key: 'Escape'}),
+          createEvent.keyDown(input, {key: 'Escape'}),
+          createEvent.keyDown(input, {key: 'Escape'}),
+        ]
+
+        for (let index = 0; index < keyDownEvents.length; index++) {
+          fireEvent(input, keyDownEvents[index])
+          expect(keyDownEvents[index].defaultPrevented).toBe(
+            index !== keyDownEvents.length - 1,
+          )
+        }
       })
 
       test('enter it closes the menu and selects highlighted item', () => {

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -190,7 +190,7 @@ function useCombobox(userProps = {}) {
           getItemNodeFromIndex,
         })
       },
-      Escape() {
+      Escape(event) {
         const latestState = latest.current.state
         if (
           latestState.isOpen ||
@@ -198,6 +198,8 @@ function useCombobox(userProps = {}) {
           latestState.selectedItem ||
           latestState.highlightedIndex > -1
         ) {
+          event.preventDefault()
+
           dispatch({
             type: stateChangeTypes.InputKeyDownEscape,
           })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Closes https://github.com/downshift-js/downshift/issues/1406.
<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
