### PR TITLE
fix: Improve `ControllerStateAndHelpers` typing

### DIFF
--- a/flow-typed/npm/downshift_v2.x.x.js.flow
+++ b/flow-typed/npm/downshift_v2.x.x.js.flow
@@ -234,7 +234,9 @@ declare module downshift {
   }
   declare export type ControllerStateAndHelpers<Item> = DownshiftState<Item> &
     PropGetters<Item> &
-    Actions<Item>
+    Actions<Item> & {
+      type: StateChangeTypes
+    }
   declare export type ChildrenFunction<Item> = (
     options: ControllerStateAndHelpers<Item>,
   ) => React.ReactNode

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -202,7 +202,9 @@ export interface Actions<Item> {
 
 export type ControllerStateAndHelpers<Item> = DownshiftState<Item> &
   PropGetters<Item> &
-  Actions<Item>
+  Actions<Item> & {
+    type: StateChangeTypes
+  }
 
 export type ChildrenFunction<Item> = (
   options: ControllerStateAndHelpers<Item>,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix typings (TS & Flow)

<!-- Why are these changes necessary? -->

**Why**: The `type` field [is set on the state](https://github.com/downshift-js/downshift/blob/1c7698080805e05f5180dd223cbc17932a85fd42/src/downshift.js#L351) that is passed to the `onInputValueChange` callback prop but the typings don't include it. This field is set correctly for other state change callbacks, it is just missing for this one.

<!-- How were these changes implemented? -->

**How**: Just edited index.d.ts to include the correct type

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation n/a
- [ ] Tests n/a
- [x] TypeScript Types
- [x] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
