### PR TITLE
fix(typescript): missing generic parameter of React.RefObject

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -109,7 +109,7 @@ type StateChangeFunction<Item> = (
 
 export interface GetRootPropsOptions {
   refKey?: string
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
 }
 
 export interface GetRootPropsReturnValue {
@@ -117,7 +117,7 @@ export interface GetRootPropsReturnValue {
   'aria-haspopup': 'listbox'
   'aria-labelledby': string
   'aria-owns': string | undefined
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
   role: 'combobox'
 }
 
@@ -174,7 +174,7 @@ export interface GetMenuPropsOptions
 
 export interface GetMenuPropsReturnValue {
   'aria-labelledby': string | undefined
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
   role: 'listbox'
   id: string
 }
@@ -411,7 +411,7 @@ export interface UseSelectGetToggleButtonReturnValue
   'aria-haspopup': 'listbox'
   'aria-labelledby': string | undefined
   id: string
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
   role: 'combobox'
   tabIndex: 0
 }
@@ -427,7 +427,7 @@ export interface UseSelectGetItemPropsOptions<Item>
 export interface UseSelectGetItemPropsReturnValue
   extends Omit<GetItemPropsReturnValue, 'onMouseDown'> {
   'aria-disabled': boolean
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
 }
 
 export interface UseSelectPropGetters<Item> {
@@ -603,7 +603,7 @@ export interface UseComboboxGetToggleButtonPropsReturnValue {
   id: string
   onPress?: (event: React.BaseSyntheticEvent) => void
   onClick?: React.MouseEventHandler
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
   tabIndex: -1
 }
 
@@ -619,7 +619,7 @@ export interface UseComboboxGetItemPropsOptions<Item>
 export interface UseComboboxGetItemPropsReturnValue
   extends GetItemPropsReturnValue {
   'aria-disabled': boolean
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
 }
 
 export interface UseComboboxGetInputPropsOptions
@@ -782,7 +782,7 @@ export interface UseMultipleSelectionGetSelectedItemPropsOptions<Item>
 }
 
 export interface UseMultipleSelectionGetSelectedItemReturnValue {
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
   tabIndex: 0 | -1
   onClick: React.MouseEventHandler
   onKeyDown: React.KeyboardEventHandler
@@ -794,7 +794,7 @@ export interface UseMultipleSelectionGetDropdownPropsOptions
 }
 
 export interface UseMultipleSelectionGetDropdownReturnValue {
-  ref?: React.RefObject
+  ref?: React.RefObject<any>
   onClick?: React.MouseEventHandler
   onKeyDown?: React.KeyboardEventHandler
 }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adds the generic type parameter for React.RefObject.

<!-- Why are these changes necessary? -->

**Why**:

In `@types/react`, the type definition looks like this:

```
    interface RefObject<T> {
        readonly current: T | null;
    }
```

This means the `T` generic parameter needs to be set mandatorily. 

In case `skipLibCheck` is **not** set to `true`, this causes a typescript type error:

```
../../node_modules/downshift/typings/index.d.ts:112:9 - error TS2314: Generic type 'RefObject<T>' requires 1 type argument(s).

112   ref?: React.RefObject
            ~~~~~~~~~~~~~~~
```

<!-- How were these changes implemented? -->

**How**:

I've added `any` as type parameter, which is not ideal but avoids adding a generic type parameter to the parent types (e.g. `GetRootPropsOptions`).

Open for better suggestions.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] TypeScript Types
- [ ] Flow Types N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
