### PR TITLE
fix(hooks): use createInitialState in reducer

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -39,11 +39,10 @@ function useCombobox(userProps = {}) {
     itemToString,
   } = props
   // Initial state depending on controlled props.
-  const initialState = getInitialState(props)
   const [state, dispatch] = useControlledReducer(
     downshiftUseComboboxReducer,
-    initialState,
     props,
+    getInitialState,
   )
   const {isOpen, highlightedIndex, selectedItem, inputValue} = state
 

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -56,13 +56,17 @@ const propTypes = {
  * compute the rest of the state.
  *
  * @param {Function} reducer Reducer function from downshift.
- * @param {Object} initialState Initial state of the hook.
- * @param {Object} props The hook props.
+ * @param {Object} props The hook props, also passed to createInitialState.
+ * @param {Function} createInitialState Function that returns the initial state.
  * @returns {Array} An array with the state and an action dispatcher.
  */
-export function useControlledReducer(reducer, initialState, props) {
+export function useControlledReducer(reducer, props, createInitialState) {
   const previousSelectedItemRef = useRef()
-  const [state, dispatch] = useEnhancedReducer(reducer, initialState, props)
+  const [state, dispatch] = useEnhancedReducer(
+    reducer,
+    props,
+    createInitialState,
+  )
 
   // ToDo: if needed, make same approach as selectedItemChanged from Downshift.
   useEffect(() => {

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -38,8 +38,8 @@ function useMultipleSelection(userProps = {}) {
   // Reducer init.
   const [state, dispatch] = useControlledReducer(
     downshiftMultipleSelectionReducer,
-    getInitialState(props),
     props,
+    getInitialState,
   )
   const {activeIndex, selectedItems} = state
 

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -42,11 +42,10 @@ function useSelect(userProps = {}) {
     getA11yStatusMessage,
   } = props
   // Initial state depending on controlled props.
-  const initialState = getInitialState(props)
   const [state, dispatch] = useControlledReducer(
     downshiftSelectReducer,
-    initialState,
     props,
+    getInitialState,
   )
   const {isOpen, highlightedIndex, selectedItem, inputValue} = state
 

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -187,11 +187,11 @@ function useLatestRef(val) {
  * Also calls the onChange handlers for state values that have changed.
  *
  * @param {Function} reducer Reducer function from downshift.
- * @param {Object} initialState Initial state of the hook.
- * @param {Object} props The hook props.
+ * @param {Object} props The hook props, also passed to createInitialState.
+ * @param {Function} createInitialState Function that returns the initial state.
  * @returns {Array} An array with the state and an action dispatcher.
  */
-function useEnhancedReducer(reducer, initialState, props) {
+function useEnhancedReducer(reducer, props, createInitialState) {
   const prevStateRef = useRef()
   const actionRef = useRef()
   const enhancedReducer = useCallback(
@@ -206,7 +206,11 @@ function useEnhancedReducer(reducer, initialState, props) {
     },
     [reducer],
   )
-  const [state, dispatch] = useReducer(enhancedReducer, initialState)
+  const [state, dispatch] = useReducer(
+    enhancedReducer,
+    props,
+    createInitialState,
+  )
   const propsRef = useLatestRef(props)
   const dispatchWithProps = useCallback(
     action => dispatch({props: propsRef.current, ...action}),
@@ -234,12 +238,16 @@ function useEnhancedReducer(reducer, initialState, props) {
  * returning the new state.
  *
  * @param {Function} reducer Reducer function from downshift.
- * @param {Object} initialState Initial state of the hook.
- * @param {Object} props The hook props.
+ * @param {Object} props The hook props, also passed to createInitialState.
+ * @param {Function} createInitialState Function that returns the initial state.
  * @returns {Array} An array with the state and an action dispatcher.
  */
-function useControlledReducer(reducer, initialState, props) {
-  const [state, dispatch] = useEnhancedReducer(reducer, initialState, props)
+function useControlledReducer(reducer, props, createInitialState) {
+  const [state, dispatch] = useEnhancedReducer(
+    reducer,
+    props,
+    createInitialState,
+  )
 
   return [getState(state, props), dispatch]
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Use function to create initial state in reducer.

**Why**:

Avoid recreating the initial state on every render. https://react.dev/reference/react/useReducer#avoiding-recreating-the-initial-state

**How**:

Refactor the usage according to the React API

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
