### PR TITLE
Updated onBlur to always trigger when input is blurred

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -419,10 +419,7 @@ function useCombobox(userProps = {}) {
       }
       const inputHandleBlur = event => {
         /* istanbul ignore else */
-        if (
-          latestState.isOpen &&
-          !mouseAndTouchTrackersRef.current.isMouseDown
-        ) {
+        if (!mouseAndTouchTrackersRef.current.isMouseDown) {
           const isBlurByTabChange =
             event.relatedTarget === null &&
             environment.document.activeElement !== environment.document.body


### PR DESCRIPTION
**What**:

When using the `stateReducer` function of `useCombobox`, the `InputBlur` change type only gets called if the combobox is currently open.

**Why**:

I believe the current behaviour is confusing and unexpected behaviour. I believe `InputBlur` should always be called when the input is blurred. Consumers of downshift have access to the current state and next changes in the state reducer, so they could replicate the current behaviour if they wish.

**How**:

I've made this change by removing the if statement for checking if combobox is opened in the `inputHandleBlur` function.

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged

Thank you 🙂
