### PR TITLE
feat(hooks): itemToKey prop

### DIFF
--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -435,7 +435,7 @@ function selectedItemChanged(item1, item2) {
 // moving forward, switch to this one.
 function itemToKey(item) {
   return item.id
-  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) === itemToKey(nextSelectedItem)
+  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) !== itemToKey(nextSelectedItem)
 }
 ```
 

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -81,6 +81,7 @@ and update if necessary.
   - [defaultIsOpen](#defaultisopen)
   - [defaultHighlightedIndex](#defaulthighlightedindex)
   - [defaultInputValue](#defaultinputvalue)
+  - [itemToKey](#itemtokey)
   - [selectedItemChanged](#selecteditemchanged)
   - [getA11yStatusMessage](#geta11ystatusmessage)
   - [getA11ySelectionMessage](#geta11yselectionmessage)
@@ -393,7 +394,48 @@ reset or when an item is selected.
 Pass a string that sets the content of the input when downshift is reset or when
 an item is selected.
 
+### itemToKey
+
+> `function(item: any)` | defaults to: `item => item`
+
+Used to determine the uniqueness of an item when searching for the item or
+comparing the item with another. Returns the item itself, by default, so the
+comparing/searching is done internally via referential equality.
+
+If using items as objects and their reference will change during use, you can
+use the function to generate a unique key for each item, such as an `id` prop.
+
+```js
+function itemToKey(item) {
+  return item.id
+}
+```
+
+> This deprecates the "selectedItemChanged" prop. If you are using the prop
+> already, make sure you change to "itemToKey" as the former will be removed in
+> the next Breaking Change update. A migration example:
+
+```js
+// initial items.
+const items = [{id: 1, value: 'Apples'}, {id: 2, value: 'Oranges'}]
+// same items but with new references, from the server.
+const newItems = [{id: 1, value: 'Apples'}, {id: 2, value: 'Oranges'}]
+
+// previous prop
+function selectedItemChanged(item1, item2) {
+  return item1.id === item2.id
+}
+
+// moving forward
+function itemToKey(item) {
+  return item.id
+  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) === itemToKey(nextSelectedItem)
+}
+```
+
 ### selectedItemChanged
+
+> DEPRECATED. Please use "itemToKey".
 
 > `function(prevItem: any, item: any)` | defaults to:
 > `(prevItem, item) => (prevItem !== item)`

--- a/src/hooks/useCombobox/README.md
+++ b/src/hooks/useCombobox/README.md
@@ -417,16 +417,22 @@ function itemToKey(item) {
 
 ```js
 // initial items.
-const items = [{id: 1, value: 'Apples'}, {id: 2, value: 'Oranges'}]
-// same items but with new references, from the server.
-const newItems = [{id: 1, value: 'Apples'}, {id: 2, value: 'Oranges'}]
+const items = [
+  {id: 1, value: 'Apples'},
+  {id: 2, value: 'Oranges'},
+]
+// the same items but with different references, for any reason.
+const newItems = [
+  {id: 1, value: 'Apples'},
+  {id: 2, value: 'Oranges'},
+]
 
-// previous prop
+// previously, if you probably had something like this.
 function selectedItemChanged(item1, item2) {
   return item1.id === item2.id
 }
 
-// moving forward
+// moving forward, switch to this one.
 function itemToKey(item) {
   return item.id
   // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) === itemToKey(nextSelectedItem)

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -202,7 +202,7 @@ describe('props', () => {
       )
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        `The "selectedItemChanged" is deprecated. Please use "itemToKey instead".`,
+        `The "selectedItemChanged" is deprecated. Please use "itemToKey instead". https://github.com/downshift-js/downshift/blob/master/src/hooks/useCombobox/README.md#selecteditemchanged`,
       )
       consoleWarnSpy.mockRestore()
     })
@@ -712,6 +712,67 @@ describe('props', () => {
     await clickOnToggleButton()
 
     expect(input).toHaveValue(selectedItem)
+  })
+
+  test('selectedItem change updates the input value', async () => {
+    const selectedItem = items[2]
+    const newSelectedItem = items[4]
+    const nullSelectedItem = null
+    const lastSelectedItem = items[1]
+    const stateReducer = jest.fn().mockImplementation((s, a) => a.changes)
+
+    const {rerender} = renderCombobox({
+      selectedItem,
+      stateReducer,
+    })
+    const input = getInput()
+
+    expect(input).toHaveValue(selectedItem)
+    expect(stateReducer).not.toHaveBeenCalled() // don't call on first render.
+
+    rerender({
+      selectedItem: newSelectedItem,
+      stateReducer,
+    })
+
+    expect(stateReducer).toHaveBeenCalledTimes(1)
+    expect(stateReducer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem,
+      }),
+    )
+    expect(input).toHaveValue(newSelectedItem)
+
+    stateReducer.mockClear()
+    rerender({
+      selectedItem: nullSelectedItem,
+      stateReducer,
+    })
+
+    expect(stateReducer).toHaveBeenCalledTimes(1)
+    expect(stateReducer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem,
+      }),
+    )
+    expect(input).toHaveValue('')
+
+    stateReducer.mockClear()
+    rerender({
+      selectedItem: lastSelectedItem,
+      stateReducer,
+    })
+
+    expect(stateReducer).toHaveBeenCalledTimes(1)
+    expect(stateReducer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem,
+      }),
+    )
+    expect(input).toHaveValue(lastSelectedItem)
   })
 
   describe('stateReducer', () => {

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -93,7 +93,7 @@ export function useControlledReducer(
           props.itemToKey(previousSelectedItemRef.current)
       } else {
         console.warn(
-          `The "selectedItemChanged" is deprecated. Please use "itemToKey instead".`,
+          `The "selectedItemChanged" is deprecated. Please use "itemToKey instead". https://github.com/downshift-js/downshift/blob/master/src/hooks/useCombobox/README.md#selecteditemchanged`,
         )
 
         shouldCallDispatch = props.selectedItemChanged(

--- a/src/hooks/useCombobox/utils.js
+++ b/src/hooks/useCombobox/utils.js
@@ -83,16 +83,31 @@ export function useControlledReducer(
     }
 
     if (
-      !isInitialMount && // on first mount we already have the proper inputValue for a initial selected item.
-      props.selectedItemChanged(
-        previousSelectedItemRef.current,
-        props.selectedItem,
-      )
+      !isInitialMount // on first mount we already have the proper inputValue for a initial selected item.
     ) {
-      dispatch({
-        type: ControlledPropUpdatedSelectedItem,
-        inputValue: props.itemToString(props.selectedItem),
-      })
+      let shouldCallDispatch
+
+      if (props.selectedItemChanged === undefined) {
+        shouldCallDispatch =
+          props.itemToKey(props.selectedItem) !==
+          props.itemToKey(previousSelectedItemRef.current)
+      } else {
+        console.warn(
+          `The "selectedItemChanged" is deprecated. Please use "itemToKey instead".`,
+        )
+
+        shouldCallDispatch = props.selectedItemChanged(
+          previousSelectedItemRef.current,
+          props.selectedItem,
+        )
+      }
+
+      if (shouldCallDispatch) {
+        dispatch({
+          type: ControlledPropUpdatedSelectedItem,
+          inputValue: props.itemToString(props.selectedItem),
+        })
+      }
     }
 
     previousSelectedItemRef.current =
@@ -116,7 +131,6 @@ if (process.env.NODE_ENV !== 'production') {
 
 export const defaultProps = {
   ...defaultPropsCommon,
-  selectedItemChanged: (prevItem, item) => prevItem !== item,
   getA11yStatusMessage,
   isItemDisabled() {
     return false

--- a/src/hooks/useMultipleSelection/README.md
+++ b/src/hooks/useMultipleSelection/README.md
@@ -44,6 +44,7 @@ such as when an item has been removed from selection.
   - [initialActiveIndex](#initialactiveindex)
   - [defaultSelectedItems](#defaultselecteditems)
   - [defaultActiveIndex](#defaultactiveindex)
+  - [itemToKey](#itemtokey)
   - [getA11yRemovalMessage](#geta11yremovalmessage)
   - [onActiveIndexChange](#onactiveindexchange)
   - [onStateChange](#onstatechange)
@@ -422,6 +423,35 @@ Pass an array of items that are going to be used when downshift is reset.
 
 Pass a number that sets the index of the focused / active selected item when
 downshift is reset.
+
+### itemToKey
+
+> `function(item: any)` | defaults to: `item => item`
+
+Used to determine the uniqueness of an item when searching for the item or
+comparing the item with another. Returns the item itself, by default, so the
+comparing/searching is done internally via referential equality.
+
+If using items as objects and their reference will change during use, you can
+use the function to generate a unique key for each item, such as an `id` prop.
+
+```js
+// initial items.
+const selectedItems = [
+  {id: 1, value: 'Apples'},
+  {id: 2, value: 'Oranges'},
+]
+// the same items but with different references, for any reason.
+const newSelectedItems = [
+  {id: 1, value: 'Apples'},
+  {id: 2, value: 'Oranges'},
+]
+
+function itemToKey(item) {
+  return item.id
+  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) === itemToKey(nextSelectedItem)
+}
+```
 
 ### getA11yRemovalMessage
 

--- a/src/hooks/useMultipleSelection/README.md
+++ b/src/hooks/useMultipleSelection/README.md
@@ -449,7 +449,7 @@ const newSelectedItems = [
 
 function itemToKey(item) {
   return item.id
-  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) === itemToKey(nextSelectedItem)
+  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) !== itemToKey(nextSelectedItem)
 }
 ```
 

--- a/src/hooks/useMultipleSelection/index.js
+++ b/src/hooks/useMultipleSelection/index.js
@@ -63,7 +63,10 @@ function useMultipleSelection(userProps = {}) {
 
     if (selectedItems.length < previousSelectedItemsRef.current.length) {
       const removedSelectedItem = previousSelectedItemsRef.current.find(
-        item => selectedItems.indexOf(item) < 0,
+        selectedItem =>
+          selectedItems.findIndex(
+            item => props.itemToKey(item) === props.itemToKey(selectedItem),
+          ) < 0,
       )
 
       setStatus(

--- a/src/hooks/useMultipleSelection/reducer.js
+++ b/src/hooks/useMultipleSelection/reducer.js
@@ -74,7 +74,9 @@ export default function downshiftMultipleSelectionReducer(state, action) {
       break
     case stateChangeTypes.FunctionRemoveSelectedItem: {
       let newActiveIndex = activeIndex
-      const selectedItemIndex = selectedItems.indexOf(selectedItem)
+      const selectedItemIndex = selectedItems.findIndex(
+        item => props.itemToKey(item) === props.itemToKey(selectedItem),
+      )
 
       if (selectedItemIndex < 0) {
         break

--- a/src/hooks/useMultipleSelection/utils.js
+++ b/src/hooks/useMultipleSelection/utils.js
@@ -127,6 +127,7 @@ const propTypes = {
 
 export const defaultProps = {
   itemToString: defaultPropsCommon.itemToString,
+  itemToKey: defaultPropsCommon.itemToKey,
   stateReducer: defaultPropsCommon.stateReducer,
   environment: defaultPropsCommon.environment,
   getA11yRemovalMessage,

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -347,7 +347,7 @@ const newItems = [
 
 function itemToKey(item) {
   return item.id
-  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) === itemToKey(nextSelectedItem)
+  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) !== itemToKey(nextSelectedItem)
 }
 ```
 

--- a/src/hooks/useSelect/README.md
+++ b/src/hooks/useSelect/README.md
@@ -49,6 +49,7 @@ guide][migration-guide-v7] and update if necessary.
   - [defaultSelectedItem](#defaultselecteditem)
   - [defaultIsOpen](#defaultisopen)
   - [defaultHighlightedIndex](#defaulthighlightedindex)
+  - [itemToKey](#itemtokey)
   - [getA11yStatusMessage](#geta11ystatusmessage)
   - [getA11ySelectionMessage](#geta11yselectionmessage)
   - [onHighlightedIndexChange](#onhighlightedindexchange)
@@ -320,6 +321,35 @@ when an item is selected.
 
 Pass a number that sets the index of the highlighted item when downshift is
 reset or when an item is selected.
+
+### itemToKey
+
+> `function(item: any)` | defaults to: `item => item`
+
+Used to determine the uniqueness of an item when searching for the item or
+comparing the item with another. Returns the item itself, by default, so the
+comparing/searching is done internally via referential equality.
+
+If using items as objects and their reference will change during use, you can
+use the function to generate a unique key for each item, such as an `id` prop.
+
+```js
+// initial items.
+const items = [
+  {id: 1, value: 'Apples'},
+  {id: 2, value: 'Oranges'},
+]
+// the same items but with different references, for any reason.
+const newItems = [
+  {id: 1, value: 'Apples'},
+  {id: 2, value: 'Oranges'},
+]
+
+function itemToKey(item) {
+  return item.id
+  // and we will do the comparison like: const isChanged = itemToKey(prevSelectedItem) === itemToKey(nextSelectedItem)
+}
+```
 
 ### getA11yStatusMessage
 

--- a/src/hooks/useSelect/reducer.js
+++ b/src/hooks/useSelect/reducer.js
@@ -28,7 +28,10 @@ export default function downshiftSelectReducer(state, action) {
         const inputValue = `${state.inputValue}${lowercasedKey}`
         const prevHighlightedIndex =
           !state.isOpen && state.selectedItem
-            ? props.items.indexOf(state.selectedItem)
+            ? props.items.findIndex(
+                item =>
+                  props.itemToKey(item) === props.itemToKey(state.selectedItem),
+              )
             : state.highlightedIndex
         const highlightedIndex = getItemIndexByCharacterKey({
           keysSoFar: inputValue,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -162,6 +162,10 @@ function itemToString(item) {
   return item ? String(item) : ''
 }
 
+function itemToKey(item) {
+  return item
+}
+
 function isAcceptedCharacterKey(key) {
   return /^\S{1}$/.test(key)
 }
@@ -261,6 +265,7 @@ function useControlledReducer(
 }
 
 const defaultProps = {
+  itemToKey,
   itemToString,
   stateReducer,
   getA11ySelectionMessage,

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -72,10 +72,10 @@ function stateReducer(s, a) {
  * @returns {string} The a11y message.
  */
 function getA11ySelectionMessage(selectionParameters) {
-  const {selectedItem, itemToString: itemToStringLocal} = selectionParameters
+  const {selectedItem, itemToString} = selectionParameters
 
   return selectedItem
-    ? `${itemToStringLocal(selectedItem)} has been selected.`
+    ? `${itemToString(selectedItem)} has been selected.`
     : ''
 }
 
@@ -156,14 +156,6 @@ function getItemAndIndex(itemProp, indexProp, items, errorMessage) {
   }
 
   return [item, index]
-}
-
-function itemToString(item) {
-  return item ? String(item) : ''
-}
-
-function itemToKey(item) {
-  return item
 }
 
 function isAcceptedCharacterKey(key) {
@@ -265,8 +257,12 @@ function useControlledReducer(
 }
 
 const defaultProps = {
-  itemToKey,
-  itemToString,
+  itemToString(item) {
+    return item ? String(item) : ''
+  },
+  itemToKey(item) {
+    return item
+  },
   stateReducer,
   getA11ySelectionMessage,
   scrollIntoView,
@@ -318,7 +314,9 @@ function getInitialState(props) {
   return {
     highlightedIndex:
       highlightedIndex < 0 && selectedItem && isOpen
-        ? props.items.indexOf(selectedItem)
+        ? props.items.findIndex(
+            item => props.itemToKey(item) === props.itemToKey(selectedItem),
+          )
         : highlightedIndex,
     isOpen,
     selectedItem,
@@ -327,7 +325,8 @@ function getInitialState(props) {
 }
 
 function getHighlightedIndexOnOpen(props, state, offset) {
-  const {items, initialHighlightedIndex, defaultHighlightedIndex} = props
+  const {items, initialHighlightedIndex, defaultHighlightedIndex, itemToKey} =
+    props
   const {selectedItem, highlightedIndex} = state
 
   if (items.length === 0) {
@@ -345,7 +344,7 @@ function getHighlightedIndexOnOpen(props, state, offset) {
     return defaultHighlightedIndex
   }
   if (selectedItem) {
-    return items.indexOf(selectedItem)
+    return items.findIndex(item => itemToKey(selectedItem) === itemToKey(item))
   }
   if (offset === 0) {
     return -1
@@ -654,6 +653,7 @@ const commonPropTypes = {
     Node: PropTypes.func.isRequired,
   }),
   itemToString: PropTypes.func,
+  itemToKey: PropTypes.func,
   stateReducer: PropTypes.func,
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -341,6 +341,7 @@ export interface UseSelectProps<Item> {
   items: Item[]
   isItemDisabled?(item: Item, index: number): boolean
   itemToString?: (item: Item | null) => string
+  itemToKey?: (item: Item | null) => any
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   getA11ySelectionMessage?: (options: A11yStatusMessageOptions<Item>) => string
   highlightedIndex?: number
@@ -537,6 +538,7 @@ export interface UseComboboxProps<Item> {
   items: Item[]
   isItemDisabled?(item: Item, index: number): boolean
   itemToString?: (item: Item | null) => string
+  itemToKey?: (item: Item | null) => any
   selectedItemChanged?: (prevItem: Item, item: Item) => boolean
   getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
   getA11ySelectionMessage?: (options: A11yStatusMessageOptions<Item>) => string
@@ -735,6 +737,7 @@ export interface UseMultipleSelectionProps<Item> {
   initialSelectedItems?: Item[]
   defaultSelectedItems?: Item[]
   itemToString?: (item: Item) => string
+  itemToKey?: (item: Item | null) => any
   getA11yRemovalMessage?: (options: A11yRemovalMessage<Item>) => string
   stateReducer?: (
     state: UseMultipleSelectionState<Item>,


### PR DESCRIPTION
**What**:
Reboot https://github.com/downshift-js/downshift/pull/1529 without the breaking change part.
<!-- Why are these changes necessary? -->

**Why**:
Closes https://github.com/downshift-js/downshift/issues/1495.
<!-- How were these changes implemented? -->

**How**:
Initially have both itemToKey and selectedItemChanged props but warn that the latter is going to be deprecated.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
