### PR TITLE
fix(defaultProps): use undefined environment on React Native

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -109,7 +109,7 @@ class Downshift extends Component {
     selectedItemChanged: (prevItem, item) => prevItem !== item,
     environment:
       /* istanbul ignore next (ssr) */
-      typeof window === 'undefined' ? undefined : window,
+      typeof window === 'undefined' || isReactNative ? undefined : window,
     stateReducer: (state, stateToSet) => stateToSet,
     suppressRefError: false,
     scrollIntoView,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -251,7 +251,7 @@ const defaultProps = {
   scrollIntoView,
   environment:
     /* istanbul ignore next (ssr) */
-    typeof window === 'undefined' ? undefined : window,
+    typeof window === 'undefined' || isReactNative ? undefined : window,
 }
 
 function getDefaultValue(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Keep default prop `environment` as `undefined` in React Native.
Closes https://github.com/downshift-js/downshift/issues/1525.
<!-- Why are these changes necessary? -->

**Why**:
In React Native, we do have a defined `window` object, but does not have the properties we need.
<!-- How were these changes implemented? -->

**How**:
Check `isReactNative` in both Downshift and the hooks.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
