### PR TITLE
docs: align docs with v7

### DIFF
--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -442,7 +442,7 @@ that are part of their starting string equivalent.
   property with the new value. This also has a `type` property which you can
   learn more about in the [`stateChangeTypes`](#statechangetypes) section. This
   property will be part of the actions that can trigger a `highlightedIndex`
-  change, for example `useCombobox.stateChangeTypes.MenuKeyDownArrowUp`.
+  change, for example `useCombobox.stateChangeTypes.InputKeyDownArrowUp`.
 
 ### onIsOpenChange
 

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -434,9 +434,8 @@ properties:
 
 Called each time the highlighted item was changed. Items can be highlighted
 while hovering the mouse over them or by keyboard keys such as Up Arrow, Down
-Arrow, Home and End. Arrow keys can be combined with Shift to move by a step of
-5 positions instead of 1. Items can also be highlighted by hitting character
-keys that are part of their starting string equivalent.
+Arrow, Home and End. Items can also be highlighted by hitting character keys
+that are part of their starting string equivalent.
 
 - `changes`: These are the properties that actually have changed since the last
   state change. This object is guaranteed to contain the `highlightedIndex`
@@ -640,8 +639,8 @@ that state from other components, `redux`, `react-router`, or anywhere else.
 
 > Note: This is very similar to how normal controlled components work elsewhere
 > in react (like `<input />`). If you want to learn more about this concept, you
-> can learn about that from this the
-> [Advanced React Component Patterns course][advanced-react-component-patterns-course]
+> can learn about that from the [Advanced React Component Patterns
+> course][advanced-react-component-patterns-course]
 
 ## Returned props
 
@@ -1064,6 +1063,7 @@ suggestion and the Codesandbox for it, and we will take it from there.
   https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf
 [docsite]: https://downshift-js.com/
 [sandbox-repo]: https://codesandbox.io/s/github/kentcdodds/downshift-examples
-[advanced-react-component-patterns-course]: https://github.com/downshift-js/downshift#advanced-react-component-patterns-course
+[advanced-react-component-patterns-course]:
+  https://github.com/downshift-js/downshift#advanced-react-component-patterns-course
 [migration-guide-v7]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/MIGRATION_V7.md#usecombobox

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -249,7 +249,7 @@ function stateReducer(state, actionAndChanges) {
   const {type, changes} = actionAndChanges
   // this prevents the menu from being closed when the user selects an item with 'Enter' or mouse
   switch (type) {
-    case useSelect.stateChangeTypes.MenuKeyDownEnter:
+    case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
     case useSelect.stateChangeTypes.ItemClick:
       return {
         ...changes, // default Downshift new state changes on item selection.
@@ -371,7 +371,7 @@ that are part of their starting string equivalent.
   property with the new value. This also has a `type` property which you can
   learn more about in the [`stateChangeTypes`](#statechangetypes) section. This
   property will be part of the actions that can trigger a `highlightedIndex`
-  change, for example `useSelect.stateChangeTypes.MenuKeyDownArrowUp`.
+  change, for example `useSelect.stateChangeTypes.ToggleButtonKeyDownArrowUp`.
 
 ### onIsOpenChange
 

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -363,9 +363,8 @@ properties:
 
 Called each time the highlighted item was changed. Items can be highlighted
 while hovering the mouse over them or by keyboard keys such as Up Arrow, Down
-Arrow, Home and End. Arrow keys can be combined with Shift to move by a step of
-5 positions instead of 1. Items can also be highlighted by hitting character
-keys that are part of their starting string equivalent.
+Arrow, Home and End. Items can also be highlighted by hitting character keys
+that are part of their starting string equivalent.
 
 - `changes`: These are the properties that actually have changed since the last
   state change. This object is guaranteed to contain the `highlightedIndex`
@@ -540,8 +539,8 @@ that state from other components, `redux`, `react-router`, or anywhere else.
 
 > Note: This is very similar to how normal controlled components work elsewhere
 > in react (like `<input />`). If you want to learn more about this concept, you
-> can learn about that from this the
-> [Advanced React Component Patterns course][advanced-react-component-patterns-course]
+> can learn about that from the [Advanced React Component Patterns
+> course][advanced-react-component-patterns-course]
 
 ## Returned props
 
@@ -937,6 +936,7 @@ suggestion and the Codesandbox for it, and we will take it from there.
   https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf
 [docsite]: https://downshift-js.com/
 [sandbox-repo]: https://codesandbox.io/s/github/kentcdodds/downshift-examples
-[advanced-react-component-patterns-course]: https://github.com/downshift-js/downshift#advanced-react-component-patterns-course
+[advanced-react-component-patterns-course]:
+  https://github.com/downshift-js/downshift#advanced-react-component-patterns-course
 [migration-guide-v7]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/MIGRATION_V7.md#useselect


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Remove reference to usage of shift modifier with arrow keys from useSelect and useCombobox docs

<!-- Why are these changes necessary? -->

**Why**: Since v7, using shift modifier key + arrow key is not supported.

