### PR TITLE
fix(highlightedIndex): do not highlight disabled items

### DIFF
--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -1,4 +1,8 @@
-import {getHighlightedIndexOnOpen, getDefaultValue} from './utils'
+import {
+  getHighlightedIndexOnOpen,
+  getDefaultValue,
+  getDefaultHighlightedIndex,
+} from './utils'
 
 export default function downshiftCommonReducer(
   state,
@@ -46,7 +50,12 @@ export default function downshiftCommonReducer(
       break
     case stateChangeTypes.FunctionSetHighlightedIndex:
       changes = {
-        highlightedIndex: action.highlightedIndex,
+        highlightedIndex: props.isItemDisabled(
+          props.items[action.highlightedIndex],
+          action.highlightedIndex,
+        )
+          ? -1
+          : action.highlightedIndex,
       }
 
       break
@@ -58,7 +67,7 @@ export default function downshiftCommonReducer(
       break
     case stateChangeTypes.FunctionReset:
       changes = {
-        highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
+        highlightedIndex: getDefaultHighlightedIndex(props),
         isOpen: getDefaultValue(props, 'isOpen'),
         selectedItem: getDefaultValue(props, 'selectedItem'),
         inputValue: getDefaultValue(props, 'inputValue'),

--- a/src/hooks/useCombobox/__tests__/__snapshots__/getInputProps.test.js.snap
+++ b/src/hooks/useCombobox/__tests__/__snapshots__/getInputProps.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getInputProps event handlers on key down arrow down defaultHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Americium,
+    2,
+  ],
+  [
+    Neptunium,
+    0,
+  ],
+]
+`;
+
+exports[`getInputProps event handlers on key down arrow down initialHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Neptunium,
+    0,
+  ],
+]
+`;
+
+exports[`getInputProps event handlers on key down arrow up defaultHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Americium,
+    2,
+  ],
+  [
+    Oganesson,
+    25,
+  ],
+]
+`;
+
+exports[`getInputProps event handlers on key down arrow up initialHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Oganesson,
+    25,
+  ],
+]
+`;

--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -436,47 +436,64 @@ describe('getInputProps', () => {
   })
 
   describe('event handlers', () => {
-    test('on change should open the menu and keep the input value', async () => {
-      renderCombobox()
+    describe('on change', () => {
+      test('should open the menu and keep the input value', async () => {
+        renderCombobox()
 
-      await changeInputValue('california')
+        await changeInputValue('california')
 
-      expect(getItems()).toHaveLength(items.length)
-      expect(getInput()).toHaveValue('california')
-    })
+        expect(getItems()).toHaveLength(items.length)
+        expect(getInput()).toHaveValue('california')
+      })
 
-    test('on change should remove the highlightedIndex', async () => {
-      renderCombobox({initialHighlightedIndex: 2})
+      test('should remove the highlightedIndex', async () => {
+        renderCombobox({initialHighlightedIndex: 2})
 
-      await changeInputValue('california')
+        await changeInputValue('california')
 
-      expect(getInput()).toHaveAttribute('aria-activedescendant', '')
-    })
+        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+      })
 
-    test('on change should reset to defaultHighlightedIndex', async () => {
-      const defaultHighlightedIndex = 2
-      renderCombobox({defaultHighlightedIndex})
+      test('should reset to defaultHighlightedIndex', async () => {
+        const defaultHighlightedIndex = 2
+        renderCombobox({defaultHighlightedIndex})
 
-      await changeInputValue('a')
+        await changeInputValue('a')
 
-      expect(getInput()).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(defaultHighlightedIndex),
-      )
+        expect(getInput()).toHaveAttribute(
+          'aria-activedescendant',
+          defaultIds.getItemId(defaultHighlightedIndex),
+        )
 
-      await keyDownOnInput('{ArrowDown}')
+        await keyDownOnInput('{ArrowDown}')
 
-      expect(getInput()).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(defaultHighlightedIndex + 1),
-      )
+        expect(getInput()).toHaveAttribute(
+          'aria-activedescendant',
+          defaultIds.getItemId(defaultHighlightedIndex + 1),
+        )
 
-      await changeInputValue('a')
+        await changeInputValue('a')
 
-      expect(getInput()).toHaveAttribute(
-        'aria-activedescendant',
-        defaultIds.getItemId(defaultHighlightedIndex),
-      )
+        expect(getInput()).toHaveAttribute(
+          'aria-activedescendant',
+          defaultIds.getItemId(defaultHighlightedIndex),
+        )
+      })
+
+      test('should not reset to defaultHighlightedIndex if disabled', async () => {
+        const defaultHighlightedIndex = 2
+        renderCombobox({
+          defaultHighlightedIndex,
+          isItemDisabled(_item, index) {
+            return index === defaultHighlightedIndex
+          },
+        })
+
+        await keyDownOnInput('{ArrowDown}')
+        await changeInputValue('a')
+
+        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+      })
     })
 
     describe('on key down', () => {
@@ -579,11 +596,14 @@ describe('getInputProps', () => {
 
         test('initialHighlightedIndex is ignored if item is disabled', async () => {
           const initialHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === initialHighlightedIndex,
+            )
           renderCombobox({
             initialHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === initialHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnInput('{ArrowUp}')
@@ -592,6 +612,7 @@ describe('getInputProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(items.length - 1),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 2)).toMatchSnapshot()
         })
 
         test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
@@ -615,11 +636,14 @@ describe('getInputProps', () => {
 
         test('defaultHighlightedIndex is ignored if item is disabled', async () => {
           const defaultHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === defaultHighlightedIndex,
+            )
           renderCombobox({
             defaultHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === defaultHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnInput('{ArrowUp}')
@@ -628,6 +652,7 @@ describe('getInputProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(items.length - 1),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 3)).toMatchSnapshot()
         })
 
         test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {
@@ -901,11 +926,14 @@ describe('getInputProps', () => {
 
         test('initialHighlightedIndex is ignored if item is disabled', async () => {
           const initialHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === initialHighlightedIndex,
+            )
           renderCombobox({
             initialHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === initialHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnInput('{ArrowDown}')
@@ -914,6 +942,7 @@ describe('getInputProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(0),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 2)).toMatchSnapshot()
         })
 
         test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
@@ -937,11 +966,14 @@ describe('getInputProps', () => {
 
         test('defaultHighlightedIndex is ignored if item is disabled', async () => {
           const defaultHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === defaultHighlightedIndex,
+            )
           renderCombobox({
             defaultHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === defaultHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnInput('{ArrowDown}')
@@ -950,6 +982,7 @@ describe('getInputProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(0),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 3)).toMatchSnapshot()
         })
 
         test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {
@@ -1859,7 +1892,7 @@ describe('getInputProps', () => {
         renderCombobox({
           initialIsOpen: true,
           initialHighlightedIndex,
-          environment: undefined
+          environment: undefined,
         })
 
         await tab()
@@ -1967,19 +2000,26 @@ describe('getInputProps', () => {
         )
       })
 
-
       test('initialHighlightedIndex is ignored if item is disabled', async () => {
         const initialHighlightedIndex = 2
+        const isItemDisabled = jest
+          .fn()
+          .mockImplementation(
+            item => items.indexOf(item) === initialHighlightedIndex,
+          )
         renderCombobox({
           initialHighlightedIndex,
-          isItemDisabled(item) {
-            return items.indexOf(item) === initialHighlightedIndex
-          },
+          isItemDisabled,
         })
 
         await clickOnInput()
 
         expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+        expect(isItemDisabled).toHaveBeenNthCalledWith(
+          1,
+          items[initialHighlightedIndex],
+          initialHighlightedIndex,
+        )
       })
 
       test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
@@ -2003,16 +2043,24 @@ describe('getInputProps', () => {
 
       test('defaultHighlightedIndex is ignored if item is disabled', async () => {
         const defaultHighlightedIndex = 2
+        const isItemDisabled = jest
+          .fn()
+          .mockImplementation(
+            item => items.indexOf(item) === defaultHighlightedIndex,
+          )
         renderCombobox({
           defaultHighlightedIndex,
-          isItemDisabled(item) {
-            return items.indexOf(item) === defaultHighlightedIndex
-          },
+          isItemDisabled,
         })
 
         await clickOnInput()
 
         expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+        expect(isItemDisabled).toHaveBeenNthCalledWith(
+          1,
+          items[defaultHighlightedIndex],
+          defaultHighlightedIndex,
+        )
       })
 
       test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {
@@ -2032,7 +2080,6 @@ describe('getInputProps', () => {
 
         expect(getInput()).toHaveAttribute('aria-activedescendant', '')
       })
-
     })
   })
 

--- a/src/hooks/useCombobox/__tests__/getItemProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getItemProps.test.js
@@ -346,6 +346,25 @@ describe('getItemProps', () => {
           defaultIds.getItemId(defaultHighlightedIndex),
         )
       })
+
+      test('it selects the item and resets to user defined defaults, but considers disabled status for an item', async () => {
+        const index = 1
+        const defaultHighlightedIndex = 2
+        renderCombobox({
+          defaultIsOpen: true,
+          defaultHighlightedIndex,
+          isItemDisabled(_item, idx) {
+            return idx === defaultHighlightedIndex
+          },
+        })
+        const input = getInput()
+
+        await clickOnItemAtIndex(index)
+
+        expect(input).toHaveValue(items[index])
+        expect(getItems()).toHaveLength(items.length)
+        expect(input).toHaveAttribute('aria-activedescendant', '')
+      })
     })
   })
 

--- a/src/hooks/useCombobox/__tests__/props.test.js
+++ b/src/hooks/useCombobox/__tests__/props.test.js
@@ -1447,4 +1447,46 @@ describe('props', () => {
       `downshift: A component has changed the controlled prop "inputValue" to be uncontrolled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props`,
     )
   })
+
+  test('initialHighlightedIndex is ignored if item is disabled and menu is intially open', () => {
+    const initialHighlightedIndex = 2
+    const isItemDisabled = jest
+      .fn()
+      .mockImplementation(
+        item => items.indexOf(item) === initialHighlightedIndex,
+      )
+    renderCombobox({
+      initialHighlightedIndex,
+      isItemDisabled,
+      initialIsOpen: true,
+    })
+
+    expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+    expect(isItemDisabled).toHaveBeenNthCalledWith(
+      1,
+      items[initialHighlightedIndex],
+      initialHighlightedIndex,
+    )
+  })
+
+  test('defaultHighlightedIndex is ignored if item is disabled and menu is intially open', () => {
+    const defaultHighlightedIndex = 2
+    const isItemDisabled = jest
+      .fn()
+      .mockImplementation(
+        item => items.indexOf(item) === defaultHighlightedIndex,
+      )
+    renderCombobox({
+      defaultHighlightedIndex,
+      isItemDisabled,
+      initialIsOpen: true,
+    })
+
+    expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+    expect(isItemDisabled).toHaveBeenNthCalledWith(
+      1,
+      items[defaultHighlightedIndex],
+      defaultHighlightedIndex,
+    )
+  })
 })

--- a/src/hooks/useCombobox/__tests__/returnProps.test.js
+++ b/src/hooks/useCombobox/__tests__/returnProps.test.js
@@ -90,6 +90,22 @@ describe('returnProps', () => {
       expect(result.current.highlightedIndex).toBe(2)
     })
 
+    test('setHighlightedIndex does not set highlightedIndex if item is disabled', () => {
+      const highlightedIndex = 2
+      const {result} = renderUseCombobox({
+        initialIsOpen: true,
+        isItemDisabled(_item, index) {
+          return index === highlightedIndex
+        },
+      })
+
+      act(() => {
+        result.current.setHighlightedIndex(highlightedIndex)
+      })
+
+      expect(result.current.highlightedIndex).toBe(-1)
+    })
+
     test('setInputValue sets inputValue', () => {
       const {result} = renderUseCombobox({})
 
@@ -162,6 +178,29 @@ describe('returnProps', () => {
       )
       expect(result.current.isOpen).toBe(props.defaultIsOpen)
       expect(result.current.inputValue).toBe(props.defaultInputValue)
+    })
+
+    test('reset does not set the defaultHighlightedIndex if item is disabled', () => {
+      const props = {
+        defaultIsOpen: false,
+        defaultHighlightedIndex: 3,
+        defaultSelectedItem: items[2],
+        isItemDisabled(_item, index) {
+          return index === 3
+        },
+      }
+      const {result} = renderUseCombobox(props)
+
+      act(() => {
+        result.current.openMenu()
+        result.current.selectItem(items[4])
+        result.current.setHighlightedIndex(1)
+        result.current.reset()
+      })
+
+      expect(result.current.selectedItem).toBe(props.defaultSelectedItem)
+      expect(result.current.highlightedIndex).toBe(-1)
+      expect(result.current.isOpen).toBe(props.defaultIsOpen)
     })
   })
 

--- a/src/hooks/useCombobox/reducer.js
+++ b/src/hooks/useCombobox/reducer.js
@@ -2,6 +2,7 @@ import {
   getHighlightedIndexOnOpen,
   getDefaultValue,
   getChangesOnSelection,
+  getDefaultHighlightedIndex,
 } from '../utils'
 import {getHighlightedIndex, getNonDisabledIndex} from '../../utils'
 import commonReducer from '../reducer'
@@ -16,10 +17,11 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.ItemClick:
       changes = {
         isOpen: getDefaultValue(props, 'isOpen'),
-        highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
+        highlightedIndex: getDefaultHighlightedIndex(props),
         selectedItem: props.items[action.index],
         inputValue: props.itemToString(props.items[action.index]),
       }
+
       break
     case stateChangeTypes.InputKeyDownArrowDown:
       if (state.isOpen) {
@@ -135,7 +137,7 @@ export default function downshiftUseComboboxReducer(state, action) {
     case stateChangeTypes.InputChange:
       changes = {
         isOpen: true,
-        highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
+        highlightedIndex: getDefaultHighlightedIndex(props),
         inputValue: action.inputValue,
       }
       break

--- a/src/hooks/useSelect/__tests__/__snapshots__/getToggleButtonProps.test.js.snap
+++ b/src/hooks/useSelect/__tests__/__snapshots__/getToggleButtonProps.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getToggleButtonProps event handlers on keydown arrow down defaultHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Americium,
+    2,
+  ],
+  [
+    Neptunium,
+    0,
+  ],
+]
+`;
+
+exports[`getToggleButtonProps event handlers on keydown arrow down initialHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Neptunium,
+    0,
+  ],
+]
+`;
+
+exports[`getToggleButtonProps event handlers on keydown arrow up defaultHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Americium,
+    2,
+  ],
+  [
+    Oganesson,
+    25,
+  ],
+]
+`;
+
+exports[`getToggleButtonProps event handlers on keydown arrow up initialHighlightedIndex is ignored if item is disabled 1`] = `
+[
+  [
+    Americium,
+    2,
+  ],
+  [
+    Oganesson,
+    25,
+  ],
+]
+`;

--- a/src/hooks/useSelect/__tests__/getItemProps.test.js
+++ b/src/hooks/useSelect/__tests__/getItemProps.test.js
@@ -374,6 +374,25 @@ describe('getItemProps', () => {
           defaultIds.getItemId(2),
         )
       })
+
+      test('it selects the item and resets to user defined defaults, but considers disabled status for an item', async () => {
+        const index = 1
+        const defaultHighlightedIndex = 2
+        renderSelect({
+          defaultIsOpen: true,
+          defaultHighlightedIndex,
+          isItemDisabled(_item, idx) {
+            return idx === defaultHighlightedIndex
+          },
+        })
+        const toggleButton = getToggleButton()
+
+        await clickOnItemAtIndex(index)
+
+        expect(toggleButton).toHaveTextContent(items[index])
+        expect(getItems()).toHaveLength(items.length)
+        expect(toggleButton).toHaveAttribute('aria-activedescendant', '')
+      })
     })
   })
 

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -388,16 +388,24 @@ describe('getToggleButtonProps', () => {
 
       test('initialHighlightedIndex is ignored if item is disabled', async () => {
         const initialHighlightedIndex = 2
+        const isItemDisabled = jest
+          .fn()
+          .mockImplementation(
+            item => items.indexOf(item) === initialHighlightedIndex,
+          )
         renderSelect({
           initialHighlightedIndex,
-          isItemDisabled(item) {
-            return items.indexOf(item) === initialHighlightedIndex
-          },
+          isItemDisabled,
         })
 
         await clickOnToggleButton()
 
         expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
+        expect(isItemDisabled).toHaveBeenNthCalledWith(
+          1,
+          items[initialHighlightedIndex],
+          initialHighlightedIndex,
+        )
       })
 
       test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
@@ -421,16 +429,24 @@ describe('getToggleButtonProps', () => {
 
       test('defaultHighlightedIndex is ignored if item is disabled', async () => {
         const defaultHighlightedIndex = 2
+        const isItemDisabled = jest
+          .fn()
+          .mockImplementation(
+            item => items.indexOf(item) === defaultHighlightedIndex,
+          )
         renderSelect({
           defaultHighlightedIndex,
-          isItemDisabled(item) {
-            return items.indexOf(item) === defaultHighlightedIndex
-          },
+          isItemDisabled,
         })
 
         await clickOnToggleButton()
 
         expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
+        expect(isItemDisabled).toHaveBeenNthCalledWith(
+          1,
+          items[defaultHighlightedIndex],
+          defaultHighlightedIndex,
+        )
       })
 
       test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {
@@ -848,11 +864,14 @@ describe('getToggleButtonProps', () => {
 
         test('initialHighlightedIndex is ignored if item is disabled', async () => {
           const initialHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === initialHighlightedIndex,
+            )
           renderSelect({
             initialHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === initialHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnToggleButton('{ArrowUp}')
@@ -861,6 +880,7 @@ describe('getToggleButtonProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(items.length - 1),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 2)).toMatchSnapshot()
         })
 
         test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
@@ -884,11 +904,14 @@ describe('getToggleButtonProps', () => {
 
         test('defaultHighlightedIndex is ignored if item is disabled', async () => {
           const defaultHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === defaultHighlightedIndex,
+            )
           renderSelect({
             defaultHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === defaultHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnToggleButton('{ArrowUp}')
@@ -897,6 +920,7 @@ describe('getToggleButtonProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(items.length - 1),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 3)).toMatchSnapshot()
         })
 
         test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {
@@ -1180,11 +1204,14 @@ describe('getToggleButtonProps', () => {
 
         test('initialHighlightedIndex is ignored if item is disabled', async () => {
           const initialHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === initialHighlightedIndex,
+            )
           renderSelect({
             initialHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === initialHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnToggleButton('{ArrowDown}')
@@ -1193,6 +1220,7 @@ describe('getToggleButtonProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(0),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 2)).toMatchSnapshot()
         })
 
         test('initialHighlightedIndex is ignored and defaultHighlightedIndex is chosen if enabled', async () => {
@@ -1216,11 +1244,14 @@ describe('getToggleButtonProps', () => {
 
         test('defaultHighlightedIndex is ignored if item is disabled', async () => {
           const defaultHighlightedIndex = 2
+          const isItemDisabled = jest
+            .fn()
+            .mockImplementation(
+              item => items.indexOf(item) === defaultHighlightedIndex,
+            )
           renderSelect({
             defaultHighlightedIndex,
-            isItemDisabled(item) {
-              return items.indexOf(item) === defaultHighlightedIndex
-            },
+            isItemDisabled,
           })
 
           await keyDownOnToggleButton('{ArrowDown}')
@@ -1229,6 +1260,7 @@ describe('getToggleButtonProps', () => {
             'aria-activedescendant',
             defaultIds.getItemId(0),
           )
+          expect(isItemDisabled.mock.calls.slice(0, 3)).toMatchSnapshot()
         })
 
         test('both defaultHighlightedIndex and initialHighlightedIndex are ignored if items are disabled', async () => {

--- a/src/hooks/useSelect/__tests__/props.test.js
+++ b/src/hooks/useSelect/__tests__/props.test.js
@@ -863,4 +863,46 @@ describe('props', () => {
       `downshift: A component has changed the controlled prop "highlightedIndex" to be uncontrolled. This prop should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled Downshift element for the lifetime of the component. More info: https://github.com/downshift-js/downshift#control-props`,
     )
   })
+
+  test('initialHighlightedIndex is ignored if item is disabled and menu is intially open', () => {
+    const initialHighlightedIndex = 2
+    const isItemDisabled = jest
+      .fn()
+      .mockImplementation(
+        item => items.indexOf(item) === initialHighlightedIndex,
+      )
+    renderSelect({
+      initialHighlightedIndex,
+      isItemDisabled,
+      initialIsOpen: true,
+    })
+
+    expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
+    expect(isItemDisabled).toHaveBeenNthCalledWith(
+      1,
+      items[initialHighlightedIndex],
+      initialHighlightedIndex,
+    )
+  })
+  
+  test('defaultHighlightedIndex is ignored if item is disabled and menu is intially open', () => {
+    const defaultHighlightedIndex = 2
+    const isItemDisabled = jest
+      .fn()
+      .mockImplementation(
+        item => items.indexOf(item) === defaultHighlightedIndex,
+      )
+    renderSelect({
+      defaultHighlightedIndex,
+      isItemDisabled,
+      initialIsOpen: true,
+    })
+
+    expect(getToggleButton()).toHaveAttribute('aria-activedescendant', '')
+    expect(isItemDisabled).toHaveBeenNthCalledWith(
+      1,
+      items[defaultHighlightedIndex],
+      defaultHighlightedIndex,
+    )
+  })
 })

--- a/src/hooks/useSelect/__tests__/returnProps.test.js
+++ b/src/hooks/useSelect/__tests__/returnProps.test.js
@@ -92,6 +92,19 @@ describe('returnProps', () => {
       expect(result.current.highlightedIndex).toBe(2)
     })
 
+    test('setHighlightedIndex does not set highlightedIndex if item is disabled', () => {
+      const highlightedIndex = 2
+      const {result} = renderUseSelect({initialIsOpen: true, isItemDisabled(_item, index) {
+        return index === highlightedIndex
+      }})
+
+      act(() => {
+        result.current.setHighlightedIndex(highlightedIndex)
+      })
+
+      expect(result.current.highlightedIndex).toBe(-1)
+    })
+
     test('selectItem sets selectedItem', () => {
       const {result} = renderUseSelect()
 
@@ -137,6 +150,29 @@ describe('returnProps', () => {
       expect(result.current.highlightedIndex).toBe(
         props.defaultHighlightedIndex,
       )
+      expect(result.current.isOpen).toBe(props.defaultIsOpen)
+    })
+
+    test('reset does not set the defaultHighlightedIndex if item is disabled', () => {
+      const props = {
+        defaultIsOpen: false,
+        defaultHighlightedIndex: 3,
+        defaultSelectedItem: items[2],
+        isItemDisabled(_item, index) {
+          return index === 3
+        },
+      }
+      const {result} = renderUseSelect(props)
+
+      act(() => {
+        result.current.openMenu()
+        result.current.selectItem(items[4])
+        result.current.setHighlightedIndex(1)
+        result.current.reset()
+      })
+
+      expect(result.current.selectedItem).toBe(props.defaultSelectedItem)
+      expect(result.current.highlightedIndex).toBe(-1)
       expect(result.current.isOpen).toBe(props.defaultIsOpen)
     })
   })

--- a/src/hooks/useSelect/reducer.js
+++ b/src/hooks/useSelect/reducer.js
@@ -3,6 +3,7 @@ import {
   getHighlightedIndexOnOpen,
   getDefaultValue,
   getChangesOnSelection,
+  getDefaultHighlightedIndex,
 } from '../utils'
 import commonReducer from '../reducer'
 import {getItemIndexByCharacterKey} from './utils'
@@ -17,7 +18,7 @@ export default function downshiftSelectReducer(state, action) {
     case stateChangeTypes.ItemClick:
       changes = {
         isOpen: getDefaultValue(props, 'isOpen'),
-        highlightedIndex: getDefaultValue(props, 'highlightedIndex'),
+        highlightedIndex: getDefaultHighlightedIndex(props),
         selectedItem: props.items[action.index],
       }
 

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -293,7 +293,7 @@ function getInitialValue(
 function getInitialState(props) {
   const selectedItem = getInitialValue(props, 'selectedItem')
   const isOpen = getInitialValue(props, 'isOpen')
-  const highlightedIndex = getInitialValue(props, 'highlightedIndex')
+  const highlightedIndex = getInitialHighlightedIndex(props)
   const inputValue = getInitialValue(props, 'inputValue')
 
   return {
@@ -327,14 +327,14 @@ function getHighlightedIndexOnOpen(props, state, offset) {
   if (
     initialHighlightedIndex !== undefined &&
     highlightedIndex === initialHighlightedIndex &&
-    !isItemDisabled(items[initialHighlightedIndex])
+    !isItemDisabled(items[initialHighlightedIndex], initialHighlightedIndex)
   ) {
     return initialHighlightedIndex
   }
 
   if (
     defaultHighlightedIndex !== undefined &&
-    !isItemDisabled(items[defaultHighlightedIndex])
+    !isItemDisabled(items[defaultHighlightedIndex], defaultHighlightedIndex)
   ) {
     return defaultHighlightedIndex
   }
@@ -343,14 +343,17 @@ function getHighlightedIndexOnOpen(props, state, offset) {
     return items.findIndex(item => itemToKey(selectedItem) === itemToKey(item))
   }
 
-  if (offset < 0 && !isItemDisabled(items[items.length - 1])) {
+  if (
+    offset < 0 &&
+    !isItemDisabled(items[items.length - 1], items.length - 1)
+  ) {
     return items.length - 1
   }
 
-  if (offset > 0 && !isItemDisabled(items[0])) {
+  if (offset > 0 && !isItemDisabled(items[0], 0)) {
     return 0
   }
-  
+
   return -1
 }
 /**
@@ -643,6 +646,43 @@ function useIsInitialMount() {
   return isInitialMountRef.current
 }
 
+/**
+ * Returns the new highlightedIndex based on the defaultHighlightedIndex prop, if it's not disabled.
+ *
+ * @param {Object} props Props from useCombobox or useSelect.
+ * @returns {number} The highlighted index.
+ */
+function getDefaultHighlightedIndex(props) {
+  const highlightedIndex = getDefaultValue(props, 'highlightedIndex')
+  if (
+    highlightedIndex > -1 &&
+    props.isItemDisabled(props.items[highlightedIndex], highlightedIndex)
+  ) {
+    return -1
+  }
+
+  return highlightedIndex
+}
+
+/**
+ * Returns the new highlightedIndex based on the initialHighlightedIndex prop, if not disabled.
+ *
+ * @param {Object} props Props from useCombobox or useSelect.
+ * @returns {number} The highlighted index.
+ */
+function getInitialHighlightedIndex(props) {
+  const highlightedIndex = getInitialValue(props, 'highlightedIndex')
+
+  if (
+    highlightedIndex > -1 &&
+    props.isItemDisabled(props.items[highlightedIndex], highlightedIndex)
+  ) {
+    return -1
+  }
+
+  return highlightedIndex
+}
+
 // Shared between all exports.
 const commonPropTypes = {
   environment: PropTypes.shape({
@@ -710,4 +750,5 @@ export {
   commonPropTypes,
   useIsInitialMount,
   useA11yMessageStatus,
+  getDefaultHighlightedIndex,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix all the scenarios when an item can be highlighted even if it's disabled.
<!-- Why are these changes necessary? -->

**Why**:
Fixes https://github.com/downshift-js/downshift/issues/1599.
<!-- How were these changes implemented? -->

**How**:
Check if item is disabled when setting the highlightedIndex via reset, imperative set, as well as user actions such as open on click / arrow down and up.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
