### PR TITLE
types: return values for getter props

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^26.0.24",
     "@types/react": "^17.0.15",
+    "@types/react-native": "^0.71.3",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
     "@typescript-eslint/parser": "^4.28.5",
     "babel-plugin-macros": "^3.1.0",

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -505,7 +505,7 @@ class Downshift extends Component {
       role: 'combobox',
       'aria-expanded': isOpen,
       'aria-haspopup': 'listbox',
-      'aria-owns': isOpen ? this.menuId : null,
+      'aria-owns': isOpen ? this.menuId : undefined,
       'aria-labelledby': this.labelId,
       ...rest,
     }

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -833,7 +833,7 @@ class Downshift extends Component {
       'aria-activedescendant':
         isOpen && typeof highlightedIndex === 'number' && highlightedIndex >= 0
           ? this.getItemId(highlightedIndex)
-          : null,
+          : undefined,
       'aria-controls': isOpen ? this.menuId : undefined,
       'aria-labelledby': rest && rest['aria-label'] ? undefined : this.labelId,
       // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

--- a/src/downshift.js
+++ b/src/downshift.js
@@ -834,7 +834,7 @@ class Downshift extends Component {
         isOpen && typeof highlightedIndex === 'number' && highlightedIndex >= 0
           ? this.getItemId(highlightedIndex)
           : null,
-      'aria-controls': isOpen ? this.menuId : null,
+      'aria-controls': isOpen ? this.menuId : undefined,
       'aria-labelledby': rest && rest['aria-label'] ? undefined : this.labelId,
       // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
       // revert back since autocomplete="nope" is ignored on latest Chrome and Opera
@@ -900,7 +900,8 @@ class Downshift extends Component {
     return {
       [refKey]: handleRefs(ref, this.menuRef),
       role: 'listbox',
-      'aria-labelledby': props && props['aria-label'] ? null : this.labelId,
+      'aria-labelledby':
+        props && props['aria-label'] ? undefined : this.labelId,
       id: this.menuId,
       ...props,
     }

--- a/src/hooks/MIGRATION_V8.md
+++ b/src/hooks/MIGRATION_V8.md
@@ -10,7 +10,7 @@ hooks and are detailed below.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [isItemDisabled](#isitemdisabled)
-  - [useCombobox input click](#usecombobox-input-click)
+- [useCombobox input click](#usecombobox-input-click)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -53,7 +53,7 @@ return (
 
 The API for Downshift remains unchange.
 
-### useCombobox input click
+## useCombobox input click
 
 [ARIA 1.2](combobox-aria-example) recommends to toggle the menu open state at
 input click. Previously, in v7, the menu was opened on receiving focus, from
@@ -104,6 +104,15 @@ Consider to use the default 1.2 ARIA behaviour provided by default in order to
 align your widget to the accessibility official spec. This behaviour consistency
 improves the user experience, since all comboboxes should behave the same and
 there won't be need for any additional guess work done by your users.
+
+## Getter props return value types
+
+Previously, the return value from the getter props returned by both Downshift
+and the hooks was `any`. In v8 we improved the types in order to reflect what is
+actually returned: the default values return by the getter prop function and
+whatever else the user passes as arguments. The type changes are done in
+[this PR](https://github.com/downshift-js/downshift/pull/1482), make sure you
+adapt your TS code, if applicable.
 
 [combobox-aria-example]:
   https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-autocomplete-list.html

--- a/src/hooks/MIGRATION_V8.md
+++ b/src/hooks/MIGRATION_V8.md
@@ -114,5 +114,16 @@ whatever else the user passes as arguments. The type changes are done in
 [this PR](https://github.com/downshift-js/downshift/pull/1482), make sure you
 adapt your TS code, if applicable.
 
+Also, in the `Downshift` component, the return values for some getter prop
+values have changed from `null` to `undefined`, since that is what HTML elements
+expect (value or undefined). These values are also reflected in the TS types.
+
+- getRootProps: 'aria-owns': isOpen ? this.menuId : ~~null~~undefined,
+- getInputProps:
+  - 'aria-controls': isOpen ? this.menuId : ~~null~~undefined
+  - 'aria-activedescendant': isOpen && typeof highlightedIndex === 'number' &&
+    highlightedIndex >= 0 ? this.getItemId(highlightedIndex) : ~~null~~undefined
+- getMenuProps: props && props['aria-label'] ? ~~null~~undefined : this.labelId,
+
 [combobox-aria-example]:
   https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-autocomplete-list.html

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -481,7 +481,7 @@ function useCombobox(userProps = {}) {
         'aria-controls': elementIds.menuId,
         'aria-expanded': latestState.isOpen,
         'aria-labelledby':
-          rest && rest['aria-label'] ? undefined : `${elementIds.labelId}`,
+          rest && rest['aria-label'] ? undefined : elementIds.labelId,
         // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
         // revert back since autocomplete="nope" is ignored on latest Chrome and Opera
         autoComplete: 'off',

--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -31,43 +31,55 @@ export default class App extends React.Component<Props, State> {
           getToggleButtonProps,
           getInputProps,
           getItemProps,
+          getLabelProps,
+          getRootProps,
+          getMenuProps,
           isOpen,
           inputValue,
           selectedItem,
           highlightedIndex,
-        }) => (
-          <div>
-            <input
-              {...getInputProps({
-                placeholder: 'Favorite color ?',
-              })}
-            />
-            <button {...getToggleButtonProps()} />
-            {isOpen ? (
-              <div style={{border: '1px solid #ccc'}}>
-                {items
-                  .filter(
-                    i =>
-                      !inputValue ||
-                      i.toLowerCase().includes(inputValue.toLowerCase()),
-                  )
-                  .map((item, index: number) => (
-                    <div
-                      {...getItemProps({item, index})}
-                      key={item}
-                      style={{
-                        backgroundColor:
-                          highlightedIndex === index ? 'gray' : 'white',
-                        fontWeight: selectedItem === item ? 'bold' : 'normal',
-                      }}
-                    >
-                      {item}
-                    </div>
-                  ))}
-              </div>
-            ) : null}
-          </div>
-        )}
+        }) => {
+          return (
+            <div>
+              <div {...getRootProps({}, {})}></div>
+              <label
+                {...getLabelProps()}
+              >
+                Hello:
+              </label>
+              <label {...getLabelProps()}>Hello:</label>
+              <input
+                {...getInputProps({
+                  placeholder: 'Favorite color ?',
+                })}
+              />
+              <button {...getToggleButtonProps()} />
+              {isOpen ? (
+                <div style={{border: '1px solid #ccc'}} {...getMenuProps()}>
+                  {items
+                    .filter(
+                      i =>
+                        !inputValue ||
+                        i.toLowerCase().includes(inputValue.toLowerCase()),
+                    )
+                    .map((item, index: number) => (
+                      <div
+                        {...getItemProps({item, index})}
+                        key={item}
+                        style={{
+                          backgroundColor:
+                            highlightedIndex === index ? 'gray' : 'white',
+                          fontWeight: selectedItem === item ? 'bold' : 'normal',
+                        }}
+                      >
+                        {item}
+                      </div>
+                    ))}
+                </div>
+              ) : null}
+            </div>
+          )
+        }}
       </Downshift>
     )
   }

--- a/test/downshift.test.tsx
+++ b/test/downshift.test.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+
+import Downshift from '..'
+
+export const colors = [
+  'Black',
+  'Red',
+  'Green',
+  'Blue',
+  'Orange',
+  'Purple',
+  'Pink',
+  'Orchid',
+  'Aqua',
+  'Lime',
+  'Gray',
+  'Brown',
+  'Teal',
+  'Skyblue',
+]
+
+export default function ComboBox() {
+  return (
+    <Downshift>
+      {({
+        getInputProps,
+        getItemProps,
+        getMenuProps,
+        getLabelProps,
+        getToggleButtonProps,
+        inputValue,
+        isOpen,
+        getRootProps,
+        clearSelection,
+      }) => (
+        <div>
+          <label {...getLabelProps()}>Choose an element:</label>
+          <div {...getRootProps({}, {suppressRefError: true})}>
+            <input {...getInputProps()} data-testid="combobox-input" />
+            <button
+              {...getToggleButtonProps({
+                'aria-label': 'toggle menu',
+                'data-testid': 'combobox-toggle-button',
+              })}
+            >
+              {isOpen ? <>&#8593;</> : <>&#8595;</>}
+            </button>
+            <button
+              aria-label="toggle menu"
+              data-testid="clear-button"
+              onClick={() => clearSelection()}
+            >
+              &#10007;
+            </button>
+          </div>
+          <ul {...getMenuProps()}>
+            {isOpen &&
+              (inputValue
+                ? colors.filter(i =>
+                    i.toLowerCase().includes(inputValue.toLowerCase()),
+                  )
+                : colors
+              ).map((item, index) => (
+                <li
+                  key={`${item}${index}`}
+                  {...getItemProps({
+                    item,
+                    index,
+                    'data-testid': `downshift-item-${index}`,
+                  })}
+                >
+                  {item}
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </Downshift>
+  )
+}

--- a/test/useCombobox.test.tsx
+++ b/test/useCombobox.test.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+
+import {useCombobox} from '..'
+
+export const colors = [
+  'Black',
+  'Red',
+  'Green',
+  'Blue',
+  'Orange',
+  'Purple',
+  'Pink',
+  'Orchid',
+  'Aqua',
+  'Lime',
+  'Gray',
+  'Brown',
+  'Teal',
+  'Skyblue',
+]
+
+export default function DropdownCombobox() {
+  const [inputItems, setInputItems] = React.useState(colors)
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    getItemProps,
+    selectItem,
+  } = useCombobox({
+    items: inputItems,
+    onInputValueChange: ({inputValue}) => {
+      inputValue !== undefined &&
+        setInputItems(
+          colors.filter(item =>
+            item.toLowerCase().startsWith(inputValue.toLowerCase()),
+          ),
+        )
+    },
+  })
+  return (
+    <div>
+      <label {...getLabelProps()}>Choose an element:</label>
+      <div>
+        <input {...getInputProps()} data-testid="combobox-input" />
+        <button
+          aria-label="toggle menu"
+          data-testid="combobox-toggle-button"
+          {...getToggleButtonProps()}
+        >
+          {isOpen ? <>&#8593;</> : <>&#8595;</>}
+        </button>
+        <button
+          aria-label="toggle menu"
+          data-testid="clear-button"
+          onClick={() => selectItem(null)}
+        >
+          &#10007;
+        </button>
+      </div>
+      <ul {...getMenuProps()}>
+        {isOpen &&
+          inputItems.map((item, index) => (
+            <li
+              key={`${item}${index}`}
+              {...getItemProps({
+                item,
+                index,
+                'data-testid': `downshift-item-${index}`,
+              })}
+            >
+              {item}
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/test/useMultipleSelect.test.tsx
+++ b/test/useMultipleSelect.test.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+
+import {useMultipleSelection, useSelect} from '..'
+
+export const colors = [
+  'Black',
+  'Red',
+  'Green',
+  'Blue',
+  'Orange',
+  'Purple',
+  'Pink',
+  'Orchid',
+  'Aqua',
+  'Lime',
+  'Gray',
+  'Brown',
+  'Teal',
+  'Skyblue',
+]
+
+const initialSelectedItems = colors.slice(0, 2)
+
+function getFilteredItems(selectedItems: string[]): string[] {
+  return colors.filter(colour => !selectedItems.includes(colour))
+}
+
+export default function DropdownMultipleSelect() {
+  const {
+    getSelectedItemProps,
+    getDropdownProps,
+    addSelectedItem,
+    removeSelectedItem,
+    selectedItems,
+  } = useMultipleSelection({initialSelectedItems})
+  const items = getFilteredItems(selectedItems)
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    getItemProps,
+  } = useSelect({
+    items,
+    selectedItem: null,
+    stateReducer(_state, actionAndChanges) {
+      const {changes, type} = actionAndChanges
+      switch (type) {
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownSpaceButton:
+        case useSelect.stateChangeTypes.ItemClick:
+          return {
+            ...changes,
+            isOpen: true, // keep the menu open after selection.
+          }
+        default:
+          return changes
+      }
+    },
+    onStateChange({type, selectedItem: newSelectedItem}) {
+      switch (type) {
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownSpaceButton:
+        case useSelect.stateChangeTypes.ItemClick:
+          if (newSelectedItem) {
+            addSelectedItem(newSelectedItem)
+          }
+          break
+        default:
+          break
+      }
+    },
+  })
+
+  return (
+    <div>
+      <label {...getLabelProps()}>Choose an element:</label>
+      <div>
+        {selectedItems.map(function renderSelectedItem(
+          selectedItemForRender,
+          index,
+        ) {
+          return (
+            <span
+              key={`selected-item-${index}`}
+              {...getSelectedItemProps({
+                selectedItem: selectedItemForRender,
+                index,
+              })}
+            >
+              {selectedItemForRender}
+              <span
+                onClick={e => {
+                  e.stopPropagation()
+                  removeSelectedItem(selectedItemForRender)
+                }}
+              >
+                &#10005;
+              </span>
+            </span>
+          )
+        })}
+        <div
+          {...getToggleButtonProps(
+            getDropdownProps({preventKeyAction: isOpen}),
+          )}
+        >
+          Elements {isOpen ? <>&#8593;</> : <>&#8595;</>}
+        </div>
+      </div>
+      <ul {...getMenuProps()}>
+        {isOpen &&
+          colors.map((item, index) => (
+            <li
+              key={`${item}${index}`}
+              {...getItemProps({
+                item,
+                index,
+              })}
+            >
+              {item}
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/test/useSelect.test.tsx
+++ b/test/useSelect.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+
+import {useSelect} from '..'
+
+export const colors = [
+  'Black',
+  'Red',
+  'Green',
+  'Blue',
+  'Orange',
+  'Purple',
+  'Pink',
+  'Orchid',
+  'Aqua',
+  'Lime',
+  'Gray',
+  'Brown',
+  'Teal',
+  'Skyblue',
+]
+
+export default function DropdownSelect() {
+  const {
+    isOpen,
+    selectedItem,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    getItemProps,
+  } = useSelect({items: colors})
+
+  return (
+    <div>
+      <label {...getLabelProps()}>Choose an element:</label>
+      <div {...getToggleButtonProps()}>
+        {selectedItem ?? 'Elements'}
+        {isOpen ? <>&#8593;</> : <>&#8595;</>}
+      </div>
+      <ul {...getMenuProps()}>
+        {isOpen &&
+          colors.map((item, index) => (
+            <li
+              key={`${item}${index}`}
+              {...getItemProps({
+                item,
+                index,
+              })}
+            >
+              {item}
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,6 +3,8 @@ import * as ReactNative from 'react-native'
 
 type Callback = () => void
 
+type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
+
 export interface DownshiftState<Item> {
   highlightedIndex: number | null
   inputValue: string | null
@@ -131,13 +133,13 @@ export interface GetInputPropsReturnValue {
   'aria-controls': string | undefined
   'aria-labelledby': string | undefined
   autoComplete: 'off'
-  value: string
   id: string
   onChange?: React.ChangeEventHandler
   onChangeText?: React.ChangeEventHandler
   onInput?: React.FormEventHandler
   onKeyDown?: React.KeyboardEventHandler
   onBlur?: React.FocusEventHandler
+  value: string
 }
 
 export interface GetLabelPropsOptions
@@ -154,8 +156,6 @@ export interface GetToggleButtonPropsOptions
 }
 
 interface GetToggleButtonPropsReturnValue {
-  type: 'button'
-  role: 'button'
   'aria-label': 'close menu' | 'open menu'
   'aria-haspopup': true
   'data-toggle': true
@@ -164,6 +164,8 @@ interface GetToggleButtonPropsReturnValue {
   onKeyDown?: React.KeyboardEventHandler
   onKeyUp?: React.KeyboardEventHandler
   onBlur?: React.FocusEventHandler
+  role: 'button'
+  type: 'button'
 }
 export interface GetMenuPropsOptions
   extends React.HTMLProps<HTMLElement>,
@@ -172,9 +174,9 @@ export interface GetMenuPropsOptions
 }
 
 export interface GetMenuPropsReturnValue {
+  'aria-labelledby': string | undefined
   ref?: React.RefObject
   role: 'listbox'
-  'aria-labelledby': string | undefined
   id: string
 }
 
@@ -197,34 +199,34 @@ export interface GetItemPropsOptions<Item>
 export interface GetItemPropsReturnValue {
   'aria-selected': boolean
   id: string
-  role: 'option'
   onClick?: React.MouseEventHandler
   onMouseDown?: React.MouseEventHandler
   onMouseMove?: React.MouseEventHandler
   onPress?: React.MouseEventHandler
+  role: 'option'
 }
 
 export interface PropGetters<Item> {
   getRootProps: <Options>(
     options?: GetRootPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => GetRootPropsReturnValue & Options
+  ) => Overwrite<GetRootPropsReturnValue, Options>
   getToggleButtonProps: <Options>(
     options?: GetToggleButtonPropsOptions & Options,
-  ) => GetToggleButtonPropsReturnValue & Options
+  ) => Overwrite<GetToggleButtonPropsReturnValue, Options>
   getLabelProps: <Options>(
     options?: GetLabelPropsOptions & Options,
-  ) => GetLabelPropsReturnValue & Options
+  ) => Overwrite<GetLabelPropsReturnValue, Options>
   getMenuProps: <Options>(
     options?: GetMenuPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => GetMenuPropsReturnValue & Options
+  ) => Overwrite<GetMenuPropsReturnValue, Options>
   getInputProps: <Options>(
     options?: GetInputPropsOptions & Options,
-  ) => GetInputPropsReturnValue & Options
+  ) => Overwrite<GetInputPropsReturnValue, Options>
   getItemProps: <Options>(
     options: GetItemPropsOptions<Item> & Options,
-  ) => GetItemPropsReturnValue<Item> & Options
+  ) => Omit<Overwrite<GetItemPropsReturnValue, Options>, 'index' | 'item'>
 }
 
 export interface Actions<Item> {
@@ -404,13 +406,13 @@ export interface UseSelectGetToggleButtonReturnValue
     GetToggleButtonPropsReturnValue,
     'onBlur' | 'onClick' | 'onPress' | 'onKeyDown'
   > {
-  ref?: React.RefObject
   'aria-activedescendant': string
   'aria-controls': string
   'aria-expanded': boolean
   'aria-haspopup': 'listbox'
   'aria-labelledby': string | undefined
   id: string
+  ref?: React.RefObject
   role: 'combobox'
   tabIndex: 0
 }
@@ -424,7 +426,7 @@ export interface UseSelectGetItemPropsOptions<Item>
     GetPropsWithRefKey {}
 
 export interface UseSelectGetItemPropsReturnValue
-  extends Exclude<GetItemPropsReturnValue, 'onMouseDown'> {
+  extends Omit<GetItemPropsReturnValue, 'onMouseDown'> {
   'aria-disabled': boolean
   ref?: React.RefObject
 }
@@ -433,17 +435,20 @@ export interface UseSelectPropGetters<Item> {
   getToggleButtonProps: <Options>(
     options?: UseSelectGetToggleButtonPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => UseSelectGetToggleButtonReturnValue & Options
+  ) => Overwrite<UseSelectGetToggleButtonReturnValue, Options>
   getLabelProps: <Options>(
     options?: UseSelectGetLabelPropsOptions & Options,
-  ) => UseSelectGetLabelPropsReturnValue & Options
+  ) => Overwrite<UseSelectGetLabelPropsReturnValue, Options>
   getMenuProps: <Options>(
     options?: UseSelectGetMenuPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => UseSelectGetMenuReturnValue & Options
+  ) => Overwrite<UseSelectGetMenuReturnValue, Options>
   getItemProps: <Options>(
     options: UseSelectGetItemPropsOptions<Item> & Options,
-  ) => UseSelectGetItemPropsReturnValue & Options
+  ) => Omit<
+    Overwrite<UseSelectGetItemPropsReturnValue, Options>,
+    'index' | 'item'
+  >
 }
 
 export interface UseSelectActions<Item> {
@@ -594,13 +599,13 @@ export interface UseComboboxGetToggleButtonPropsOptions
     GetToggleButtonPropsOptions {}
 
 export interface UseComboboxGetToggleButtonPropsReturnValue {
-  ref?: React.RefObject
   'aria-controls': string
   'aria-expanded': boolean
   id: string
-  tabIndex: -1
   onPress?: (event: ReactNative.GestureResponderEvent) => void
   onClick?: React.MouseEventHandler
+  ref?: React.RefObject
+  tabIndex: -1
 }
 
 export interface UseComboboxGetLabelPropsOptions extends GetLabelPropsOptions {}
@@ -633,21 +638,24 @@ export interface UseComboboxGetInputPropsReturnValue
 export interface UseComboboxPropGetters<Item> {
   getToggleButtonProps: <Options>(
     options?: UseComboboxGetToggleButtonPropsOptions & Options,
-  ) => UseComboboxGetToggleButtonPropsReturnValue & Options
+  ) => Overwrite<UseComboboxGetToggleButtonPropsReturnValue, Options>
   getLabelProps: <Options>(
     options?: UseComboboxGetLabelPropsOptions & Options,
-  ) => UseComboboxGetLabelPropsReturnValue & Options
+  ) => Overwrite<UseComboboxGetLabelPropsReturnValue, Options>
   getMenuProps: <Options>(
     options?: UseComboboxGetMenuPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => UseComboboxGetMenuPropsReturnValue & Options
+  ) => Overwrite<UseComboboxGetMenuPropsReturnValue, Options>
   getItemProps: <Options>(
     options: UseComboboxGetItemPropsOptions<Item> & Options,
-  ) => UseComboboxGetItemPropsReturnValue & Options
+  ) => Omit<
+    Overwrite<UseComboboxGetItemPropsReturnValue, Options>,
+    'index' | 'item'
+  >
   getInputProps: <Options>(
     options?: UseComboboxGetInputPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => UseComboboxGetInputPropsReturnValue & Options
+  ) => Overwrite<UseComboboxGetInputPropsReturnValue, Options>
 }
 
 export interface UseComboboxActions<Item> {
@@ -774,20 +782,19 @@ export interface UseMultipleSelectionGetSelectedItemPropsOptions<Item>
   selectedItem: Item
 }
 
-export interface UseMultipleSelectionGetSelectedItemPropsReturnValue {
+export interface UseMultipleSelectionGetSelectedItemReturnValue {
   ref?: React.RefObject
   tabIndex: 0 | -1
   onClick: React.MouseEventHandler
   onKeyDown: React.KeyboardEventHandler
 }
 
-export type UseMultipleSelectionGetDropdownPropsOptions = GetInputPropsOptions &
-  GetToggleButtonPropsOptions &
-  GetPropsWithRefKey & {
-    preventKeyAction?: boolean
-  }
+export interface UseMultipleSelectionGetDropdownPropsOptions
+  extends React.HTMLProps<HTMLElement> {
+  preventKeyAction?: boolean
+}
 
-export interface UseMultipleSelectionGetDropdownPropsReturnValue {
+export interface UseMultipleSelectionGetDropdownReturnValue {
   ref?: React.RefObject
   onClick?: React.MouseEventHandler
   onKeyDown?: React.KeyboardEventHandler
@@ -797,10 +804,16 @@ export interface UseMultipleSelectionPropGetters<Item> {
   getDropdownProps: <Options>(
     options?: UseMultipleSelectionGetDropdownPropsOptions & Options,
     extraOptions?: GetPropsCommonOptions,
-  ) => UseMultipleSelectionGetDropdownPropsReturnValue & Options
+  ) => Omit<
+    Overwrite<UseMultipleSelectionGetDropdownReturnValue, Options>,
+    'preventKeyAction'
+  >
   getSelectedItemProps: <Options>(
     options: UseMultipleSelectionGetSelectedItemPropsOptions<Item> & Options,
-  ) => UseMultipleSelectionGetSelectedItemPropsReturnValue & Options
+  ) => Omit<
+    Overwrite<UseMultipleSelectionGetSelectedItemReturnValue, Options>,
+    'index' | 'selectedItem'
+  >
 }
 
 export interface UseMultipleSelectionActions<Item> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -107,6 +107,15 @@ type StateChangeFunction<Item> = (
 
 export interface GetRootPropsOptions {
   refKey?: string
+  ref?: React.RefObject
+}
+
+export interface GetRootPropsReturnValue {
+  role: string
+  'aria-expanded': boolean
+  'aria-haspopup': 'listbox'
+  'aria-labelledby': string
+  'aria-owns': string | undefined
 }
 
 export interface GetInputPropsOptions
@@ -116,6 +125,11 @@ export interface GetInputPropsOptions
 
 export interface GetLabelPropsOptions
   extends React.HTMLProps<HTMLLabelElement> {}
+
+export interface GetLabelPropsReturnValue {
+  htmlFor: string
+  id: string
+}
 
 export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {
@@ -145,12 +159,14 @@ export interface GetItemPropsOptions<Item>
 }
 
 export interface PropGetters<Item> {
-  getRootProps: (
-    options?: GetRootPropsOptions,
+  getRootProps: <Options>(
+    options?: Options & GetRootPropsOptions,
     otherOptions?: GetPropsCommonOptions,
-  ) => any
+  ) => Options & GetRootPropsReturnValue
   getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
-  getLabelProps: (options?: GetLabelPropsOptions) => any
+  getLabelProps: <Options>(
+    options?: Options & GetLabelPropsOptions,
+  ) => GetLabelPropsReturnValue & Options
   getMenuProps: (
     options?: GetMenuPropsOptions,
     otherOptions?: GetPropsCommonOptions,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,9 @@
 import * as React from 'react'
+import * as ReactNative from 'react-native'
 
 type Callback = () => void
+
+type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 
 export interface DownshiftState<Item> {
   highlightedIndex: number | null
@@ -136,6 +139,18 @@ export interface GetToggleButtonPropsOptions
   disabled?: boolean
 }
 
+interface GetToggleButtonPropsReturnValue {
+  type: 'button'
+  role: 'button'
+  'aria-label': 'close menu' | 'open menu'
+  'aria-haspopup': true
+  'data-toggle': true
+  onPress?: (event: ReactNative.GestureResponderEvent) => void
+  onClick?: React.MouseEventHandler
+  onKeyDown?: React.KeyboardEventHandler
+  onKeyUp?: React.KeyboardEventHandler
+  onBlur?: React.FocusEventHandler
+}
 export interface GetMenuPropsOptions
   extends React.HTMLProps<HTMLElement>,
     GetPropsWithRefKey {
@@ -160,13 +175,15 @@ export interface GetItemPropsOptions<Item>
 
 export interface PropGetters<Item> {
   getRootProps: <Options>(
-    options?: Options & GetRootPropsOptions,
+    options?: Overwrite<GetRootPropsOptions, Options>,
     otherOptions?: GetPropsCommonOptions,
-  ) => Options & GetRootPropsReturnValue
-  getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
+  ) => Overwrite<GetRootPropsReturnValue, Options>
+  getToggleButtonProps: <Options>(
+    options?: Overwrite<GetToggleButtonPropsOptions, Options>,
+  ) => Overwrite<GetToggleButtonPropsReturnValue, Options>
   getLabelProps: <Options>(
-    options?: Options & GetLabelPropsOptions,
-  ) => GetLabelPropsReturnValue & Options
+    options?: Overwrite<GetLabelPropsOptions, Options>,
+  ) => Overwrite<GetLabelPropsReturnValue, Options>
   getMenuProps: (
     options?: GetMenuPropsOptions,
     otherOptions?: GetPropsCommonOptions,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -152,8 +152,8 @@ export interface GetLabelPropsReturnValue {
 
 export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {
-  disabled?: boolean
-}
+    disabled?: boolean
+  }
 
 interface GetToggleButtonPropsReturnValue {
   type: 'button'
@@ -393,27 +393,58 @@ export interface UseSelectGetMenuPropsOptions
   extends GetPropsWithRefKey,
     GetMenuPropsOptions {}
 
+export interface UseSelectGetMenuReturnValue extends GetMenuPropsReturnValue {
+  onMouseLeave: React.MouseEventHandler
+}
+
 export interface UseSelectGetToggleButtonPropsOptions
   extends GetPropsWithRefKey,
-    GetToggleButtonPropsOptions {}
+    React.HTMLProps<HTMLElement> {}
+
+export interface UseSelectGetToggleButtonReturnValue
+  extends Pick<
+    GetToggleButtonPropsReturnValue,
+    'onBlur' | 'onClick' | 'onPress' | 'onKeyDown'
+  > {
+  ref?: React.RefObject
+  'aria-activedescendant': string | undefined
+  'aria-controls': string
+  'aria-expanded': boolean
+  'aria-haspopup': 'listbox'
+  'aria-labelledby': string | undefined
+  id: string
+  role: 'combobox'
+  tabIndex: 0
+}
 
 export interface UseSelectGetLabelPropsOptions extends GetLabelPropsOptions {}
+export interface UseSelectGetLabelPropsReturnValue
+  extends GetLabelPropsReturnValue {}
 
 export interface UseSelectGetItemPropsOptions<Item>
   extends Omit<GetItemPropsOptions<Item>, 'disabled'>,
     GetPropsWithRefKey {}
 
+export interface UseSelectGetItemPropsReturnValue
+  extends Exclude<GetItemPropsReturnValue, 'onMouseDown'> {
+  ref?: React.RefObject
+}
+
 export interface UseSelectPropGetters<Item> {
-  getToggleButtonProps: (
-    options?: UseSelectGetToggleButtonPropsOptions,
+  getToggleButtonProps: <Options>(
+    options?: Overwrite<UseSelectGetToggleButtonPropsOptions, Options>,
     otherOptions?: GetPropsCommonOptions,
-  ) => any
-  getLabelProps: (options?: UseSelectGetLabelPropsOptions) => any
-  getMenuProps: (
-    options?: UseSelectGetMenuPropsOptions,
+  ) => Overwrite<UseSelectGetToggleButtonReturnValue, Options>
+  getLabelProps: <Options>(
+    options?: Overwrite<UseSelectGetLabelPropsOptions, Options>,
+  ) => Overwrite<UseSelectGetLabelPropsReturnValue, Options>
+  getMenuProps: <Options>(
+    options?: Overwrite<UseSelectGetMenuPropsOptions, Options>,
     otherOptions?: GetPropsCommonOptions,
-  ) => any
-  getItemProps: (options: UseSelectGetItemPropsOptions<Item>) => any
+  ) => Overwrite<UseSelectGetMenuReturnValue, Options>
+  getItemProps: <Options>(
+    options: Overwrite<UseSelectGetItemPropsOptions<Item>, Overwrite>,
+  ) => Overwrite<UseSelectGetItemPropsReturnValue, Options>
 }
 
 export interface UseSelectActions<Item> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -131,7 +131,7 @@ export interface GetInputPropsReturnValue {
   'aria-autocomplete': 'list'
   'aria-activedescendant': string | undefined
   'aria-controls': string | undefined
-  'aria-labelledby': string
+  'aria-labelledby': string | undefined
   autoComplete: 'off'
   value: string
   id: string
@@ -152,8 +152,8 @@ export interface GetLabelPropsReturnValue {
 
 export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {
-    disabled?: boolean
-  }
+  disabled?: boolean
+}
 
 interface GetToggleButtonPropsReturnValue {
   type: 'button'
@@ -407,7 +407,7 @@ export interface UseSelectGetToggleButtonReturnValue
     'onBlur' | 'onClick' | 'onPress' | 'onKeyDown'
   > {
   ref?: React.RefObject
-  'aria-activedescendant': string | undefined
+  'aria-activedescendant': string
   'aria-controls': string
   'aria-expanded': boolean
   'aria-haspopup': 'listbox'
@@ -427,6 +427,7 @@ export interface UseSelectGetItemPropsOptions<Item>
 
 export interface UseSelectGetItemPropsReturnValue
   extends Exclude<GetItemPropsReturnValue, 'onMouseDown'> {
+  'aria-disabled': boolean
   ref?: React.RefObject
 }
 
@@ -587,34 +588,68 @@ export interface UseComboboxGetMenuPropsOptions
   extends GetPropsWithRefKey,
     GetMenuPropsOptions {}
 
+export interface UseComboboxGetMenuPropsReturnValue
+  extends UseSelectGetMenuReturnValue {}
+
 export interface UseComboboxGetToggleButtonPropsOptions
   extends GetPropsWithRefKey,
     GetToggleButtonPropsOptions {}
 
+export interface UseComboboxGetToggleButtonPropsReturnValue {
+  ref?: React.RefObject
+  'aria-controls': string
+  'aria-expanded': boolean
+  id: string
+  tabIndex: -1
+  onPress?: (event: ReactNative.GestureResponderEvent) => void
+  onClick?: React.MouseEventHandler
+}
+
 export interface UseComboboxGetLabelPropsOptions extends GetLabelPropsOptions {}
+
+export interface UseComboboxGetLabelPropsReturnValue
+  extends GetLabelPropsReturnValue {}
 
 export interface UseComboboxGetItemPropsOptions<Item>
   extends Omit<GetItemPropsOptions<Item>, 'disabled'>,
     GetPropsWithRefKey {}
 
+export interface UseComboboxGetItemPropsReturnValue
+  extends GetItemPropsReturnValue {
+  'aria-disabled': boolean
+  ref?: React.RefObject
+}
+
 export interface UseComboboxGetInputPropsOptions
   extends GetInputPropsOptions,
     GetPropsWithRefKey {}
 
+export interface UseComboboxGetInputPropsReturnValue
+  extends GetInputPropsReturnValue {
+  'aria-activedescendant': string
+  'aria-controls': string
+  'aria-expanded': boolean
+  role: 'combobox'
+  onClick: React.MouseEventHandler
+}
 export interface UseComboboxPropGetters<Item> {
-  getToggleButtonProps: (
-    options?: UseComboboxGetToggleButtonPropsOptions,
-  ) => any
-  getLabelProps: (options?: UseComboboxGetLabelPropsOptions) => any
-  getMenuProps: (
-    options?: UseComboboxGetMenuPropsOptions,
+  getToggleButtonProps: <Options>(
+    options?: Overwrite<UseComboboxGetToggleButtonPropsOptions, Options>,
+  ) => Overwrite<UseComboboxGetToggleButtonPropsReturnValue, Options>
+  getLabelProps: <Options>(
+    options?: Overwrite<UseComboboxGetLabelPropsOptions, Options>,
+  ) => Overwrite<UseComboboxGetLabelPropsReturnValue, Options>
+  getMenuProps: <Options>(
+    options?: Overwrite<UseComboboxGetMenuPropsOptions, Options>,
     otherOptions?: GetPropsCommonOptions,
-  ) => any
-  getItemProps: (options: UseComboboxGetItemPropsOptions<Item>) => any
-  getInputProps: (
-    options?: UseComboboxGetInputPropsOptions,
+  ) => Overwrite<UseComboboxGetMenuPropsReturnValue, Options>
+  getItemProps: <Options>(
+    options: Overwrite<UseComboboxGetItemPropsOptions<Item>, Options>,
+  ) => Overwrite<UseComboboxGetItemPropsReturnValue, Options>
+  getInputProps: <Options>(
+    options?: Overwrite<UseComboboxGetInputPropsOptions, Options>,
     otherOptions?: GetPropsCommonOptions,
-  ) => any
+  ) => Overwrite<UseComboboxGetInputPropsReturnValue, Options>
 }
 
 export interface UseComboboxActions<Item> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -114,16 +114,32 @@ export interface GetRootPropsOptions {
 }
 
 export interface GetRootPropsReturnValue {
-  role: string
   'aria-expanded': boolean
   'aria-haspopup': 'listbox'
   'aria-labelledby': string
   'aria-owns': string | undefined
+  ref?: React.RefObject
+  role: 'combobox'
 }
 
 export interface GetInputPropsOptions
   extends React.HTMLProps<HTMLInputElement> {
   disabled?: boolean
+}
+
+export interface GetInputPropsReturnValue {
+  'aria-autocomplete': 'list'
+  'aria-activedescendant': string | undefined
+  'aria-controls': string | undefined
+  'aria-labelledby': string
+  autoComplete: 'off'
+  value: string
+  id: string
+  onChange?: React.ChangeEventHandler
+  onChangeText?: React.ChangeEventHandler
+  onInput?: React.FormEventHandler
+  onKeyDown?: React.KeyboardEventHandler
+  onBlur?: React.FocusEventHandler
 }
 
 export interface GetLabelPropsOptions
@@ -157,6 +173,13 @@ export interface GetMenuPropsOptions
   ['aria-label']?: string
 }
 
+export interface GetMenuPropsReturnValue {
+  ref?: React.RefObject
+  role: 'listbox'
+  'aria-labelledby': string | undefined
+  id: string
+}
+
 export interface GetPropsCommonOptions {
   suppressRefError?: boolean
 }
@@ -173,6 +196,16 @@ export interface GetItemPropsOptions<Item>
   disabled?: boolean
 }
 
+export interface GetItemPropsReturnValue {
+  'aria-selected': boolean
+  id: string
+  role: 'option'
+  onClick?: React.MouseEventHandler
+  onMouseDown?: React.MouseEventHandler
+  onMouseMove?: React.MouseEventHandler
+  onPress?: React.MouseEventHandler
+}
+
 export interface PropGetters<Item> {
   getRootProps: <Options>(
     options?: Overwrite<GetRootPropsOptions, Options>,
@@ -184,12 +217,16 @@ export interface PropGetters<Item> {
   getLabelProps: <Options>(
     options?: Overwrite<GetLabelPropsOptions, Options>,
   ) => Overwrite<GetLabelPropsReturnValue, Options>
-  getMenuProps: (
-    options?: GetMenuPropsOptions,
+  getMenuProps: <Options>(
+    options?: Overwrite<GetMenuPropsOptions, Options>,
     otherOptions?: GetPropsCommonOptions,
-  ) => any
-  getInputProps: <T>(options?: T) => T & GetInputPropsOptions
-  getItemProps: (options: GetItemPropsOptions<Item>) => any
+  ) => Overwrite<GetMenuPropsReturnValue, Options>
+  getInputProps: <Options>(
+    options?: Overwrite<GetInputPropsOptions, Options>,
+  ) => Overwrite<GetInputPropsReturnValue, Options>
+  getItemProps: <Options>(
+    options: Overwrite<GetItemPropsOptions<Item>, Options>,
+  ) => Overwrite<GetItemPropsReturnValue<Item>, Options>
 }
 
 export interface Actions<Item> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,8 +3,6 @@ import * as ReactNative from 'react-native'
 
 type Callback = () => void
 
-type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
-
 export interface DownshiftState<Item> {
   highlightedIndex: number | null
   inputValue: string | null
@@ -208,25 +206,25 @@ export interface GetItemPropsReturnValue {
 
 export interface PropGetters<Item> {
   getRootProps: <Options>(
-    options?: Overwrite<GetRootPropsOptions, Options>,
+    options?: GetRootPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => Overwrite<GetRootPropsReturnValue, Options>
+  ) => GetRootPropsReturnValue & Options
   getToggleButtonProps: <Options>(
-    options?: Overwrite<GetToggleButtonPropsOptions, Options>,
-  ) => Overwrite<GetToggleButtonPropsReturnValue, Options>
+    options?: GetToggleButtonPropsOptions & Options,
+  ) => GetToggleButtonPropsReturnValue & Options
   getLabelProps: <Options>(
-    options?: Overwrite<GetLabelPropsOptions, Options>,
-  ) => Overwrite<GetLabelPropsReturnValue, Options>
+    options?: GetLabelPropsOptions & Options,
+  ) => GetLabelPropsReturnValue & Options
   getMenuProps: <Options>(
-    options?: Overwrite<GetMenuPropsOptions, Options>,
+    options?: GetMenuPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => Overwrite<GetMenuPropsReturnValue, Options>
+  ) => GetMenuPropsReturnValue & Options
   getInputProps: <Options>(
-    options?: Overwrite<GetInputPropsOptions, Options>,
-  ) => Overwrite<GetInputPropsReturnValue, Options>
+    options?: GetInputPropsOptions & Options,
+  ) => GetInputPropsReturnValue & Options
   getItemProps: <Options>(
-    options: Overwrite<GetItemPropsOptions<Item>, Options>,
-  ) => Overwrite<GetItemPropsReturnValue<Item>, Options>
+    options: GetItemPropsOptions<Item> & Options,
+  ) => GetItemPropsReturnValue<Item> & Options
 }
 
 export interface Actions<Item> {
@@ -433,19 +431,19 @@ export interface UseSelectGetItemPropsReturnValue
 
 export interface UseSelectPropGetters<Item> {
   getToggleButtonProps: <Options>(
-    options?: Overwrite<UseSelectGetToggleButtonPropsOptions, Options>,
+    options?: UseSelectGetToggleButtonPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => Overwrite<UseSelectGetToggleButtonReturnValue, Options>
+  ) => UseSelectGetToggleButtonReturnValue & Options
   getLabelProps: <Options>(
-    options?: Overwrite<UseSelectGetLabelPropsOptions, Options>,
-  ) => Overwrite<UseSelectGetLabelPropsReturnValue, Options>
+    options?: UseSelectGetLabelPropsOptions & Options,
+  ) => UseSelectGetLabelPropsReturnValue & Options
   getMenuProps: <Options>(
-    options?: Overwrite<UseSelectGetMenuPropsOptions, Options>,
+    options?: UseSelectGetMenuPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => Overwrite<UseSelectGetMenuReturnValue, Options>
+  ) => UseSelectGetMenuReturnValue & Options
   getItemProps: <Options>(
-    options: Overwrite<UseSelectGetItemPropsOptions<Item>, Overwrite>,
-  ) => Overwrite<UseSelectGetItemPropsReturnValue, Options>
+    options: UseSelectGetItemPropsOptions<Item> & Options,
+  ) => UseSelectGetItemPropsReturnValue & Options
 }
 
 export interface UseSelectActions<Item> {
@@ -634,22 +632,22 @@ export interface UseComboboxGetInputPropsReturnValue
 }
 export interface UseComboboxPropGetters<Item> {
   getToggleButtonProps: <Options>(
-    options?: Overwrite<UseComboboxGetToggleButtonPropsOptions, Options>,
-  ) => Overwrite<UseComboboxGetToggleButtonPropsReturnValue, Options>
+    options?: UseComboboxGetToggleButtonPropsOptions & Options,
+  ) => UseComboboxGetToggleButtonPropsReturnValue & Options
   getLabelProps: <Options>(
-    options?: Overwrite<UseComboboxGetLabelPropsOptions, Options>,
-  ) => Overwrite<UseComboboxGetLabelPropsReturnValue, Options>
+    options?: UseComboboxGetLabelPropsOptions & Options,
+  ) => UseComboboxGetLabelPropsReturnValue & Options
   getMenuProps: <Options>(
-    options?: Overwrite<UseComboboxGetMenuPropsOptions, Options>,
+    options?: UseComboboxGetMenuPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => Overwrite<UseComboboxGetMenuPropsReturnValue, Options>
+  ) => UseComboboxGetMenuPropsReturnValue & Options
   getItemProps: <Options>(
-    options: Overwrite<UseComboboxGetItemPropsOptions<Item>, Options>,
-  ) => Overwrite<UseComboboxGetItemPropsReturnValue, Options>
+    options: UseComboboxGetItemPropsOptions<Item> & Options,
+  ) => UseComboboxGetItemPropsReturnValue & Options
   getInputProps: <Options>(
-    options?: Overwrite<UseComboboxGetInputPropsOptions, Options>,
+    options?: UseComboboxGetInputPropsOptions & Options,
     otherOptions?: GetPropsCommonOptions,
-  ) => Overwrite<UseComboboxGetInputPropsReturnValue, Options>
+  ) => UseComboboxGetInputPropsReturnValue & Options
 }
 
 export interface UseComboboxActions<Item> {
@@ -776,30 +774,33 @@ export interface UseMultipleSelectionGetSelectedItemPropsOptions<Item>
   selectedItem: Item
 }
 
-export interface UseMultipleSelectionComboboxGetDropdownProps
-  extends GetInputPropsOptions,
-    GetPropsWithRefKey {
-  preventKeyAction?: boolean
+export interface UseMultipleSelectionGetSelectedItemPropsReturnValue {
+  ref?: React.RefObject
+  tabIndex: 0 | -1
+  onClick: React.MouseEventHandler
+  onKeyDown: React.KeyboardEventHandler
 }
 
-export interface UseMultipleSelectionSelectGetDropdownProps
-  extends GetToggleButtonPropsOptions,
-    GetPropsWithRefKey {
-  preventKeyAction?: boolean
-}
+export type UseMultipleSelectionGetDropdownPropsOptions = GetInputPropsOptions &
+  GetToggleButtonPropsOptions &
+  GetPropsWithRefKey & {
+    preventKeyAction?: boolean
+  }
 
-export type UseMultipleSelectionGetDropdownProps =
-  | UseMultipleSelectionSelectGetDropdownProps
-  | UseMultipleSelectionComboboxGetDropdownProps
+export interface UseMultipleSelectionGetDropdownPropsReturnValue {
+  ref?: React.RefObject
+  onClick?: React.MouseEventHandler
+  onKeyDown?: React.KeyboardEventHandler
+}
 
 export interface UseMultipleSelectionPropGetters<Item> {
-  getDropdownProps: (
-    options?: UseMultipleSelectionGetDropdownProps,
+  getDropdownProps: <Options>(
+    options?: UseMultipleSelectionGetDropdownPropsOptions & Options,
     extraOptions?: GetPropsCommonOptions,
-  ) => any
-  getSelectedItemProps: (
-    options: UseMultipleSelectionGetSelectedItemPropsOptions<Item>,
-  ) => any
+  ) => UseMultipleSelectionGetDropdownPropsReturnValue & Options
+  getSelectedItemProps: <Options>(
+    options: UseMultipleSelectionGetSelectedItemPropsOptions<Item> & Options,
+  ) => UseMultipleSelectionGetSelectedItemPropsReturnValue & Options
 }
 
 export interface UseMultipleSelectionActions<Item> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Replace `any` with proper return values in getter props Typescript types.
Return value should be Downshift returns + Props passed as Options, which, in turn, should be HTML props for those elements + any optional props passed by the user.

<!-- Why are these changes necessary? -->

**Why**:
To better reflect the return value of the getter props.

Use cases:

- props accepted by getter function should stay the same.
- props returned by getter function should be the ones returned by Downshift / hooks.
- ~~if prop types are passed to getter that have a different type from the one returned by Downshift / hooks, the type of the returned prop should be changed. For example, `getLabelProps({htmlFor: true})` will have the return type `{id: string, htmlFor: true}`.~~
- returned props should contain the custom props passed to the getter function. For example, `getLabelProps({foo: 123})` will have the return type `{id: string, htmlFor: string, foo: number}`
- props that are returned by getter function by default should be overriden in type if user passes the same prop as getter prop argument. For instance, `getToggleButtonProps({"aria-haspopup": "dialog"})["aria-haspopup"]` will have its type changed from `listbox` to `dialog`.

<!-- How were these changes implemented? -->

**How**:
```ts
type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U

export interface GetLabelPropsOptions
  extends React.HTMLProps<HTMLLabelElement> {}

export interface GetLabelPropsReturnValue {
  htmlFor: string
  id: string
}

export interface PropGetters<Item> {
  getLabelProps: <Options>(
    options?: GetLabelPropsOptions & Options,
  ) => Overwrite<GetLabelPropsReturnValue, Options>
  // other getters
}
```

In VScode I'm getting this result in the `basic.test.tsx`:

![Screenshot 2023-03-13 at 10 20 36](https://user-images.githubusercontent.com/11275392/224645314-73756b3d-a9c4-455a-9505-059a5e4997ee.png)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

_Deprecated implementation that used `Overwrite` for the getter prop function arguments was dropped. This was problematic because it allowed passing any type for options that were used by the getter props._
```ts
type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U

export interface GetLabelPropsOptions
  extends React.HTMLProps<HTMLLabelElement> {}

export interface GetLabelPropsReturnValue {
  htmlFor: string
  id: string
}

export interface PropGetters<Item> {
  getLabelProps: <Options>(
    options?: Overwrite<GetLabelPropsOptions, Options>,
  ) => Overwrite<GetLabelPropsReturnValue, Options>
  // other getters
}
```