### PR TITLE
fix(useCombobox): exhaustive deps for getInputProps

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -500,12 +500,13 @@ function useCombobox(userProps = {}) {
       }
     },
     [
-      dispatch,
-      inputKeyDownHandlers,
-      latest,
-      mouseAndTouchTrackersRef,
       setGetterPropCallInfo,
+      latest,
       elementIds,
+      inputKeyDownHandlers,
+      dispatch,
+      mouseAndTouchTrackersRef,
+      environment
     ],
   )
 


### PR DESCRIPTION
Leftover from https://github.com/downshift-js/downshift/pull/1517, the useCallback deps array also needs to be updated.