### PR TITLE
docs: fix Downshift example to work in TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ render(
         <label {...getLabelProps()}>Enter a fruit</label>
         <div
           style={{display: 'inline-block'}}
-          {...getRootProps({}, {suppressRefError: true})}
+          {...getRootProps({refKey: 'ref'}, {suppressRefError: true})}
         >
           <input {...getInputProps()} />
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix the downshift example usage to work for TS as well.
<!-- Why are these changes necessary? -->

**Why**:
Copy-paste of code should work.
Closes https://github.com/downshift-js/downshift/issues/1354.
<!-- How were these changes implemented? -->

**How**:
Add `{refKey: ref}` as first argument to `getRootProps`.
Maybe there can be a TS update for that property to be optional, but since it has been around for about 5 years and Downshift is replaced by useCombobox, digging into the matter is not something I'd want to do.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
