### PR TITLE
fix: set `browserlist` so that js files are transpiled

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,7 +6,15 @@ module.exports = defineConfig({
     baseUrl: 'http://localhost:6006',
     video: false,
     setupNodeEvents(on) {
-      on('file:preprocessor', webpackPreprocessor())
+      on(
+        'file:preprocessor',
+        webpackPreprocessor({
+          webpackOptions: {
+            ...webpackPreprocessor.defaultOptions.webpackOptions,
+            target: 'web',
+          },
+        }),
+      )
     },
   },
 })

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,16 @@ const config = {
       }),
     ],
   ],
-  plugins: [require.resolve('./docusaurus/plugins/webpack5polyfills.js')],
+  plugins: [
+    // @ts-ignore
+    () => ({
+      name: 'configure-webpack-target',
+      configureWebpack(webpackConfig, isServer) {
+        webpackConfig.target = isServer ? 'node' : 'web'
+      },
+    }),
+    require.resolve('./docusaurus/plugins/webpack5polyfills.js'),
+  ],
 }
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/downshift.esm.js",
   "typings": "typings/index.d.ts",
   "sideEffects": false,
+  "browserslist": [],
   "scripts": {
     "build": "npm run build:web --silent && npm run build:native --silent",
     "build:web": "kcd-scripts build --bundle --p-react --no-clean --size-snapshot",


### PR DESCRIPTION
**What**:

This PR changes the JS to be transpiled.

**Why**:

Unfortunately at the moment we cannot use downshift because it is tripping up our storybook and webpack builds due to some syntax that is too new, such as `??`.

**How**:

Configure the `browserlist` in package.json.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
