### PR TITLE
fix(TS): make refKey optional in GetRootPropsOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -105,7 +105,7 @@ type StateChangeFunction<Item> = (
 ) => Partial<StateChangeOptions<Item>>
 
 export interface GetRootPropsOptions {
-  refKey: string
+  refKey?: string
 }
 
 export interface GetInputPropsOptions


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Make `refKey` optional in `GetRootPropsOptions`.
<!-- Why are these changes necessary? -->

**Why**:
Closes https://github.com/downshift-js/downshift/issues/1354.
The `refKey` prop is treated as optional in downshift.
<!-- How were these changes implemented? -->

**How**:
Make it optional in the typings.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
