### PR TITLE
fix: add clean up to avoid effect firing twice in strict mode

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -139,6 +139,10 @@ function useCombobox(userProps = {}) {
   // Make initial ref false.
   useEffect(() => {
     isInitialMountRef.current = false
+
+    return () => {
+      isInitialMountRef.current = true
+    }
   }, [])
   // Reset itemRefs on close.
   useEffect(() => {

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -99,6 +99,10 @@ function useMultipleSelection(userProps = {}) {
   // Make initial ref false.
   useEffect(() => {
     isInitialMountRef.current = false
+
+    return () => {
+      isInitialMountRef.current = true
+    }
   }, [])
 
   // Event handler functions.

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -159,6 +159,10 @@ function useSelect(userProps = {}) {
   // Make initial ref false.
   useEffect(() => {
     isInitialMountRef.current = false
+
+    return () => {
+      isInitialMountRef.current = true
+    }
   }, [])
   // Reset itemRefs on close.
   useEffect(() => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add clean up function to `isInitialMountRef` initialization. 

<!-- Why are these changes necessary? -->

**Why**:

It fixes the bug that when the page load and if the dropdown is not above the content, the dropdown is focused and cases the page scrolled in strict mode. 

<!-- How were these changes implemented? -->

**How**:

As react [official doc](https://beta.reactjs.org/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development), we should add clean-up function for initialization on effect to avoid the effect firing twice in the strict mode (development mode) 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->