### PR TITLE
fix(useMultipleSelection): prevent adding items on Backspace/Delete without activeIndex

### DIFF
--- a/src/hooks/useMultipleSelection/__tests__/getSelectedItemProps.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/getSelectedItemProps.test.js
@@ -389,6 +389,22 @@ describe('getSelectedItemProps', () => {
         expect(getSelectedItemAtIndex(1)).toHaveTextContent(items[1])
       })
 
+      test('backspace and delete change nothing if there is no selected item focused', async () => {
+        renderMultipleCombobox({
+          multipleSelectionProps: {
+            initialSelectedItems: [items[0], items[1], items[2]],
+          },
+        })
+
+        await keyDownOnSelectedItemAtIndex(2, '{Backspace}')
+
+        expect(getSelectedItems()).toHaveLength(3)
+
+        await keyDownOnSelectedItemAtIndex(1, '{Delete}')
+
+        expect(getSelectedItems()).toHaveLength(3)
+      })
+
       test('navigation works correctly with both click and arrow keys', async () => {
         renderMultipleCombobox({
           multipleSelectionProps: {

--- a/src/hooks/useMultipleSelection/__tests__/props.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/props.test.js
@@ -569,16 +569,18 @@ describe('props', () => {
     })
 
     test('can have downshift actions executed', () => {
+      const initialActiveIndex = 3
       const {result} = renderUseMultipleSelection({
         onSelectedItemsChange: () => {
           result.current.setActiveIndex(1)
         },
         initialSelectedItems: items,
+        initialActiveIndex,
       })
 
       act(() => {
         result.current
-          .getSelectedItemProps({index: 3})
+          .getSelectedItemProps({index: initialActiveIndex})
           .onKeyDown({key: 'Backspace'})
       })
 

--- a/src/hooks/useMultipleSelection/reducer.js
+++ b/src/hooks/useMultipleSelection/reducer.js
@@ -29,6 +29,10 @@ export default function downshiftMultipleSelectionReducer(state, action) {
       break
     case stateChangeTypes.SelectedItemKeyDownBackspace:
     case stateChangeTypes.SelectedItemKeyDownDelete: {
+      if (activeIndex < 0) {
+        break
+      }
+
       let newActiveIndex = activeIndex
 
       if (selectedItems.length === 1) {
@@ -47,6 +51,7 @@ export default function downshiftMultipleSelectionReducer(state, action) {
 
       break
     }
+
     case stateChangeTypes.DropdownKeyDownNavigationPrevious:
       changes = {
         activeIndex: selectedItems.length - 1,
@@ -71,21 +76,24 @@ export default function downshiftMultipleSelectionReducer(state, action) {
       let newActiveIndex = activeIndex
       const selectedItemIndex = selectedItems.indexOf(selectedItem)
 
-      if (selectedItemIndex >= 0) {
-        if (selectedItems.length === 1) {
-          newActiveIndex = -1
-        } else if (selectedItemIndex === selectedItems.length - 1) {
-          newActiveIndex = selectedItems.length - 2
-        }
-
-        changes = {
-          selectedItems: [
-            ...selectedItems.slice(0, selectedItemIndex),
-            ...selectedItems.slice(selectedItemIndex + 1),
-          ],
-          activeIndex: newActiveIndex,
-        }
+      if (selectedItemIndex < 0) {
+        break
       }
+
+      if (selectedItems.length === 1) {
+        newActiveIndex = -1
+      } else if (selectedItemIndex === selectedItems.length - 1) {
+        newActiveIndex = selectedItems.length - 2
+      }
+
+      changes = {
+        selectedItems: [
+          ...selectedItems.slice(0, selectedItemIndex),
+          ...selectedItems.slice(selectedItemIndex + 1),
+        ],
+        activeIndex: newActiveIndex,
+      }
+
       break
     }
     case stateChangeTypes.FunctionSetSelectedItems: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

If activeIndex is -1, do not react on Backspace/Delete keydown from selected item element.
Even when a selected item is no properly focused (not active), it can still receive keydowns, and the previous implementation did not account for it, resulting in adding duplicated selected items.

<!-- Why are these changes necessary? -->

**Why**:

Fixes https://github.com/downshift-js/downshift/issues/1138.

<!-- How were these changes implemented? -->

**How**:

Exit fast from reducer's SelectedItemKeyDownBackspace and SelectedItemKeyDownDelete handler if activeIndex is -1.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
