### PR TITLE
feat(useSelect): focus toggle when opened initially

### DIFF
--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -26,6 +26,7 @@ import {
 } from '../../testUtils'
 import useSelect from '..'
 import * as stateChangeTypes from '../stateChangeTypes'
+import { initialFocusAndOpenTestCases } from '../../useCombobox/testUtils'
 
 describe('getToggleButtonProps', () => {
   describe('hook props', () => {
@@ -254,6 +255,31 @@ describe('getToggleButtonProps', () => {
       expect(userOnBlur).toHaveBeenCalledTimes(1)
       expect(result.current.isOpen).toBe(true)
     })
+  })
+
+  describe('initial focus', () => {
+    for (const [
+      initialIsOpen,
+      defaultIsOpen,
+      isOpen,
+      status,
+    ] of initialFocusAndOpenTestCases) {
+      /* eslint-disable */
+      test(`is ${
+        status ? '' : 'not '
+      }grabbed when initialIsOpen: ${initialIsOpen}, defaultIsOpen: ${defaultIsOpen} and props.isOpen: ${isOpen}`, () => {
+        renderSelect({isOpen, defaultIsOpen, initialIsOpen})
+
+        if (status) {
+          expect(getToggleButton()).toHaveFocus()
+          expect(getItems()).toHaveLength(items.length)
+        } else {
+          expect(getToggleButton()).not.toHaveFocus()
+          expect(getItems()).toHaveLength(0)
+        }
+      })
+      /* eslint-enable */
+    }
   })
 
   describe('event handlers', () => {
@@ -1429,11 +1455,7 @@ describe('getToggleButtonProps', () => {
           )
         })
 
-        // focus the toggle button in 2 tabs
-        await tab()
-        await tab()
-
-        // now blur
+        // focus is already on the toggle button, tab should blur
         await tab()
 
         expect(getItems()).toHaveLength(0)
@@ -1463,7 +1485,6 @@ describe('getToggleButtonProps', () => {
           },
         )
 
-        await tab()
         await mouseMoveItemAtIndex(defaultHighlightedIndex)
         await mouseLeaveItemAtIndex(defaultHighlightedIndex)
         await tab()
@@ -1518,11 +1539,7 @@ describe('getToggleButtonProps', () => {
           )
         })
 
-        // focus the toggle button in 2 tabs
-        await tab()
-        await tab()
-
-        // now blur
+        // focus is already on the toggle button, tab should blur
         await tab(true)
 
         expect(getItems()).toHaveLength(0)

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -11,6 +11,7 @@ import {
   useElementIds,
   useMouseAndTouchTracker,
   getItemAndIndex,
+  getInitialValue,
 } from '../utils'
 import {
   callAllEventHandlers,
@@ -142,6 +143,15 @@ function useSelect(userProps = {}) {
 
     previousResultCountRef.current = items.length
   })
+  // Focus the toggle button on first render if required.
+  useEffect(() => {
+    const focusOnOpen = getInitialValue(props, 'isOpen')
+
+    if (focusOnOpen && toggleButtonRef.current) {
+      toggleButtonRef.current.focus()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   // Add mouse/touch events to document.
   const mouseAndTouchTrackersRef = useMouseAndTouchTracker(
     isOpen,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Focus the toggle element if the menu is opened initially.
<!-- Why are these changes necessary? -->

**Why**:
Similar behaviour to useCombobox and the input focus.
<!-- How were these changes implemented? -->

**How**:
Same implementation as for useCombobox.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
