### PR TITLE
feat(useSelect): improve highlight by character keys algorithm

### DIFF
--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -247,11 +247,22 @@ function useSelect(userProps = {}) {
       ' '(event) {
         event.preventDefault()
 
-        dispatch({
-          type: latest.current.state.isOpen
-            ? stateChangeTypes.ToggleButtonKeyDownSpaceButton
-            : stateChangeTypes.ToggleButtonClick,
-        })
+        const currentState = latest.current.state
+
+        if (!currentState.isOpen) {
+          dispatch({type: stateChangeTypes.ToggleButtonClick})
+          return
+        }
+
+        if (currentState.inputValue) {
+          dispatch({
+            type: stateChangeTypes.ToggleButtonKeyDownCharacter,
+            key: ' ',
+            getItemNodeFromIndex,
+          })
+        } else {
+          dispatch({type: stateChangeTypes.ToggleButtonKeyDownSpaceButton})
+        }
       },
     }),
     [dispatch, getItemNodeFromIndex, latest],

--- a/src/hooks/useSelect/utils.ts
+++ b/src/hooks/useSelect/utils.ts
@@ -14,14 +14,15 @@ export function getItemIndexByCharacterKey<Item>({
   const lowerCasedKeysSoFar = keysSoFar.toLowerCase()
 
   for (let index = 0; index < items.length; index++) {
-    const offsetIndex = (index + highlightedIndex + 1) % items.length
+    // if we already have a search query in progress, we also consider the current highlighted item.
+    const offsetIndex =
+      (index + highlightedIndex + (keysSoFar.length < 2 ? 1 : 0)) % items.length
+
     const item = items[offsetIndex]
 
     if (
       item !== undefined &&
-      itemToString(item)
-        .toLowerCase()
-        .startsWith(lowerCasedKeysSoFar)
+      itemToString(item).toLowerCase().startsWith(lowerCasedKeysSoFar)
     ) {
       const element = getItemNodeFromIndex(offsetIndex)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Improve the highlight by character keys algorithm of useSelect.

<!-- Why are these changes necessary? -->

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1163.
Fixes https://github.com/downshift-js/downshift/issues/1339.


<!-- How were these changes implemented? -->

**How**:

1. If we hit Space when select is closed, it will trigger ToggleButtonClick, and will open the menu. If it's open, it will close it, with the same state change type, and select the highlighted item, if any.
2. If we hit Space after we typed at least one character key in the last 500ms, it will count as the next character key of the search query, and will trigger the ToggleButtonKeyDownCharacter state change type.
3. If we hit character key for the first time with the select open, it will search to highlight the first item starting with that character, and it will begin the search from highlightedIndex + 1, if any.
4. If we hit character key after we already typed at least another one in the last 500ms, it will search to highlight the first item starting with those characters, and it will begin the search from highlightedIndex, if any. Previous to this change, it searched from highlightedIndex + 1, so even if the current highlighted item was still matching the search query criteria, it was skipped for the next valid item, if any.

The native select works a bit differently for behaviour #3, as it begins search from highlightedIndex. I don't think it's a great behaviour. We typed a search query, landed on a valid item. If I will type the search query again, then I most probably want to jump to the next valid item.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
