### PR TITLE
fix(hooks): setSelectedItems updates now previous selected items (#1535)

### DIFF
--- a/src/hooks/useMultipleSelection/__tests__/returnProps.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/returnProps.test.js
@@ -109,6 +109,28 @@ describe('returnProps', () => {
       expect(result.current.selectedItems).toBe(inputItems)
     })
 
+    test('setSelectedItems updates previous selected items', () => {
+      let removedItem = null
+      const {result} = renderUseMultipleSelection({
+        getA11yRemovalMessage({ removedSelectedItem }) {
+          removedItem = removedSelectedItem
+        },
+        initialSelectedItems: [1, 2],
+        initialActiveIndex: 0,
+      })
+
+      act(() => {
+        result.current.setSelectedItems([1, 2])
+      })
+      expect(removedItem).toBeNull()
+
+      act(() => {
+        result.current.setSelectedItems([2, 3])
+      })
+      expect(removedItem).toBe(1)
+      expect(result.current.selectedItems).toStrictEqual([2, 3])
+    })
+
     test('reset sets the state to default values', () => {
       const {result} = renderUseMultipleSelection()
 

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -58,11 +58,11 @@ function useMultipleSelection(userProps = {}) {
       return
     }
 
-    if (selectedItems.length < previousSelectedItemsRef.current.length) {
-      const removedSelectedItem = previousSelectedItemsRef.current.find(
-        item => selectedItems.indexOf(item) < 0,
-      )
+    const removedSelectedItem = previousSelectedItemsRef.current.find(
+      item => !selectedItems.includes(item),
+    )
 
+    if (removedSelectedItem) {
       setStatus(
         getA11yRemovalMessage({
           itemToString,
@@ -78,7 +78,7 @@ function useMultipleSelection(userProps = {}) {
     previousSelectedItemsRef.current = selectedItems
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedItems.length])
+  }, [JSON.stringify(selectedItems)])
   // Sets focus on active item.
   useEffect(() => {
     if (isInitialMountRef.current) {


### PR DESCRIPTION
- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged

Rrepaired useEffect dependency so also in case same amount of different selected items is set previous selection is updated