### PR TITLE
fix: change getToggleButtonProps typing to support div

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -117,7 +117,7 @@ export interface GetLabelPropsOptions
   extends React.HTMLProps<HTMLLabelElement> {}
 
 export interface GetToggleButtonPropsOptions
-  extends React.HTMLProps<HTMLButtonElement> {
+  extends React.HTMLProps<HTMLButtonElement | HTMLDivElement> {
   disabled?: boolean
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

`getToggleButtonProps` should support HTMLButtonElement **_or_** HTMLDivElement props

**Why**:

[In the downshift docs](https://www.downshift-js.com/use-select/), `useSelect` recommends applying `getToggleButtonProps` to a div element but `getToggleButtonProps` specifies its `options` are specific to a button.  This works fine, unless you want to provide options to `getToggleButtonProps` that are unique to a div element, in my case I ran into this when providing a `ref` to my HTMLDivElement - this conflicted because `Ref<HTMLDivElement>` is not applicable to `Ref<HTMLButtonElement>`

**How**:

Simply added `| HTMLDivElement` to its type.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
