### PR TITLE
dev: use cypress preprocessor

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,8 @@ const customPreset = api => {
   const plugins = [
     require.resolve('babel-plugin-dynamic-import-node'),
     ['no-side-effect-class-properties'],
+    ['@babel/plugin-proposal-private-property-in-object', {loose: true}], // cypress warning because loose is false in preset-env
+    ['@babel/plugin-proposal-private-methods', {loose: true}], // cypress warning because loose is false in preset-env
     ...evaluatedPreset.plugins,
   ]
   return {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,8 +1,12 @@
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 const {defineConfig} = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:6006',
     video: false,
+    setupNodeEvents(on) {
+      on('file:preprocessor', webpackPreprocessor())
+    },
   },
 })

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@babel/helpers": "^7.14.8",
+    "@cypress/webpack-preprocessor": "^5.12.2",
     "@docusaurus/core": "^2.0.1",
     "@docusaurus/module-type-aliases": "^2.0.1",
     "@docusaurus/preset-classic": "^2.0.1",


### PR DESCRIPTION
Fixes https://github.com/downshift-js/downshift/issues/1411.

Installs and uses cypress preprocessor for cypress tests. This should allow the parsing of the code that has modules

```
[test:cypress] Error: Webpack Compilation Error
[test:cypress] ./node_modules/@testing-library/dom/dist/@testing-library/dom.esm.js 429:27
[test:cypress] Module parse failed: Unexpected token (429:27)
```

As explained on the [cypress docsite](https://github.com/cypress-io/cypress/tree/master/npm/webpack-preprocessor). Not sure why the issue started to happen now, but this fix should probably solve it, as far as I understand from digging around.