### PR TITLE
fix(onMouseMove): only call handler on non-touch devices

### DIFF
--- a/src/hooks/__tests__/utils.test.js
+++ b/src/hooks/__tests__/utils.test.js
@@ -149,7 +149,7 @@ describe('utils', () => {
       )
 
       expect(result.current).toEqual({
-        current: {isMouseDown: false, isTouchMove: false},
+        current: {isMouseDown: false, isTouchMove: false, isTouchEnd: false},
       })
     })
   })

--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -280,6 +280,37 @@ describe('getItemProps', () => {
         await mouseMoveItemAtIndex(disabledIndex)
         expect(input).toHaveAttribute('aria-activedescendant', '')
       })
+
+      // Test that we don't call the mouse move handler on mobile.
+      test('does not set highlight the item if a touch event ocurred', async () => {
+        let touchEndHandler
+        const index = 1
+
+        renderCombobox({
+          isOpen: true,
+          environment: {
+            addEventListener: (name, handler) => {
+              // eslint-disable-next-line jest/no-conditional-in-test
+              if (name === 'touchend') {
+                touchEndHandler = handler
+              }
+            },
+            removeEventListener: () => {},
+            document: {
+              createElement: () => {},
+              getElementById: () => {},
+              activeElement: () => {},
+              body: {},
+            },
+            Node: () => {},
+          },
+        })
+
+        act(() => touchEndHandler({target: null}))
+        await mouseMoveItemAtIndex(index)
+
+        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+      })
     })
 
     describe('on click', () => {

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -93,6 +93,7 @@ describe('props', () => {
 
   describe('selectedItemChanged', () => {
     test('props update of selectedItem will update inputValue state with default selectedItemChanged referential equality check', () => {
+      const initialSelectedItem = {id: 3, value: 'init'}
       const selectedItem = {id: 1, value: 'wow'}
       const newSelectedItem = {id: 1, value: 'not wow'}
       function itemToString(item) {
@@ -105,13 +106,21 @@ describe('props', () => {
       const {rerender} = renderCombobox({
         stateReducer,
         itemToString,
+        selectedItem: initialSelectedItem,
+      })
+
+      expect(stateReducer).not.toHaveBeenCalled() // won't get called on first render
+
+      rerender({
+        stateReducer,
+        itemToString,
         selectedItem,
       })
 
       expect(stateReducer).toHaveBeenCalledTimes(1)
       expect(stateReducer).toHaveBeenCalledWith(
         {
-          inputValue: itemToString(selectedItem),
+          inputValue: itemToString(initialSelectedItem),
           selectedItem,
           highlightedIndex: -1,
           isOpen: false,
@@ -155,15 +164,15 @@ describe('props', () => {
       expect(getInput()).toHaveValue(itemToString(newSelectedItem))
     })
 
-    test('props update of selectedItem will not update inputValue state', () => {
+    test('props update of selectedItem will not update inputValue state if selectedItemChanged returns false', () => {
+      const initialSelectedItem = {id: 1, value: 'hmm'}
       const selectedItem = {id: 1, value: 'wow'}
-      const newSelectedItem = {id: 1, value: 'not wow'}
       function itemToString(item) {
         return item.value
       }
       const selectedItemChanged = jest
         .fn()
-        .mockReturnValue((prev, next) => prev.id !== next.id)
+        .mockImplementation((prev, next) => prev.id !== next.id)
       const stateReducer = jest
         .fn()
         .mockImplementation((_state, {changes}) => changes)
@@ -171,30 +180,23 @@ describe('props', () => {
       const {rerender} = renderCombobox({
         selectedItemChanged,
         stateReducer,
+        selectedItem: initialSelectedItem,
+        itemToString,
+      })
+
+      rerender({
+        selectedItemChanged,
+        stateReducer,
         selectedItem,
         itemToString,
       })
 
-      expect(getInput()).toHaveValue(itemToString(selectedItem))
-      expect(selectedItemChanged).toHaveBeenCalledTimes(1)
-      expect(selectedItemChanged).toHaveBeenCalledWith(undefined, selectedItem)
-
-      stateReducer.mockReset()
-      selectedItemChanged.mockReset()
-      rerender({
-        stateReducer,
-        itemToString,
-        selectedItem: newSelectedItem,
-        selectedItemChanged,
-      })
-
+      expect(getInput()).toHaveValue(itemToString(initialSelectedItem))
       expect(selectedItemChanged).toHaveBeenCalledTimes(1)
       expect(selectedItemChanged).toHaveBeenCalledWith(
+        initialSelectedItem,
         selectedItem,
-        newSelectedItem,
       )
-      expect(stateReducer).not.toHaveBeenCalled()
-      expect(getInput()).toHaveValue(itemToString(selectedItem))
     })
   })
 

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -11,6 +11,7 @@ import {
   defaultProps as defaultPropsCommon,
   getInitialState as getInitialStateCommon,
   useEnhancedReducer,
+  useIsInitialMount,
 } from '../utils'
 import {ControlledPropUpdatedSelectedItem} from './stateChangeTypes'
 
@@ -61,22 +62,28 @@ const propTypes = {
  * @param {Function} isStateEqual Function that checks if a previous state is equal to the next.
  * @returns {Array} An array with the state and an action dispatcher.
  */
-export function useControlledReducer(reducer, props, createInitialState, isStateEqual) {
+export function useControlledReducer(
+  reducer,
+  props,
+  createInitialState,
+  isStateEqual,
+) {
   const previousSelectedItemRef = useRef()
   const [state, dispatch] = useEnhancedReducer(
     reducer,
     props,
     createInitialState,
-    isStateEqual
+    isStateEqual,
   )
+  const isInitialMount = useIsInitialMount()
 
-  // ToDo: if needed, make same approach as selectedItemChanged from Downshift.
   useEffect(() => {
     if (!isControlledProp(props, 'selectedItem')) {
       return
     }
 
     if (
+      !isInitialMount && // on first mount we already have the proper inputValue for a initial selected item.
       props.selectedItemChanged(
         previousSelectedItemRef.current,
         props.selectedItem,

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -8,13 +8,14 @@ import {
   useLatestRef,
   useControlPropsValidator,
   getItemAndIndex,
+  useIsInitialMount,
 } from '../utils'
 import {
   getInitialState,
   defaultProps,
   isKeyDownOperationPermitted,
   validatePropTypes,
-  isStateEqual
+  isStateEqual,
 } from './utils'
 import downshiftMultipleSelectionReducer from './reducer'
 import * as stateChangeTypes from './stateChangeTypes'
@@ -41,12 +42,12 @@ function useMultipleSelection(userProps = {}) {
     downshiftMultipleSelectionReducer,
     props,
     getInitialState,
-    isStateEqual
+    isStateEqual,
   )
   const {activeIndex, selectedItems} = state
 
   // Refs.
-  const isInitialMountRef = useRef(true)
+  const isInitialMount = useIsInitialMount()
   const dropdownRef = useRef(null)
   const previousSelectedItemsRef = useRef(selectedItems)
   const selectedItemRefs = useRef()
@@ -56,7 +57,7 @@ function useMultipleSelection(userProps = {}) {
   // Effects.
   /* Sets a11y status message on changes in selectedItem. */
   useEffect(() => {
-    if (isInitialMountRef.current || isReactNative || !environment?.document) {
+    if (isInitialMount || isReactNative || !environment?.document) {
       return
     }
 
@@ -83,7 +84,7 @@ function useMultipleSelection(userProps = {}) {
   }, [selectedItems.length])
   // Sets focus on active item.
   useEffect(() => {
-    if (isInitialMountRef.current) {
+    if (isInitialMount) {
       return
     }
 
@@ -92,21 +93,12 @@ function useMultipleSelection(userProps = {}) {
     } else if (selectedItemRefs.current[activeIndex]) {
       selectedItemRefs.current[activeIndex].focus()
     }
-  }, [activeIndex])
+  }, [activeIndex, isInitialMount])
   useControlPropsValidator({
-    isInitialMount: isInitialMountRef.current,
     props,
     state,
   })
   const setGetterPropCallInfo = useGetterPropsCalledChecker('getDropdownProps')
-  // Make initial ref false.
-  useEffect(() => {
-    isInitialMountRef.current = false
-
-    return () => {
-      isInitialMountRef.current = true
-    }
-  }, [])
 
   // Event handler functions.
   const selectedItemKeyDownHandlers = useMemo(

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -9,8 +9,9 @@ import {
   getItems,
   keyDownOnToggleButton,
   clickOnToggleButton,
+  items,
+  defaultIds,
 } from '../testUtils'
-import {items, defaultIds} from '../../testUtils'
 import useSelect from '..'
 
 describe('getItemProps', () => {
@@ -304,6 +305,37 @@ describe('getItemProps', () => {
 
         await mouseMoveItemAtIndex(disabledIndex)
         expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+      })
+
+      // Test that we don't call the mouse move handler on mobile.
+      test('does not set highlight the item if a touch event ocurred', async () => {
+        let touchEndHandler
+        const index = 1
+
+        renderSelect({
+          isOpen: true,
+          environment: {
+            addEventListener: (name, handler) => {
+              // eslint-disable-next-line jest/no-conditional-in-test
+              if (name === 'touchend') {
+                touchEndHandler = handler
+              }
+            },
+            removeEventListener: () => {},
+            document: {
+              createElement: () => {},
+              getElementById: () => {},
+              activeElement: () => {},
+              body: {},
+            },
+            Node: () => {},
+          },
+        })
+
+        act(() => touchEndHandler({target: null}))
+        await mouseMoveItemAtIndex(index)
+
+        expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
       })
     })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { compute } from 'compute-scroll-into-view'
+import {compute} from 'compute-scroll-into-view'
 import React from 'react'
 import {isPreact} from './is.macro'
 
@@ -267,6 +267,10 @@ function pickState(state = {}) {
  * @returns {Object} The merged controlled state.
  */
 function getState(state, props) {
+  if (!state || !props) {
+    return state
+  }
+
   return Object.keys(state).reduce((prevState, key) => {
     prevState[key] = isControlledProp(props, key) ? props[key] : state[key]
 
@@ -422,16 +426,19 @@ function targetWithinDownshift(
   environment,
   checkActiveElement = true,
 ) {
-  return environment && downshiftElements.some(
-    contextNode =>
-      contextNode &&
-      (isOrContainsNode(contextNode, target, environment) ||
-        (checkActiveElement &&
-          isOrContainsNode(
-            contextNode,
-            environment.document.activeElement,
-            environment,
-          ))),
+  return (
+    environment &&
+    downshiftElements.some(
+      contextNode =>
+        contextNode &&
+        (isOrContainsNode(contextNode, target, environment) ||
+          (checkActiveElement &&
+            isOrContainsNode(
+              contextNode,
+              environment.document.activeElement,
+              environment,
+            ))),
+    )
   )
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Don't call the onMouseMove handler when a touch event is detected.

<!-- Why are these changes necessary? -->

**Why**:
Not really needed, since on mobile we don't highlight items with touch.
It also causes a sequence of batched dispatch calls that are difficult to understand and, most probably, wrong.
On mobile, when touching to select an item, we had a couple of batched dispatch calls:
1. item click
2. item mouse move + item click.
To me, it did not make sense. On non-mobile, it was fine, mouse move when mouse actually moved, and click after click. Nothing else.

Now we should only get itemClick on mobile when we touch to select an item.
Closes https://github.com/downshift-js/downshift/issues/1540.
Closes https://github.com/downshift-js/downshift/issues/1566.
Closes https://github.com/downshift-js/downshift/issues/1447.

It should also fix our example with [Basic multiple selection](https://www.downshift-js.com/use-combobox#basic-multiple-selection). Once this PR will get merged, the example also needs to have the `selectedItem` passed as `null`, as the example already does not care about it since we keep the selectedItems as custom state. Passing selectedItem as null controlled prop will also make the onSelectedItemChange get called on successive item clicks.
<!-- How were these changes implemented? -->

**How**:
Check if we have onTouchDown, and if so, don't call dispatch in the onMouseMove handler. We update the `useMouseAndTouchTracker` to provide us with the value.
Also a few changes:
1. Don't call `ControlledPropUpdatedSelectedItem` on first render, since we already get the proper selectedItem + input value combination in the initial state setup.
2. Use a custom hook to get isInitialRender info.
3. Check if state changed by also merging previous state with actual props, since that makes sense in the controlled component scenario.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
