### PR TITLE
fix(useSelect): correct getLabelProps return type

### DIFF
--- a/src/hooks/useSelect/__tests__/getLabelProps.test.js
+++ b/src/hooks/useSelect/__tests__/getLabelProps.test.js
@@ -1,4 +1,4 @@
-import {act, screen} from '@testing-library/react'
+import {screen} from '@testing-library/react'
 import {renderSelect, renderUseSelect} from '../testUtils'
 import {defaultIds, getToggleButton, user} from '../../testUtils'
 
@@ -53,15 +53,13 @@ describe('getLabelProps', () => {
     const mockToggleButton = {focus: jest.fn()}
     const {result} = renderUseSelect()
 
-    act(() => {
-      const {onClick} = result.current.getLabelProps({
-        onClick: userOnClick,
-      })
-      const {ref} = result.current.getToggleButtonProps()
-      ref(mockToggleButton)
-
-      onClick({})
+    const {onClick} = result.current.getLabelProps({
+      onClick: userOnClick,
     })
+    const {ref} = result.current.getToggleButtonProps()
+    ref(mockToggleButton)
+
+    onClick({})
 
     expect(userOnClick).toHaveBeenCalledTimes(1)
     expect(mockToggleButton.focus).toHaveBeenCalledTimes(1)
@@ -74,15 +72,13 @@ describe('getLabelProps', () => {
     const mockToggleButton = {focus: jest.fn()}
     const {result} = renderUseSelect()
 
-    act(() => {
-      const {onClick} = result.current.getLabelProps({
-        onClick: userOnClick,
-      })
-      const {ref} = result.current.getToggleButtonProps()
-      ref(mockToggleButton)
-
-      onClick({})
+    const {onClick} = result.current.getLabelProps({
+      onClick: userOnClick,
     })
+    const {ref} = result.current.getToggleButtonProps()
+    ref(mockToggleButton)
+
+    onClick({})
 
     expect(userOnClick).toHaveBeenCalledTimes(1)
     expect(mockToggleButton.focus).not.toHaveBeenCalled()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -419,11 +419,11 @@ export interface UseSelectGetToggleButtonReturnValue
   tabIndex: 0
 }
 
-export interface UseSelectGetLabelPropsOptions extends GetLabelPropsOptions {
+export interface UseSelectGetLabelPropsOptions extends GetLabelPropsOptions {}
+export interface UseSelectGetLabelPropsReturnValue
+  extends GetLabelPropsReturnValue {
   onClick: React.MouseEventHandler
 }
-export interface UseSelectGetLabelPropsReturnValue
-  extends GetLabelPropsReturnValue {}
 
 export interface UseSelectGetItemPropsOptions<Item>
   extends Omit<GetItemPropsOptions<Item>, 'disabled'>,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
FIx a type change from https://github.com/downshift-js/downshift/pull/1561.
<!-- Why are these changes necessary? -->

**Why**:
The type change was meant to be on the returned value, not the props
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
