### PR TITLE
fix(typescript): add onPress to toggle button props parameter

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -152,6 +152,7 @@ export interface GetLabelPropsReturnValue {
 export interface GetToggleButtonPropsOptions
   extends React.HTMLProps<HTMLButtonElement> {
   disabled?: boolean
+  onPress?: (event: React.BaseSyntheticEvent) => void
 }
 
 interface GetToggleButtonPropsReturnValue {
@@ -398,7 +399,9 @@ export interface UseSelectGetMenuReturnValue extends GetMenuPropsReturnValue {
 
 export interface UseSelectGetToggleButtonPropsOptions
   extends GetPropsWithRefKey,
-    React.HTMLProps<HTMLElement> {}
+    React.HTMLProps<HTMLElement> {
+  onPress?: (event: React.BaseSyntheticEvent) => void
+}
 
 export interface UseSelectGetToggleButtonReturnValue
   extends Pick<


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add `onPress` optional type to the toggle button functions parameter.
<!-- Why are these changes necessary? -->

**Why**:
The getToggleButtonProps can also take  onPress in RN which does not exist in the current types. 
<!-- How were these changes implemented? -->

**How**:
Add the type to both the downshift/useCombobox and useSelect typ.es
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
