### PR TITLE
fix(defaultProps): only select if there are items and one is highlighted

### DIFF
--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -950,7 +950,7 @@ described below.
 - `Alt+ArrowUp`: If the menu is open, it will close it and will select the item
   that was highlighted.
 - `CharacterKey`: Will change the `inputValue` according to the value visible in
-  the `<input>`. `Backspace` or `Space` triggere the same event.
+  the `<input>`. `Backspace` or `Space` trigger the same event.
 - `End`: If the menu is open, it will highlight the last item in the list.
 - `Home`: If the menu is open, it will highlight the first item in the list.
 - `PageUp`: If the menu is open, it will move the highlight the item 10

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -1,4 +1,8 @@
-import {getHighlightedIndexOnOpen, getDefaultValue} from '../utils'
+import {
+  getHighlightedIndexOnOpen,
+  getDefaultValue,
+  getChangesOnSelection,
+} from '../utils'
 import {getNextWrappingIndex, getNextNonDisabledIndex} from '../../utils'
 import commonReducer from '../reducer'
 import * as stateChangeTypes from './stateChangeTypes'
@@ -46,16 +50,7 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.InputKeyDownArrowUp:
       if (state.isOpen) {
         if (altKey) {
-          changes = {
-            isOpen: getDefaultValue(props, 'isOpen'),
-            highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
-            ...(state.highlightedIndex >= 0 && {
-              selectedItem: props.items[state.highlightedIndex],
-              inputValue: props.itemToString(
-                props.items[state.highlightedIndex],
-              ),
-            }),
-          }
+          changes = getChangesOnSelection(props, state.highlightedIndex)
         } else {
           changes = {
             highlightedIndex: getNextWrappingIndex(
@@ -80,14 +75,8 @@ export default function downshiftUseComboboxReducer(state, action) {
       }
       break
     case stateChangeTypes.InputKeyDownEnter:
-      changes = {
-        isOpen: getDefaultValue(props, 'isOpen'),
-        highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
-        ...(state.highlightedIndex >= 0 && {
-          selectedItem: props.items[state.highlightedIndex],
-          inputValue: props.itemToString(props.items[state.highlightedIndex]),
-        }),
-      }
+      changes = getChangesOnSelection(props, state.highlightedIndex)
+
       break
     case stateChangeTypes.InputKeyDownEscape:
       changes = {
@@ -148,6 +137,7 @@ export default function downshiftUseComboboxReducer(state, action) {
         isOpen: false,
         highlightedIndex: -1,
         ...(state.highlightedIndex >= 0 &&
+          props.items?.length &&
           action.selectItem && {
             selectedItem: props.items[state.highlightedIndex],
             inputValue: props.itemToString(props.items[state.highlightedIndex]),

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -13,7 +13,7 @@ import {
 } from '../utils'
 import {ControlledPropUpdatedSelectedItem} from './stateChangeTypes'
 
-function getInitialState(props) {
+export function getInitialState(props) {
   const initialState = getInitialStateCommon(props)
   const {selectedItem} = initialState
   let {inputValue} = initialState
@@ -86,7 +86,7 @@ const propTypes = {
  * @param {Object} props The hook props.
  * @returns {Array} An array with the state and an action dispatcher.
  */
-function useControlledReducer(reducer, initialState, props) {
+export function useControlledReducer(reducer, initialState, props) {
   const previousSelectedItemRef = useRef()
   const [state, dispatch] = useEnhancedReducer(reducer, initialState, props)
 
@@ -111,7 +111,7 @@ function useControlledReducer(reducer, initialState, props) {
 }
 
 // eslint-disable-next-line import/no-mutable-exports
-let validatePropTypes = noop
+export let validatePropTypes = noop
 /* istanbul ignore next */
 if (process.env.NODE_ENV !== 'production') {
   validatePropTypes = (options, caller) => {
@@ -119,9 +119,7 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
-const defaultProps = {
+export const defaultProps = {
   ...defaultPropsCommon,
   getA11yStatusMessage,
 }
-
-export {validatePropTypes, useControlledReducer, getInitialState, defaultProps}

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -18,7 +18,12 @@ import {
   tab,
 } from '../testUtils'
 import utils from '../../utils'
-import {items, defaultIds} from '../../testUtils'
+import {
+  items,
+  defaultIds,
+  mouseMoveItemAtIndex,
+  mouseLeaveItemAtIndex,
+} from '../../testUtils'
 import useSelect from '..'
 import * as stateChangeTypes from '../stateChangeTypes'
 
@@ -795,6 +800,61 @@ describe('getToggleButtonProps', () => {
             defaultIds.getItemId(items.length - 1),
           )
         })
+
+        test('with Alt selects highlighted item and resets to user defaults', async () => {
+          const defaultHighlightedIndex = 2
+          renderSelect({
+            defaultHighlightedIndex,
+            defaultIsOpen: true,
+          })
+          const toggleButton = getToggleButton()
+
+          await keyDownOnToggleButton('{Alt>}{ArrowUp}{/Alt}')
+
+          expect(toggleButton).toHaveTextContent(items[defaultHighlightedIndex])
+          expect(getItems()).toHaveLength(items.length)
+          expect(toggleButton).toHaveAttribute(
+            'aria-activedescendant',
+            defaultIds.getItemId(defaultHighlightedIndex),
+          )
+        })
+
+        test('with Alt closes the menu without resetting to user defaults if no item is highlighted', async () => {
+          const defaultHighlightedIndex = 2
+          const initialSelectedItem = items[0]
+          renderSelect({
+            defaultHighlightedIndex,
+            defaultIsOpen: true,
+            initialSelectedItem,
+          })
+          const toggleButton = getToggleButton()
+
+          await mouseMoveItemAtIndex(defaultHighlightedIndex)
+          await mouseLeaveItemAtIndex(defaultHighlightedIndex)
+          await keyDownOnToggleButton('{Alt>}{ArrowUp}{/Alt}')
+
+          expect(toggleButton).toHaveTextContent(initialSelectedItem)
+          expect(getItems()).toHaveLength(0)
+          expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+        })
+
+        test('with Alt closes the menu without resetting to user defaults if the list is empty', async () => {
+          const defaultHighlightedIndex = 2
+          const initialSelectedItem = items[0]
+          renderSelect({
+            defaultHighlightedIndex,
+            defaultIsOpen: true,
+            initialSelectedItem,
+            items: [],
+          })
+          const toggleButton = getToggleButton()
+
+          await keyDownOnToggleButton('{Alt>}{ArrowUp}{/Alt}')
+
+          expect(toggleButton).toHaveTextContent(initialSelectedItem)
+          expect(getItems()).toHaveLength(0)
+          expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+        })
       })
 
       describe('arrow down', () => {
@@ -1122,6 +1182,43 @@ describe('getToggleButtonProps', () => {
         )
       })
 
+      test('enter closes the menu without resetting to user defaults if no item is highlighted', async () => {
+        const defaultHighlightedIndex = 2
+        const initialSelectedItem = items[0]
+        renderSelect({
+          defaultHighlightedIndex,
+          defaultIsOpen: true,
+          initialSelectedItem,
+        })
+        const toggleButton = getToggleButton()
+
+        await mouseMoveItemAtIndex(defaultHighlightedIndex)
+        await mouseLeaveItemAtIndex(defaultHighlightedIndex)
+        await keyDownOnToggleButton('{Enter}')
+
+        expect(toggleButton).toHaveTextContent(initialSelectedItem)
+        expect(getItems()).toHaveLength(0)
+        expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+      })
+
+      test('enter closes the menu without resetting to user defaults if the list is empty', async () => {
+        const defaultHighlightedIndex = 2
+        const initialSelectedItem = items[0]
+        renderSelect({
+          defaultHighlightedIndex,
+          defaultIsOpen: true,
+          initialSelectedItem,
+          items: [],
+        })
+        const toggleButton = getToggleButton()
+
+        await keyDownOnToggleButton('{Enter}')
+
+        expect(toggleButton).toHaveTextContent(initialSelectedItem)
+        expect(getItems()).toHaveLength(0)
+        expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+      })
+
       test('enter prevents the default event behavior with the menu open', () => {
         renderSelect({isOpen: true})
         const toggleButton = getToggleButton()
@@ -1186,6 +1283,43 @@ describe('getToggleButtonProps', () => {
         )
       })
 
+      test('space closes the menu without resetting to user defaults if no item is highlighted', async () => {
+        const defaultHighlightedIndex = 2
+        const initialSelectedItem = items[0]
+        renderSelect({
+          defaultHighlightedIndex,
+          defaultIsOpen: true,
+          initialSelectedItem,
+        })
+        const toggleButton = getToggleButton()
+
+        await mouseMoveItemAtIndex(defaultHighlightedIndex)
+        await mouseLeaveItemAtIndex(defaultHighlightedIndex)
+        await keyDownOnToggleButton(' ')
+
+        expect(toggleButton).toHaveTextContent(initialSelectedItem)
+        expect(getItems()).toHaveLength(0)
+        expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+      })
+
+      test('space closes the menu without resetting to user defaults if the list is empty', async () => {
+        const defaultHighlightedIndex = 2
+        const initialSelectedItem = items[0]
+        renderSelect({
+          defaultHighlightedIndex,
+          defaultIsOpen: true,
+          initialSelectedItem,
+          items: [],
+        })
+        const toggleButton = getToggleButton()
+
+        await keyDownOnToggleButton(' ')
+
+        expect(toggleButton).toHaveTextContent(initialSelectedItem)
+        expect(getItems()).toHaveLength(0)
+        expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+      })
+
       test('space prevents the default event behavior when select is open', () => {
         renderSelect({isOpen: true})
         const toggleButton = getToggleButton()
@@ -1236,6 +1370,63 @@ describe('getToggleButtonProps', () => {
           items[initialHighlightedIndex],
         )
         expect(screen.getByTestId(secondFocusableItemTestId)).toHaveFocus()
+      })
+
+      test('tab closes the menu if there is no highlighted item', async () => {
+        const defaultHighlightedIndex = 2
+        const initialSelectedItem = items[0]
+
+        renderSelect(
+          {
+            defaultHighlightedIndex,
+            defaultIsOpen: true,
+            initialSelectedItem,
+          },
+          ui => {
+            return (
+              <>
+                {ui}
+                <div tabIndex={0}>Second element</div>
+              </>
+            )
+          },
+        )
+
+        await tab()
+        await mouseMoveItemAtIndex(defaultHighlightedIndex)
+        await mouseLeaveItemAtIndex(defaultHighlightedIndex)
+        await tab()
+
+        expect(getItems()).toHaveLength(0)
+        expect(getToggleButton()).toHaveTextContent(initialSelectedItem)
+      })
+
+      test('tab closes the menu if there is no items', async () => {
+        const defaultHighlightedIndex = 2
+        const initialSelectedItem = items[0]
+
+        renderSelect(
+          {
+            defaultHighlightedIndex,
+            defaultIsOpen: true,
+            initialSelectedItem,
+            items: [],
+          },
+          ui => {
+            return (
+              <>
+                {ui}
+                <div tabIndex={0}>Second element</div>
+              </>
+            )
+          },
+        )
+
+        await tab()
+        await tab()
+
+        expect(getItems()).toHaveLength(0)
+        expect(getToggleButton()).toHaveTextContent(initialSelectedItem)
       })
 
       test('shift+tab closes the menu and selects highlighted item', async () => {

--- a/src/hooks/useSelect/reducer.js
+++ b/src/hooks/useSelect/reducer.js
@@ -1,5 +1,9 @@
 import {getNextWrappingIndex, getNextNonDisabledIndex} from '../../utils'
-import {getHighlightedIndexOnOpen, getDefaultValue} from '../utils'
+import {
+  getHighlightedIndexOnOpen,
+  getDefaultValue,
+  getChangesOnSelection,
+} from '../utils'
 import commonReducer from '../reducer'
 import {getItemIndexByCharacterKey} from './utils'
 import * as stateChangeTypes from './stateChangeTypes'
@@ -64,13 +68,7 @@ export default function downshiftSelectReducer(state, action) {
       break
     case stateChangeTypes.ToggleButtonKeyDownArrowUp:
       if (state.isOpen && altKey) {
-        changes = {
-          isOpen: getDefaultValue(props, 'isOpen'),
-          highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
-          ...(state.highlightedIndex >= 0 && {
-            selectedItem: props.items[state.highlightedIndex],
-          }),
-        }
+        changes = getChangesOnSelection(props, state.highlightedIndex, false)
       } else {
         const highlightedIndex = state.isOpen
           ? getNextWrappingIndex(
@@ -91,13 +89,7 @@ export default function downshiftSelectReducer(state, action) {
     // only triggered when menu is open.
     case stateChangeTypes.ToggleButtonKeyDownEnter:
     case stateChangeTypes.ToggleButtonKeyDownSpaceButton:
-      changes = {
-        isOpen: getDefaultValue(props, 'isOpen'),
-        highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
-        ...(state.highlightedIndex >= 0 && {
-          selectedItem: props.items[state.highlightedIndex],
-        }),
-      }
+      changes = getChangesOnSelection(props, state.highlightedIndex, false)
 
       break
     case stateChangeTypes.ToggleButtonKeyDownHome:
@@ -159,9 +151,10 @@ export default function downshiftSelectReducer(state, action) {
       changes = {
         isOpen: false,
         highlightedIndex: -1,
-        ...(state.highlightedIndex >= 0 && {
-          selectedItem: props.items[state.highlightedIndex],
-        }),
+        ...(state.highlightedIndex >= 0 &&
+          props.items?.length && {
+            selectedItem: props.items[state.highlightedIndex],
+          }),
       }
 
       break

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -305,7 +305,7 @@ function getHighlightedIndexOnOpen(props, state, offset) {
  * @param {Function} handleBlur Handler on blur from mouse or touch.
  * @returns {Object} Ref containing whether mouseDown or touchMove event is happening
  */
- function useMouseAndTouchTracker(
+function useMouseAndTouchTracker(
   isOpen,
   downshiftElementRefs,
   environment,
@@ -511,6 +511,31 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
+/**
+ * Handles selection on Enter / Alt + ArrowUp. Closes the menu and resets the highlighted index, unless there is a highlighted.
+ * In that case, selects the item and resets to defaults for open state and highlighted idex.
+ * @param {Object} props The useCombobox props.
+ * @param {number} highlightedIndex The index from the state.
+ * @param {boolean} inputValue Also return the input value for state.
+ * @returns The changes for the state.
+ */
+function getChangesOnSelection(props, highlightedIndex, inputValue = true) {
+  const shouldSelect = props.items?.length && highlightedIndex >= 0
+
+  return {
+    isOpen: false,
+    highlightedIndex: -1,
+    ...(shouldSelect && {
+      selectedItem: props.items[highlightedIndex],
+      isOpen: getDefaultValue(props, 'isOpen'),
+      highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
+      ...(inputValue && {
+        inputValue: props.itemToString(props.items[highlightedIndex]),
+      }),
+    }),
+  }
+}
+
 export {
   useControlPropsValidator,
   useScrollIntoView,
@@ -529,4 +554,5 @@ export {
   isAcceptedCharacterKey,
   getItemIndex,
   useElementIds,
+  getChangesOnSelection,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix the behaviour of default props in hooks to only be called on selection, and only be applied if `items` is not empty and and the `defaultHighlightedIndex` is valid.
<!-- Why are these changes necessary? -->

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1223.

<!-- How were these changes implemented? -->

**How**:

Check if a selection should be performed by the rule `props.items?.length && highlightedIndex >= 0`
If a selection should be performed, the resulting state should be:
```js
      selectedItem: props.items[highlightedIndex],
      isOpen: getDefaultValue(props, 'isOpen'),
      highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
      ...(inputValue && {
        inputValue: props.itemToString(props.items[highlightedIndex]),
      }),
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
