### PR TITLE
fix(useCombobox): controlled selectedItem extra renders

### DIFF
--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -105,7 +105,7 @@ function useControlledReducer(reducer, initialState, props) {
           ? props.selectedItem
           : state.selectedItem
     }
-  })
+  }, [props.selectedItem, state.selectedItem])
 
   return [getState(state, props), dispatch]
 }


### PR DESCRIPTION
I noticed we are getting some flickering when updating the value of a combobox built using downshift. After much debugging the culprit seems to be the logic in `useControlledReducer`. 

We store the ID of the selected item as a query parameter and when updating the value through Next.js's router we get the flickering behavior. If I store the id in local state, the flickering doesn't happen.

As far as I can tell, the reason we see the flickering is because there is an extra render and this effect gets called again before the prop updated.

This PR changes to only run the effect when `props.selectedItem` or `state.selectedItem` change. This fixes the issue in our case. Making an effect run on every render seems not ideal anyway.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
