### PR TITLE
fix(hooks): do not highlight disabled items on menu open

### DIFF
--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -334,6 +334,71 @@ describe('props', () => {
     expect(input).toHaveAttribute('aria-activedescendant', expectedItemId)
   })
 
+  test('initialHighlightedIndex is ignored if item is disabled', async () => {
+    const initialHighlightedIndex = 2
+    renderCombobox({
+      initialHighlightedIndex,
+      isItemDisabled(item) {
+        return items.indexOf(item) === initialHighlightedIndex
+      },
+    })
+
+    await clickOnInput()
+
+    expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+  })
+
+  test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
+    const initialHighlightedIndex = 0
+    const defaultHighlightedIndex = 2
+    renderCombobox({
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled(item) {
+        return items.indexOf(item) === initialHighlightedIndex
+      },
+    })
+
+    await clickOnInput()
+
+    expect(getInput()).toHaveAttribute(
+      'aria-activedescendant',
+      defaultIds.getItemId(defaultHighlightedIndex),
+    )
+  })
+
+  test('defaultHighlightedIndex is ignored if item is disabled', async () => {
+    const defaultHighlightedIndex = 2
+    renderCombobox({
+      defaultHighlightedIndex,
+      isItemDisabled(item) {
+        return items.indexOf(item) === defaultHighlightedIndex
+      },
+    })
+
+    await clickOnInput()
+
+    expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+  })
+
+  test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {
+    const initialHighlightedIndex = 0
+    const defaultHighlightedIndex = 2
+    renderCombobox({
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled(item) {
+        return [initialHighlightedIndex, defaultHighlightedIndex].includes(
+          items.indexOf(item),
+        )
+      },
+    })
+
+    await clickOnInput()
+
+    expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+  })
+
   describe('inputValue', () => {
     test('controls the state property if passed', async () => {
       renderCombobox({isOpen: true, inputValue: 'Dohn Joe'})

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -99,7 +99,7 @@ describe('props', () => {
         inputValue: 'h',
         highlightedIndex: 15,
         isOpen: true,
-        selectedItem: null
+        selectedItem: null,
       })
       expect(getA11yStatusMessage).toHaveBeenCalledTimes(1)
 
@@ -234,7 +234,72 @@ describe('props', () => {
     }
   })
 
-  test('controls the state property if passed', async () => {
+  test('initialHighlightedIndex is ignored if item is disabled', async () => {
+    const initialHighlightedIndex = 2
+    renderSelect({
+      initialHighlightedIndex,
+      isItemDisabled(item) {
+        return items.indexOf(item) === initialHighlightedIndex
+      },
+    })
+
+    await clickOnToggleButton()
+
+    expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
+  })
+
+  test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
+    const initialHighlightedIndex = 0
+    const defaultHighlightedIndex = 2
+    renderSelect({
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled(item) {
+        return items.indexOf(item) === initialHighlightedIndex
+      },
+    })
+
+    await clickOnToggleButton()
+
+    expect(getToggleButton()).toHaveAttribute(
+      'aria-activedescendant',
+      defaultIds.getItemId(defaultHighlightedIndex),
+    )
+  })
+
+  test('defaultHighlightedIndex is ignored if item is disabled', async () => {
+    const defaultHighlightedIndex = 2
+    renderSelect({
+      defaultHighlightedIndex,
+      isItemDisabled(item) {
+        return items.indexOf(item) === defaultHighlightedIndex
+      },
+    })
+
+    await clickOnToggleButton()
+
+    expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
+  })
+
+  test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {
+    const initialHighlightedIndex = 0
+    const defaultHighlightedIndex = 2
+    renderSelect({
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled(item) {
+        return [initialHighlightedIndex, defaultHighlightedIndex].includes(
+          items.indexOf(item),
+        )
+      },
+    })
+
+    await clickOnToggleButton()
+
+    expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
+  })
+
+  test('isOpen controls the state property if passed', async () => {
     renderSelect({isOpen: true})
     expect(getItems()).toHaveLength(items.length)
     await tab() // focus toggle button

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -310,8 +310,13 @@ function getInitialState(props) {
 }
 
 function getHighlightedIndexOnOpen(props, state, offset) {
-  const {items, initialHighlightedIndex, defaultHighlightedIndex, itemToKey} =
-    props
+  const {
+    items,
+    initialHighlightedIndex,
+    defaultHighlightedIndex,
+    isItemDisabled,
+    itemToKey,
+  } = props
   const {selectedItem, highlightedIndex} = state
 
   if (items.length === 0) {
@@ -321,11 +326,15 @@ function getHighlightedIndexOnOpen(props, state, offset) {
   // initialHighlightedIndex will give value to highlightedIndex on initial state only.
   if (
     initialHighlightedIndex !== undefined &&
-    highlightedIndex === initialHighlightedIndex
+    highlightedIndex === initialHighlightedIndex &&
+    !isItemDisabled(items[initialHighlightedIndex])
   ) {
     return initialHighlightedIndex
   }
-  if (defaultHighlightedIndex !== undefined) {
+  if (
+    defaultHighlightedIndex !== undefined &&
+    !isItemDisabled(items[defaultHighlightedIndex])
+  ) {
     return defaultHighlightedIndex
   }
   if (selectedItem) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Check if items are disabled before highlighting them, when opening the menu with initialHighlightedIndex or defaultHighlightedIndex.

<!-- Why are these changes necessary? -->

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1584.

<!-- How were these changes implemented? -->

**How**:
Check if the items are disabled before returning defaultHighlightedIndex / initialHighlightedIndex as the highlightedIndex on menu open.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
