### PR TITLE
Fix bugs in new `getA11yStatusMessage` option in hooks

### DIFF
--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -285,6 +285,25 @@ describe('props', () => {
         'a11y-status-message',
       )
     })
+
+    test('is not overriden if it is called once with a value and again without', async () => {
+      const a11yStatusMessage = 'bla bla'
+      const getA11yStatusMessage = jest
+        .fn()
+        .mockReturnValueOnce(a11yStatusMessage)
+        .mockReturnValueOnce(undefined)
+      renderCombobox({
+        items,
+        getA11yStatusMessage,
+      })
+
+      await clickOnToggleButton()
+      await keyDownOnInput('{ArrowDown}')
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(2)
+      expect(getA11yStatusContainer()).toHaveTextContent(a11yStatusMessage)
+    })
   })
 
   test('highlightedIndex controls the state property if passed', async () => {

--- a/src/hooks/useMultipleSelection/__tests__/props.test.js
+++ b/src/hooks/useMultipleSelection/__tests__/props.test.js
@@ -171,6 +171,28 @@ describe('props', () => {
         'a11y-status-message',
       )
     })
+
+    test('is not overriden if it is called once with a value and again without', async () => {
+      const a11yStatusMessage = 'bla bla'
+      const getA11yStatusMessage = jest
+        .fn()
+        .mockReturnValueOnce(a11yStatusMessage)
+        .mockReturnValueOnce(undefined)
+      renderMultipleCombobox({
+        multipleSelectionProps: {
+          selectedItems: [items[0], items[1]],
+          initialActiveIndex: 0,
+          getA11yStatusMessage,
+        },
+      })
+
+      await keyDownOnSelectedItemAtIndex(1, '{ArrowLeft}')
+      await keyDownOnSelectedItemAtIndex(1, '{ArrowRight}')
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(2)
+      expect(getA11yStatusContainer()).toHaveTextContent(a11yStatusMessage)
+    })
   })
 
   describe('activeIndex', () => {

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -177,6 +177,25 @@ describe('props', () => {
         'a11y-status-message',
       )
     })
+
+    test('is not overriden if it is called once with a value and again without', async () => {
+      const a11yStatusMessage = 'bla bla'
+      const getA11yStatusMessage = jest
+        .fn()
+        .mockReturnValueOnce(a11yStatusMessage)
+        .mockReturnValueOnce(undefined)
+      renderSelect({
+        items,
+        getA11yStatusMessage,
+      })
+
+      await clickOnToggleButton()
+      await keyDownOnToggleButton('{ArrowDown}')
+      waitForDebouncedA11yStatusUpdate()
+
+      expect(getA11yStatusMessage).toHaveBeenCalledTimes(2)
+      expect(getA11yStatusContainer()).toHaveTextContent(a11yStatusMessage)
+    })
   })
 
   test('highlightedIndex controls the state property if passed', async () => {

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -411,7 +411,7 @@ function useMouseAndTouchTracker(
       environment.removeEventListener('touchmove', onTouchMove)
       environment.removeEventListener('touchend', onTouchEnd)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- refs don't change
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs don't change
   }, [environment, handleBlur])
 
   return mouseAndTouchTrackersRef.current
@@ -502,7 +502,7 @@ function useA11yMessageStatus(
 
     const status = getA11yStatusMessage(options)
 
-    updateA11yStatus(status, document)
+    if (status) updateA11yStatus(status, document)
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dependencyArray])

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -38,7 +38,9 @@ export interface DownshiftProps<Item> {
   defaultIsOpen?: boolean
   itemToString?: (item: Item | null) => string
   selectedItemChanged?: (prevItem: Item, item: Item) => boolean
-  getA11yStatusMessage?: (options: A11yStatusMessageOptions<Item>) => string
+  getA11yStatusMessage?: (
+    options: A11yStatusMessageOptions<Item>,
+  ) => string | undefined
   onChange?: (
     selectedItem: Item | null,
     stateAndHelpers: ControllerStateAndHelpers<Item>,
@@ -342,7 +344,7 @@ export interface UseSelectProps<Item> {
   isItemDisabled?(item: Item, index: number): boolean
   itemToString?: (item: Item | null) => string
   itemToKey?: (item: Item | null) => any
-  getA11yStatusMessage?: (options: UseSelectState<Item>) => string
+  getA11yStatusMessage?: (options: UseSelectState<Item>) => string | undefined
   highlightedIndex?: number
   initialHighlightedIndex?: number
   defaultHighlightedIndex?: number
@@ -555,7 +557,7 @@ export interface UseComboboxProps<Item> {
   isItemDisabled?(item: Item, index: number): boolean
   itemToString?: (item: Item | null) => string
   itemToKey?: (item: Item | null) => any
-  getA11yStatusMessage?: (options: UseComboboxState<Item>) => string
+  getA11yStatusMessage?: (options: UseComboboxState<Item>) => string | undefined
   highlightedIndex?: number
   initialHighlightedIndex?: number
   defaultHighlightedIndex?: number
@@ -772,7 +774,9 @@ export interface UseMultipleSelectionProps<Item> {
   initialSelectedItems?: Item[]
   defaultSelectedItems?: Item[]
   itemToKey?: (item: Item | null) => any
-  getA11yStatusMessage?: (options: UseMultipleSelectionState<Item>) => string
+  getA11yStatusMessage?: (
+    options: UseMultipleSelectionState<Item>,
+  ) => string | undefined
   stateReducer?: (
     state: UseMultipleSelectionState<Item>,
     actionAndChanges: UseMultipleSelectionStateChangeOptions<Item>,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

1. Only update the A11Y message in the document if a non empty message is given
2. Update the return type to include `undefined` as an option

<!-- Why are these changes necessary? -->

**Why**:

If using the `getA11yStatusMessage` prop to apply an a11y message for a specific scenario and returning undefined in other scenarios, it is possible for the `getA11yStatusMessage` function to run once to set the message, then again and sets undefined overriding anything previously set (because of the `debounce` function used).

I've also updated the types to allow returning of `undefined` (this is done in your examples of this function).

I've prepared a [CodeSandbox](https://codesandbox.io/p/sandbox/downshift-accessible-message-5g67dt?file=%2Fsrc%2FApp.tsx%3A12%2C17) showing these two issues.

- This example uses the `useMultipleSelection` hook and applies the example `getA11yStatusMessage` provided in your docs.
- If you select an option and then remove it by clicking the 'X' on the option, you'll see Voiceover does not announce that it has been removed. This is because an additional state update is overriding this to an empty message.
- You can also see the type error complaining about returning `undefined` instead of `string`

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Tests
- [x] TypeScript Types
- [ ] Flow Types - N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
