### PR TITLE
fix(useCombobox): do not blur on item click

### DIFF
--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -57,6 +57,7 @@ describe('getItemProps', () => {
 
       expect(itemProps.onClick).toBeUndefined()
       expect(itemProps.onMouseMove).toBeDefined()
+      expect(itemProps.onMouseDown).toBeDefined()
       expect(itemProps.disabled).toBe(true)
     })
   })
@@ -103,6 +104,44 @@ describe('getItemProps', () => {
 
       expect(userOnMouseMove).toHaveBeenCalledTimes(1)
       expect(result.current.highlightedIndex).toBe(1)
+    })
+
+    test('event handler onMouseDown is called along with downshift handler', () => {
+      const userOnMouseDown = jest.fn()
+      const preventDefault = jest.fn()
+      const {result} = renderUseCombobox({initialIsOpen: true})
+
+      act(() => {
+        const {onMouseDown} = result.current.getItemProps({
+          index: 1,
+          onMouseDown: userOnMouseDown,
+        })
+
+        onMouseDown({preventDefault})
+      })
+
+      expect(userOnMouseDown).toHaveBeenCalledTimes(1)
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+    })
+
+    test("event handler onMouseDown is called without downshift handler if 'preventDownshiftDefault' is passed in user event", () => {
+      const userOnMouseDown = jest.fn(event => {
+        event.preventDownshiftDefault = true
+      })
+      const preventDefault = jest.fn()
+      const {result} = renderUseCombobox({initialIsOpen: true})
+
+      act(() => {
+        const {onMouseDown} = result.current.getItemProps({
+          index: 0,
+          onMouseDown: userOnMouseDown,
+        })
+
+        onMouseDown({preventDefault})
+      })
+
+      expect(userOnMouseDown).toHaveBeenCalledTimes(1)
+      expect(preventDefault).not.toHaveBeenCalled()
     })
 
     test("event handler onClick is called without downshift handler if 'preventDownshiftDefault' is passed in user event", () => {
@@ -229,7 +268,7 @@ describe('getItemProps', () => {
     })
 
     describe('on click', () => {
-      test('it selects the item', () => {
+      test('it selects the item and keeps focus on the input', () => {
         const index = 1
         const {input, getItems, clickOnItemAtIndex} = renderCombobox({
           initialIsOpen: true,
@@ -239,6 +278,7 @@ describe('getItemProps', () => {
 
         expect(getItems()).toHaveLength(0)
         expect(input).toHaveValue(items[index])
+        expect(input).toHaveFocus()
       })
 
       test('it selects the item and resets to user defined defaults', () => {

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -266,6 +266,7 @@ function useCombobox(userProps = {}) {
       refKey = 'ref',
       ref,
       onMouseMove,
+      onMouseDown,
       onClick,
       onPress,
       disabled,
@@ -292,7 +293,7 @@ function useCombobox(userProps = {}) {
         dispatch({
           type: stateChangeTypes.ItemMouseMove,
           index,
-          disabled
+          disabled,
         })
       }
       const itemHandleClick = () => {
@@ -300,11 +301,8 @@ function useCombobox(userProps = {}) {
           type: stateChangeTypes.ItemClick,
           index,
         })
-
-        if (inputRef.current) {
-          inputRef.current.focus()
-        }
       }
+      const itemHandleMouseDown = e => e.preventDefault()
 
       return {
         [refKey]: handleRefs(ref, itemNode => {
@@ -322,8 +320,9 @@ function useCombobox(userProps = {}) {
             itemHandleClick,
           ),
         }),
-          onMouseMove: callAllEventHandlers(onMouseMove, itemHandleMouseMove),
-          ...rest,
+        onMouseMove: callAllEventHandlers(onMouseMove, itemHandleMouseMove),
+        onMouseDown: callAllEventHandlers(onMouseDown, itemHandleMouseDown),
+        ...rest,
       }
     },
     [dispatch, latest, shouldScrollRef, elementIds],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Closes https://github.com/downshift-js/downshift/issues/1409.
<!-- Why are these changes necessary? -->

**Why**:
Before these changes, when an item was selected, the input was blurred, and the input received focus after the dispatch event in the item click handler.
It worked fine apart from the corner case in https://github.com/downshift-js/downshift/issues/1409 and https://github.com/downshift-js/downshift/issues/1405. There, when input received focus from the handler, it called OpenMenu, which was called with the previous `selectedItem`, since it was controlled, and the prop did not get updated yet. OpenMenu was called before this controlled prop update.
<!-- How were these changes implemented? -->

**How**:
To fix it, instead of adding focus manually after triggering item click state update, we are preventing the blur altogether via event.preventDefault() in the item onMouseDown. Consequently, we are fixing the exact use case we need to fix (item click) while leaving the other selection & blur scenarios intact (blur by click outside, select with tab).

I believe that these changes should not affect any of the working scenarios.

Updated tests to check input stays focused and the onMouseMove handler behaves as a downshift handler (can be prevented, can call user handler, is defined).
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
