### PR TITLE
fix: align useCombobox getToggleButtonProps type with useSelect

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -150,7 +150,7 @@ export interface GetLabelPropsReturnValue {
 }
 
 export interface GetToggleButtonPropsOptions
-  extends React.HTMLProps<HTMLButtonElement> {
+  extends React.HTMLProps<HTMLElement> {
   disabled?: boolean
   onPress?: (event: React.BaseSyntheticEvent) => void
 }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow comboboxes to have a toggle button of any element type in TypeScript (not just an HTMLButtonElement)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Why are these changes necessary? -->

**Why**:

useCombobox's getToggleButtonProps was only compatible with HTMLButtonElement

useSelect is compatible with any HTMLElement

This is related to my previous PR: https://github.com/downshift-js/downshift/pull/1486

I am now upgrading our repo to downshift V8 and noticed that this is fixed for selects, however comboboxes are still locked to using a button by this type.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

I simply changed HTMLButtonElement to HTMLElement to match select's behaviour.

I am not familiar enough with these types to say for sure, but it seems like we could simply align [UseSelectGetToggleButtonPropsOptions](https://github.com/downshift-js/downshift/blob/master/typings/index.d.ts#L400-L404) with this [UseComboboxGetToggleButtonPropsOptions](https://github.com/downshift-js/downshift/blob/master/typings/index.d.ts#L601-L603)?  The only difference after this PR is that `UseComboboxGetToggleButtonPropsOptions` also has a `disabled` prop (through [GetToggleButtonPropsOptions](https://github.com/downshift-js/downshift/blob/master/typings/index.d.ts#L152-L155)).  Are implementations using `useSelect` able to disable the toggle button?  If so, I think these could be simplified to use a shared type.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
