### PR TITLE
feat(useSelect): focus toggle on label click

### DIFF
--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -867,6 +867,10 @@ described below.
 - `Click`: It will select the item and close the menu.
 - `MouseOver`: It will highlight the item.
 
+#### Label
+
+- `Click`: It will move focus to the toggle element.
+
 ### Customizing Handlers
 
 You can provide your own event handlers to `useSelect` which will be called

--- a/src/hooks/useSelect/__tests__/getLabelProps.test.js
+++ b/src/hooks/useSelect/__tests__/getLabelProps.test.js
@@ -1,5 +1,6 @@
-import {renderUseSelect} from '../testUtils'
-import {defaultIds} from '../../testUtils'
+import {act, screen} from '@testing-library/react'
+import {renderSelect, renderUseSelect} from '../testUtils'
+import {defaultIds, getToggleButton, user} from '../../testUtils'
 
 describe('getLabelProps', () => {
   test('should have a default id assigned', () => {
@@ -35,5 +36,55 @@ describe('getLabelProps', () => {
     const labelProps = result.current.getLabelProps(props)
 
     expect(labelProps).toEqual(expect.objectContaining({foo: 'bar'}))
+  })
+
+  test('on click moves focus to the toggle button', async () => {
+    renderSelect()
+
+    await user.click(
+      screen.getByText('Choose an element:', {selector: 'label'}),
+    )
+
+    expect(getToggleButton()).toHaveFocus()
+  })
+
+  test('event handler onClick is called along with downshift handler', () => {
+    const userOnClick = jest.fn()
+    const mockToggleButton = {focus: jest.fn()}
+    const {result} = renderUseSelect()
+
+    act(() => {
+      const {onClick} = result.current.getLabelProps({
+        onClick: userOnClick,
+      })
+      const {ref} = result.current.getToggleButtonProps()
+      ref(mockToggleButton)
+
+      onClick({})
+    })
+
+    expect(userOnClick).toHaveBeenCalledTimes(1)
+    expect(mockToggleButton.focus).toHaveBeenCalledTimes(1)
+  })
+
+  test("the downshift handler is not called if 'preventDownshiftDefault' is passed in user event", () => {
+    const userOnClick = jest.fn(event => {
+      event.preventDownshiftDefault = true
+    })
+    const mockToggleButton = {focus: jest.fn()}
+    const {result} = renderUseSelect()
+
+    act(() => {
+      const {onClick} = result.current.getLabelProps({
+        onClick: userOnClick,
+      })
+      const {ref} = result.current.getToggleButtonProps()
+      ref(mockToggleButton)
+
+      onClick({})
+    })
+
+    expect(userOnClick).toHaveBeenCalledTimes(1)
+    expect(mockToggleButton.focus).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -322,11 +322,18 @@ function useSelect(userProps = {}) {
   )
   // Getter functions.
   const getLabelProps = useCallback(
-    labelProps => ({
-      id: elementIds.labelId,
-      htmlFor: elementIds.toggleButtonId,
-      ...labelProps,
-    }),
+    ({onClick, ...labelProps} = {}) => {
+      const labelHandleClick = () => {
+        toggleButtonRef.current?.focus()
+      }
+
+      return {
+        id: elementIds.labelId,
+        htmlFor: elementIds.toggleButtonId,
+        onClick: callAllEventHandlers(onClick, labelHandleClick),
+        ...labelProps,
+      }
+    },
     [elementIds],
   )
   const getMenuProps = useCallback(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -419,7 +419,9 @@ export interface UseSelectGetToggleButtonReturnValue
   tabIndex: 0
 }
 
-export interface UseSelectGetLabelPropsOptions extends GetLabelPropsOptions {}
+export interface UseSelectGetLabelPropsOptions extends GetLabelPropsOptions {
+  onClick: React.MouseEventHandler
+}
 export interface UseSelectGetLabelPropsReturnValue
   extends GetLabelPropsReturnValue {}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Focus the toggle element when the `<label>` is clicked, for useSelect.
<!-- Why are these changes necessary? -->

**Why**:
Closes https://github.com/downshift-js/downshift/issues/1557.
Native `<select>` works the same way with a `<label>`
ARIA also is on board: https://github.com/w3c/aria-practices/issues/2859
<!-- How were these changes implemented? -->

**How**:
Add a custom `onClick` handler to useSelect `getLabelProps` that focuses the toggle element.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
