### PR TITLE
types(hooks): improve Typescript for onChange funtions

### DIFF
--- a/src/hooks/MIGRATION_V9.md
+++ b/src/hooks/MIGRATION_V9.md
@@ -9,7 +9,7 @@ hooks and are detailed below.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [onChangeTypescriptImprovements](#onchangetypescriptimprovements)
+- [onChange Typescript Improvements](#onchange-typescript-improvements)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/src/hooks/MIGRATION_V9.md
+++ b/src/hooks/MIGRATION_V9.md
@@ -1,0 +1,34 @@
+# Migration from v8 to v9
+
+Downshift v8 receives a list of breaking changes, which are necessary to improve
+both the user and the developer experience. The changes are only affecting the
+hooks and are detailed below.
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [onChangeTypescriptImprovements](#onchangetypescriptimprovements)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## onChange Typescript Improvements
+
+The handlers below have their types improved to reflect that they will always
+get called with their corresponding state prop:
+
+- useCombobox
+  - onSelectedItemChange: selectedItem is non optional
+  - onIsOpenChange: isOpen is non optional
+  - onHighlightedIndexChange: highlightedIndex is non optional
+
+- useSelect
+  - onSelectedItemChange: selectedItem is non optional
+  - onIsOpenChange: isOpen is non optional
+  - onHighlightedIndexChange: highlightedIndex is non optional
+  - onInputValueChange: inputValue is non optional
+
+- useMultipleSelection
+  - onActiveIndexChange: activeIndex is non optional
+  - onSelectedItemsChange: selectedItems is non optional

--- a/test/useCombobox.test.tsx
+++ b/test/useCombobox.test.tsx
@@ -32,12 +32,11 @@ export default function DropdownCombobox() {
   } = useCombobox({
     items: inputItems,
     onInputValueChange: ({inputValue}) => {
-      inputValue !== undefined &&
-        setInputItems(
-          colors.filter(item =>
-            item.toLowerCase().startsWith(inputValue.toLowerCase()),
-          ),
-        )
+      setInputItems(
+        colors.filter(item =>
+          item.toLowerCase().startsWith(inputValue.toLowerCase()),
+        ),
+      )
     },
   })
   return (

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -363,9 +363,11 @@ export interface UseSelectProps<Item> {
     state: UseSelectState<Item>,
     actionAndChanges: UseSelectStateChangeOptions<Item>,
   ) => Partial<UseSelectState<Item>>
-  onSelectedItemChange?: (changes: UseSelectStateChange<Item>) => void
-  onIsOpenChange?: (changes: UseSelectStateChange<Item>) => void
-  onHighlightedIndexChange?: (changes: UseSelectStateChange<Item>) => void
+  onSelectedItemChange?: (changes: UseSelectSelectedItemChange<Item>) => void
+  onIsOpenChange?: (changes: UseSelectIsOpenChange<Item>) => void
+  onHighlightedIndexChange?: (
+    changes: UseSelectHighlightedIndexChange<Item>,
+  ) => void
   onStateChange?: (changes: UseSelectStateChange<Item>) => void
   environment?: Environment
 }
@@ -388,6 +390,21 @@ export interface UseSelectDispatchAction<Item> {
 export interface UseSelectStateChange<Item>
   extends Partial<UseSelectState<Item>> {
   type: UseSelectStateChangeTypes
+}
+
+export interface UseSelectSelectedItemChange<Item>
+  extends UseSelectStateChange<Item> {
+  selectedItem: Item
+}
+
+export interface UseSelectHighlightedIndexChange<Item>
+  extends UseSelectStateChange<Item> {
+  highlightedIndex: index
+}
+
+export interface UseSelectIsOpenChange<Item>
+  extends UseSelectStateChange<Item> {
+  isOpen: boolean
 }
 
 export interface UseSelectGetMenuPropsOptions
@@ -565,11 +582,13 @@ export interface UseComboboxProps<Item> {
     state: UseComboboxState<Item>,
     actionAndChanges: UseComboboxStateChangeOptions<Item>,
   ) => Partial<UseComboboxState<Item>>
-  onSelectedItemChange?: (changes: UseComboboxStateChange<Item>) => void
-  onIsOpenChange?: (changes: UseComboboxStateChange<Item>) => void
-  onHighlightedIndexChange?: (changes: UseComboboxStateChange<Item>) => void
+  onSelectedItemChange?: (changes: UseComboboxSelectedItemChange<Item>) => void
+  onIsOpenChange?: (changes: UseComboboxIsOpenChange<Item>) => void
+  onHighlightedIndexChange?: (
+    changes: UseComboboxHighlightedIndexChange<Item>,
+  ) => void
   onStateChange?: (changes: UseComboboxStateChange<Item>) => void
-  onInputValueChange?: (changes: UseComboboxStateChange<Item>) => void
+  onInputValueChange?: (changes: UseComboboxInputValueChange<Item>) => void
   environment?: Environment
 }
 
@@ -591,6 +610,25 @@ export interface UseComboboxDispatchAction<Item> {
 export interface UseComboboxStateChange<Item>
   extends Partial<UseComboboxState<Item>> {
   type: UseComboboxStateChangeTypes
+}
+
+export interface UseComboboxSelectedItemChange<Item>
+  extends UseComboboxStateChange<Item> {
+  selectedItem: Item
+}
+export interface UseComboboxHighlightedIndexChange<Item>
+  extends UseComboboxStateChange<Item> {
+  highlightedIndex: index
+}
+
+export interface UseComboboxIsOpenChange<Item>
+  extends UseComboboxStateChange<Item> {
+  isOpen: boolean
+}
+
+export interface UseComboboxInputValueChange<Item>
+  extends UseComboboxStateChange<Item> {
+  inputValue: string
 }
 
 export interface UseComboboxGetMenuPropsOptions
@@ -746,9 +784,11 @@ export interface UseMultipleSelectionProps<Item> {
   activeIndex?: number
   initialActiveIndex?: number
   defaultActiveIndex?: number
-  onActiveIndexChange?: (changes: UseMultipleSelectionStateChange<Item>) => void
+  onActiveIndexChange?: (
+    changes: UseMultipleSelectionActiveIndexChange<Item>,
+  ) => void
   onSelectedItemsChange?: (
-    changes: UseMultipleSelectionStateChange<Item>,
+    changes: UseMultipleSelectionSelectedItemsChange<Item>,
   ) => void
   onStateChange?: (changes: UseMultipleSelectionStateChange<Item>) => void
   keyNavigationNext?: string
@@ -772,6 +812,16 @@ export interface UseMultipleSelectionDispatchAction<Item> {
 export interface UseMultipleSelectionStateChange<Item>
   extends Partial<UseMultipleSelectionState<Item>> {
   type: UseMultipleSelectionStateChangeTypes
+}
+
+export interface UseMultipleSelectionActiveIndexChange<Item>
+  extends UseMultipleSelectionStateChange<Item> {
+  activeIndex: number
+}
+
+export interface UseMultipleSelectionSelectedItemsChange<Item>
+  extends UseMultipleSelectionStateChange<Item> {
+  selectedItems: Item[]
 }
 
 export interface A11yRemovalMessage<Item> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Improve the type of the onChange options parameter to reflect that individual onChange functions are called with non-optional state values.
<!-- Why are these changes necessary? -->

**Why**:
For example, onIsOpenChange will always be called with `isOpen`, so the type will be {type, isOpen, highlightedIndex?, inputValue?, ...}
<!-- How were these changes implemented? -->

**How**:
Change the typings.ts
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
