### PR TITLE
Customizable useSelect input debounce wait

### DIFF
--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -40,6 +40,7 @@ function useSelect(userProps = {}) {
     itemToString,
     getA11ySelectionMessage,
     getA11yStatusMessage,
+    inputCleanupDebounceWait,
   } = props
   // Initial state depending on controlled props.
   const initialState = getInitialState(props)
@@ -108,19 +109,23 @@ function useSelect(userProps = {}) {
 
   // Sets cleanup for the keysSoFar callback, debounded after 500ms.
   useEffect(() => {
-    // init the clean function here as we need access to dispatch.
-    clearTimeoutRef.current = debounce(outerDispatch => {
-      outerDispatch({
-        type: stateChangeTypes.FunctionSetInputValue,
-        inputValue: '',
-      })
-    }, 500)
+    if (inputCleanupDebounceWait > 0) {
+      // init the clean function here as we need access to dispatch.
+      clearTimeoutRef.current = debounce(outerDispatch => {
+        outerDispatch({
+          type: stateChangeTypes.FunctionSetInputValue,
+          inputValue: '',
+        })
+      }, inputCleanupDebounceWait)
+    } else {
+      clearTimeoutRef.current = null;
+    }
 
     // Cancel any pending debounced calls on mount
     return () => {
-      clearTimeoutRef.current.cancel()
+      clearTimeoutRef?.current.cancel()
     }
-  }, [])
+  }, [inputCleanupDebounceWait])
 
   // Invokes the keysSoFar callback set up above.
   useEffect(() => {
@@ -128,7 +133,7 @@ function useSelect(userProps = {}) {
       return
     }
 
-    clearTimeoutRef.current(dispatch)
+    clearTimeoutRef.current?.(dispatch)
   }, [dispatch, inputValue])
 
   useControlPropsValidator({

--- a/src/hooks/useSelect/utils.ts
+++ b/src/hooks/useSelect/utils.ts
@@ -41,6 +41,7 @@ const propTypes = {
   items: PropTypes.array.isRequired,
   isItemDisabled: PropTypes.func,
   getA11ySelectionMessage: PropTypes.func,
+  inputCleanupDebounceWait: PropTypes.number,
 }
 
 /**
@@ -79,6 +80,7 @@ export const defaultProps = {
   isItemDisabled() {
     return false
   },
+  inputCleanupDebounceWait: 500,
 }
 
 // eslint-disable-next-line import/no-mutable-exports

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -366,6 +366,7 @@ export interface UseSelectProps<Item> {
   onHighlightedIndexChange?: (changes: UseSelectStateChange<Item>) => void
   onStateChange?: (changes: UseSelectStateChange<Item>) => void
   environment?: Environment
+  inputCleanupDebounceWait?: number;
 }
 
 export interface UseSelectStateChangeOptions<Item>


### PR DESCRIPTION
**What**: The hard-coded 500ms wait until `useSelect`'s input is cleared is being changed to a customizable prop.

**Why**: So this behavior can be customized or opted out of.

**How**: Replaced the hard-coded number with a prop. If the customized value is below zero, the value won't be cleared at all.

<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged

Let me know what you think, and I can write docs etc if needed 🙂 