### PR TITLE
fix(hooks): do not add mouse and touch events in React native

### DIFF
--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -305,7 +305,7 @@ function getHighlightedIndexOnOpen(props, state, offset) {
  * @param {Function} handleBlur Handler on blur from mouse or touch.
  * @returns {Object} Ref containing whether mouseDown or touchMove event is happening
  */
- function useMouseAndTouchTracker(
+function useMouseAndTouchTracker(
   isOpen,
   downshiftElementRefs,
   environment,
@@ -317,6 +317,11 @@ function getHighlightedIndexOnOpen(props, state, offset) {
   })
 
   useEffect(() => {
+    /* istanbul ignore if (react-native) */
+    if (isReactNative) {
+      return
+    }
+
     // The same strategy for checking if a click occurred inside or outside downsift
     // as in downshift.js.
     const onMouseDown = () => {
@@ -362,6 +367,7 @@ function getHighlightedIndexOnOpen(props, state, offset) {
     environment.addEventListener('touchmove', onTouchMove)
     environment.addEventListener('touchend', onTouchEnd)
 
+    // eslint-disable-next-line consistent-return
     return function cleanup() {
       environment.removeEventListener('mousedown', onMouseDown)
       environment.removeEventListener('mouseup', onMouseUp)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Do not add mouse and touch events from useMouseAndTouchTracker in the case of React native.
<!-- Why are these changes necessary? -->

**Why**:

Fixes https://github.com/downshift-js/downshift/issues/1315.
<!-- How were these changes implemented? -->

**How**:
Check in useMouseAndTouchTracker if isReactNative, and return directly from the useEffect. The return values will always be false on react Native, but this is also done in Downshift, so it's consistent.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
