### PR TITLE
fix(useSelect): trigger click manually on Enter / Space

### DIFF
--- a/src/hooks/MIGRATION_V7.md
+++ b/src/hooks/MIGRATION_V7.md
@@ -147,6 +147,8 @@ function stateReducer(state, actionAndChanges) {
 }
 ```
 
+> Another thing to mention is that, since ARIA 1.2 does not recommend a `<button>` element for the toggle button anymore, _Enter_ and _SpaceBar_ do not perform click events out of the box, when the menu is closed. Consequently, we are triggering these events manually. For backwards compatibility to pre v7, when menu is closed and toggle element receives _Enter_ or _SpaceBar_ key event, it will trigger a `useSelect.stateChangeTypes.ToggleButtonClick` type change.
+
 ### circularNavigation
 
 The prop _circularNavigation_ has been removed. Navigation inside the menu is

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -1067,6 +1067,16 @@ describe('getToggleButtonProps', () => {
         expect(keyDownEvent.defaultPrevented).toBe(true)
       })
 
+      test('enter prevents the default event behavior with the menu closed', () => {
+        renderSelect()
+        const toggleButton = getToggleButton()
+        const keyDownEvent = createEvent.keyDown(toggleButton, {key: 'Enter'})
+
+        fireEvent(toggleButton, keyDownEvent)
+
+        expect(keyDownEvent.defaultPrevented).toBe(true)
+      })
+
       test('space opens the menu without any item selected', async () => {
         renderSelect()
         const toggleButton = getToggleButton()
@@ -1111,8 +1121,18 @@ describe('getToggleButtonProps', () => {
         )
       })
 
-      test('space prevents the default event behavior', () => {
+      test('space prevents the default event behavior when select is open', () => {
         renderSelect({isOpen: true})
+        const toggleButton = getToggleButton()
+        const keyDownEvent = createEvent.keyDown(toggleButton, {key: ' '})
+
+        fireEvent(toggleButton, keyDownEvent)
+
+        expect(keyDownEvent.defaultPrevented).toBe(true)
+      })
+
+      test('space prevents the default event behavior when select is closed', () => {
+        renderSelect()
         const toggleButton = getToggleButton()
         const keyDownEvent = createEvent.keyDown(toggleButton, {key: ' '})
 

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -212,13 +212,13 @@ function useSelect(userProps = {}) {
         }
       },
       Enter(event) {
-        if (latest.current.state.isOpen) {
-          event.preventDefault()
+        event.preventDefault()
 
-          dispatch({
-            type: stateChangeTypes.ToggleButtonKeyDownEnter,
-          })
-        }
+        dispatch({
+          type: latest.current.state.isOpen
+            ? stateChangeTypes.ToggleButtonKeyDownEnter
+            : stateChangeTypes.ToggleButtonClick,
+        })
       },
       PageUp(event) {
         if (latest.current.state.isOpen) {
@@ -241,13 +241,13 @@ function useSelect(userProps = {}) {
         }
       },
       ' '(event) {
-        if (latest.current.state.isOpen) {
-          event.preventDefault()
+        event.preventDefault()
 
-          dispatch({
-            type: stateChangeTypes.ToggleButtonKeyDownSpaceButton,
-          })
-        }
+        dispatch({
+          type: latest.current.state.isOpen
+            ? stateChangeTypes.ToggleButtonKeyDownSpaceButton
+            : stateChangeTypes.ToggleButtonClick,
+        })
       },
     }),
     [dispatch, getItemNodeFromIndex, latest],
@@ -442,7 +442,7 @@ function useSelect(userProps = {}) {
         dispatch({
           type: stateChangeTypes.ItemMouseMove,
           index,
-          disabled
+          disabled,
         })
       }
       const itemHandleClick = () => {
@@ -476,7 +476,6 @@ function useSelect(userProps = {}) {
         onMouseMove,
         itemHandleMouseMove,
       )
-
 
       return itemProps
     },

--- a/src/hooks/useSelect/testUtils.js
+++ b/src/hooks/useSelect/testUtils.js
@@ -72,14 +72,11 @@ export function DropdownSelect({renderSpy, renderItem, ...props}) {
   return (
     <div>
       <label {...getLabelProps()}>Choose an element:</label>
-      <button
-        data-testid={dataTestIds.toggleButton}
-        {...getToggleButtonProps()}
-      >
+      <div data-testid={dataTestIds.toggleButton} {...getToggleButtonProps()}>
         {(selectedItem && selectedItem instanceof Object
           ? itemToString(selectedItem)
           : selectedItem) || 'Elements'}
-      </button>
+      </div>
       <ul data-testid={dataTestIds.menu} {...getMenuProps()}>
         {isOpen &&
           (props.items || items).map((item, index) => {
@@ -119,6 +116,50 @@ export function getItemIndexByCharacter(character, startIndex = 0) {
 }
 
 export const stateChangeTestCases = [
+  {
+    step: keyDownOnToggleButton,
+    arg: '{Enter}',
+    state: {
+      isOpen: true,
+      highlightedIndex: -1,
+      inputValue: '',
+      selectedItem: null,
+    },
+    type: stateChangeTypes.ToggleButtonClick,
+  },
+  {
+    step: keyDownOnToggleButton,
+    arg: '{Enter}',
+    state: {
+      isOpen: false,
+      highlightedIndex: -1,
+      inputValue: '',
+      selectedItem: null,
+    },
+    type: stateChangeTypes.ToggleButtonKeyDownEnter,
+  },
+  {
+    step: keyDownOnToggleButton,
+    arg: ' ',
+    state: {
+      isOpen: true,
+      highlightedIndex: -1,
+      inputValue: '',
+      selectedItem: null,
+    },
+    type: stateChangeTypes.ToggleButtonClick,
+  },
+  {
+    step: keyDownOnToggleButton,
+    arg: '{Escape}',
+    state: {
+      isOpen: false,
+      highlightedIndex: -1,
+      inputValue: '',
+      selectedItem: null,
+    },
+    type: stateChangeTypes.ToggleButtonKeyDownEscape,
+  },
   {
     step: keyDownOnToggleButton,
     arg: '{ArrowDown}',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes https://github.com/downshift-js/downshift/issues/1428.
<!-- Why are these changes necessary? -->

**Why**:
As we don't use `<button>` anymore in building `useSelect` we have to trigger the click manually on Enter/SpaceBar.
<!-- How were these changes implemented? -->

**How**:
Trigger the click state change on Enter/SpaceBar if menu is closed.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Check how it works with `<button>` elements.
- [x] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
