### PR TITLE
fix(useCombobox): tab to body should select element

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -304,9 +304,10 @@ function useCombobox(userProps = {}) {
         'Pass either item or index to getItemProps!',
       )
 
-      const onSelectKey = isReactNative || isReactNativeWeb
-        ? /* istanbul ignore next (react-native) */ 'onPress'
-        : 'onClick'
+      const onSelectKey =
+        isReactNative || isReactNativeWeb
+          ? /* istanbul ignore next (react-native) */ 'onPress'
+          : 'onClick'
       const customClickHandler = isReactNative
         ? /* istanbul ignore next (react-native) */ onPress
         : onClick
@@ -412,9 +413,10 @@ function useCombobox(userProps = {}) {
       const inputHandleChange = event => {
         dispatch({
           type: stateChangeTypes.InputChange,
-          inputValue: isReactNative || isReactNativeWeb
-            ? /* istanbul ignore next (react-native) */ event.nativeEvent.text
-            : event.target.value,
+          inputValue:
+            isReactNative || isReactNativeWeb
+              ? /* istanbul ignore next (react-native) */ event.nativeEvent.text
+              : event.target.value,
         })
       }
       const inputHandleBlur = event => {
@@ -423,9 +425,13 @@ function useCombobox(userProps = {}) {
           latestState.isOpen &&
           !mouseAndTouchTrackersRef.current.isMouseDown
         ) {
+          const isBlurByTabChange =
+            event.relatedTarget === null &&
+            environment.document.activeElement !== environment.document.body
+
           dispatch({
             type: stateChangeTypes.InputBlur,
-            selectItem: event.relatedTarget !== null,
+            selectItem: !isBlurByTabChange,
           })
         }
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Tabbing with an element highlighted should select that element, even if the combobox is the last element in the tab order and the focus ends up on `body`.

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1515
<!-- How were these changes implemented? -->

**How**:
The bug is a regression from https://github.com/downshift-js/downshift/pull/1484.

The fix in the PR above handles correctly the case when blur is performed by tab change, and in this case the element should not be selected. Blur by tab change is detected via `event.relatedTarget === null`. However, tabbing from the last element in the tab order also has `event.relatedTarget === null` so we need to distinguish between these two cases. The fix is to also check the `environment.document.activeElement === environment.document.body`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
