### PR TITLE
fix(useCombobox): use environment instead of document

### DIFF
--- a/src/hooks/__tests__/utils.test.js
+++ b/src/hooks/__tests__/utils.test.js
@@ -1,8 +1,10 @@
+import {renderHook} from '@testing-library/react-hooks'
 import {
   getItemIndex,
   defaultProps,
   getInitialValue,
   getDefaultValue,
+  useMouseAndTouchTracker,
 } from '../utils'
 
 describe('utils', () => {
@@ -62,5 +64,78 @@ describe('utils', () => {
     )
 
     expect(value).toEqual(defaults.bogusValue)
+  })
+
+  describe('useMouseAndTouchTracker', () => {
+    test('renders without error', () => {
+      expect(() => {
+        renderHook(() =>
+          useMouseAndTouchTracker(false, [], undefined, jest.fn()),
+        )
+      }).not.toThrowError()
+    })
+
+    test('adds and removes listeners to environment', () => {
+      const environment = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }
+
+      const {unmount, result} = renderHook(() =>
+        useMouseAndTouchTracker(false, [], environment, jest.fn()),
+      )
+
+      expect(environment.addEventListener).toHaveBeenCalledTimes(5)
+      expect(environment.addEventListener).toHaveBeenCalledWith(
+        'mousedown',
+        expect.any(Function),
+      )
+      expect(environment.addEventListener).toHaveBeenCalledWith(
+        'mouseup',
+        expect.any(Function),
+      )
+      expect(environment.addEventListener).toHaveBeenCalledWith(
+        'touchstart',
+        expect.any(Function),
+      )
+      expect(environment.addEventListener).toHaveBeenCalledWith(
+        'touchmove',
+        expect.any(Function),
+      )
+      expect(environment.addEventListener).toHaveBeenCalledWith(
+        'touchend',
+        expect.any(Function),
+      )
+      expect(environment.removeEventListener).not.toHaveBeenCalled()
+
+      unmount()
+
+      expect(environment.addEventListener).toHaveBeenCalledTimes(5)
+      expect(environment.removeEventListener).toHaveBeenCalledTimes(5)
+      expect(environment.removeEventListener).toHaveBeenCalledWith(
+        'mousedown',
+        expect.any(Function),
+      )
+      expect(environment.removeEventListener).toHaveBeenCalledWith(
+        'mouseup',
+        expect.any(Function),
+      )
+      expect(environment.removeEventListener).toHaveBeenCalledWith(
+        'touchstart',
+        expect.any(Function),
+      )
+      expect(environment.removeEventListener).toHaveBeenCalledWith(
+        'touchmove',
+        expect.any(Function),
+      )
+      expect(environment.removeEventListener).toHaveBeenCalledWith(
+        'touchend',
+        expect.any(Function),
+      )
+
+      expect(result.current).toEqual({
+        current: {isMouseDown: false, isTouchMove: false},
+      })
+    })
   })
 })

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -148,10 +148,10 @@ function useCombobox(userProps = {}) {
   useEffect(() => {
     if (!isOpen) {
       itemRefs.current = {}
-    } else if (document.activeElement !== inputRef.current) {
+    } else if (environment.document?.activeElement !== inputRef.current) {
       inputRef?.current?.focus()
     }
-  }, [isOpen])
+  }, [isOpen, environment])
 
   /* Event handler functions */
   const inputKeyDownHandlers = useMemo(

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -317,12 +317,11 @@ function useMouseAndTouchTracker(
   })
 
   useEffect(() => {
-    /* istanbul ignore if (react-native) */
-    if (isReactNative) {
+    if (environment?.addEventListener == null) {
       return
     }
 
-    // The same strategy for checking if a click occurred inside or outside downsift
+    // The same strategy for checking if a click occurred inside or outside downshift
     // as in downshift.js.
     const onMouseDown = () => {
       mouseAndTouchTrackersRef.current.isMouseDown = true


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Use `environment` instead of `document` in a `useCombobox` line.

<!-- Why are these changes necessary? -->

**Why**:
In case there is no `document` available, like in React Native, and in other situations when `document` needs to be replaced by the `environment` prop.
<!-- How were these changes implemented? -->

**How**:
Replace `document` with `environment.document`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
