### PR TITLE
fix(useSelect): preventDefault on item props onMouseDown

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -334,7 +334,7 @@ function useCombobox(userProps = {}) {
           index,
         })
       }
-      const itemHandleMouseDown = e => e.preventDefault()
+      const itemHandleMouseDown = e => e.preventDefault() // keep focus on the input after item click select.
 
       return {
         [refKey]: handleRefs(ref, itemNode => {

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -1709,6 +1709,24 @@ describe('getToggleButtonProps', () => {
     })
 
     describe('blur', () => {
+      test('with the menu closed does nothing', async () => {
+        const initialHighlightedIndex = 2
+        renderSelect({initialHighlightedIndex}, ui => {
+          return (
+            <>
+              {ui}
+              <div tabIndex={0}>Second element</div>
+            </>
+          )
+        })
+
+        await tab() // focus the button
+        screen.getByText(/Second element/).focus()
+
+        expect(getItems()).toHaveLength(0)
+        expect(getToggleButton()).not.toHaveTextContent()
+      })
+
       test('by focusing another element should behave as a normal blur', async () => {
         const initialHighlightedIndex = 2
         renderSelect({initialIsOpen: true, initialHighlightedIndex}, ui => {

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -490,7 +490,7 @@ function useSelect(userProps = {}) {
           index,
         })
       }
-      const itemHandleMouseDown = e => e.preventDefault()
+      const itemHandleMouseDown = e => e.preventDefault() // keep focus on the toggle after item click select.
 
       const itemProps = {
         [refKey]: handleRefs(ref, itemNode => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Prevent default on getItemProps onMouseDown for useSelect.
https://github.com/downshift-js/downshift/issues/1537
<!-- Why are these changes necessary? -->

**Why**:
Keep the focus on the toggle button when item is selected by mouse click.
<!-- How were these changes implemented? -->

**How**:
This was overlooked since for very long the focus strategy with useSelect was different (switch between toggle and menu).
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
