### PR TITLE
fix(useCombobox): ensure highlighted item is not selected on browser tab change

### DIFF
--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -1460,6 +1460,38 @@ describe('getInputProps', () => {
           }),
         )
       })
+
+      test('the open menu will be closed and highlighted item will not be selected if the blur event related target is null', () => {
+        const stateReducer = jest.fn().mockImplementation(s => s)
+        const {container} = renderCombobox({
+          isOpen: true,
+          highlightedIndex: 0,
+          stateReducer,
+        })
+        const input = getInput()
+        document.body.appendChild(container)
+
+        fireEvent.blur(input, {relatedTarget: null})
+
+        expect(stateReducer).toHaveBeenCalledTimes(1)
+        expect(stateReducer).toHaveBeenCalledWith(
+          {
+            highlightedIndex: 0,
+            inputValue: '',
+            isOpen: true,
+            selectedItem: null,
+          },
+          expect.objectContaining({
+            type: stateChangeTypes.InputBlur,
+            changes: {
+              highlightedIndex: -1,
+              inputValue: '',
+              isOpen: false,
+              selectedItem: null,
+            },
+          }),
+        )
+      })
     })
 
     describe('on focus', () => {

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -416,7 +416,7 @@ function useCombobox(userProps = {}) {
             : event.target.value,
         })
       }
-      const inputHandleBlur = () => {
+      const inputHandleBlur = event => {
         /* istanbul ignore else */
         if (
           latestState.isOpen &&
@@ -424,7 +424,7 @@ function useCombobox(userProps = {}) {
         ) {
           dispatch({
             type: stateChangeTypes.InputBlur,
-            selectItem: true,
+            selectItem: event.relatedTarget !== null,
           })
         }
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

InputBlur action should return `selectedItem` only from Tab/Shift+Tab and not from clicking outside. However, before this change, if your click outside is to change browser tab, the current `highlightedIndex` is selected when returning to the page. This PR is to prevent that behaviour.

Fixes #1471.

<!-- How were these changes implemented? -->

**How**:

This PR updates the `InputBlur` handler on `useCombobox` to rely on the `event.relatedTarget`. In a blur event, this is set to the element receiving focus which is simply `null` when switching tabs because focus is no longer in that window.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
