### PR TITLE
fix(useMouseAndTouchTrackers): dependency array

### DIFF
--- a/src/hooks/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/hooks/__tests__/__snapshots__/utils.test.js.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`utils useMouseAndTouchTracker adds and removes listeners to environment: element change rerender adding events 1`] = `
+[
+  [
+    mousedown,
+    [Function],
+  ],
+  [
+    mouseup,
+    [Function],
+  ],
+  [
+    touchstart,
+    [Function],
+  ],
+  [
+    touchmove,
+    [Function],
+  ],
+  [
+    touchend,
+    [Function],
+  ],
+]
+`;
+
+exports[`utils useMouseAndTouchTracker adds and removes listeners to environment: element change rerender remove events 1`] = `
+[
+  [
+    mousedown,
+    [Function],
+  ],
+  [
+    mouseup,
+    [Function],
+  ],
+  [
+    touchstart,
+    [Function],
+  ],
+  [
+    touchmove,
+    [Function],
+  ],
+  [
+    touchend,
+    [Function],
+  ],
+]
+`;
+
+exports[`utils useMouseAndTouchTracker adds and removes listeners to environment: initial adding events 1`] = `
+[
+  [
+    mousedown,
+    [Function],
+  ],
+  [
+    mouseup,
+    [Function],
+  ],
+  [
+    touchstart,
+    [Function],
+  ],
+  [
+    touchmove,
+    [Function],
+  ],
+  [
+    touchend,
+    [Function],
+  ],
+]
+`;
+
+exports[`utils useMouseAndTouchTracker adds and removes listeners to environment: unmount remove events 1`] = `
+[
+  [
+    mousedown,
+    [Function],
+  ],
+  [
+    mouseup,
+    [Function],
+  ],
+  [
+    touchstart,
+    [Function],
+  ],
+  [
+    touchmove,
+    [Function],
+  ],
+  [
+    touchend,
+    [Function],
+  ],
+]
+`;

--- a/src/hooks/__tests__/utils.test.js
+++ b/src/hooks/__tests__/utils.test.js
@@ -84,7 +84,7 @@ describe('utils', () => {
   describe('useMouseAndTouchTracker', () => {
     test('renders without error', () => {
       expect(() => {
-        renderHook(() => useMouseAndTouchTracker(undefined, [], jest.fn()))
+        renderHook(() => useMouseAndTouchTracker(undefined, jest.fn(), []))
       }).not.toThrowError()
     })
 
@@ -93,63 +93,53 @@ describe('utils', () => {
         addEventListener: jest.fn(),
         removeEventListener: jest.fn(),
       }
-      const refs = []
+      const elements = [{}, {}]
       const handleBlur = jest.fn()
+      const initialProps = {environment, handleBlur, elements}
 
-      const {unmount, rerender, result} = renderHook(() =>
-        useMouseAndTouchTracker(environment, refs, handleBlur),
+      const {unmount, rerender, result} = renderHook(
+        props =>
+          useMouseAndTouchTracker(
+            props.environment,
+            props.handleBlur,
+            props.elements,
+          ),
+        {initialProps},
       )
 
       expect(environment.addEventListener).toHaveBeenCalledTimes(5)
-      expect(environment.addEventListener).toHaveBeenCalledWith(
-        'mousedown',
-        expect.any(Function),
-      )
-      expect(environment.addEventListener).toHaveBeenCalledWith(
-        'mouseup',
-        expect.any(Function),
-      )
-      expect(environment.addEventListener).toHaveBeenCalledWith(
-        'touchstart',
-        expect.any(Function),
-      )
-      expect(environment.addEventListener).toHaveBeenCalledWith(
-        'touchmove',
-        expect.any(Function),
-      )
-      expect(environment.addEventListener).toHaveBeenCalledWith(
-        'touchend',
-        expect.any(Function),
-      )
       expect(environment.removeEventListener).not.toHaveBeenCalled()
+      expect(environment.addEventListener.mock.calls).toMatchSnapshot(
+        'initial adding events',
+      )
 
-      rerender()
+      environment.addEventListener.mockReset()
+      environment.removeEventListener.mockReset()
+      rerender(initialProps)
 
       expect(environment.removeEventListener).not.toHaveBeenCalled()
+      expect(environment.addEventListener).not.toHaveBeenCalled()
 
-      unmount()
+      rerender({...initialProps, elements: [...elements]})
 
       expect(environment.addEventListener).toHaveBeenCalledTimes(5)
       expect(environment.removeEventListener).toHaveBeenCalledTimes(5)
-      expect(environment.removeEventListener).toHaveBeenCalledWith(
-        'mousedown',
-        expect.any(Function),
+      expect(environment.addEventListener.mock.calls).toMatchSnapshot(
+        'element change rerender adding events',
       )
-      expect(environment.removeEventListener).toHaveBeenCalledWith(
-        'mouseup',
-        expect.any(Function),
+      expect(environment.removeEventListener.mock.calls).toMatchSnapshot(
+        'element change rerender remove events',
       )
-      expect(environment.removeEventListener).toHaveBeenCalledWith(
-        'touchstart',
-        expect.any(Function),
-      )
-      expect(environment.removeEventListener).toHaveBeenCalledWith(
-        'touchmove',
-        expect.any(Function),
-      )
-      expect(environment.removeEventListener).toHaveBeenCalledWith(
-        'touchend',
-        expect.any(Function),
+
+      environment.addEventListener.mockReset()
+      environment.removeEventListener.mockReset()
+
+      unmount()
+
+      expect(environment.addEventListener).not.toHaveBeenCalled()
+      expect(environment.removeEventListener).toHaveBeenCalledTimes(5)
+      expect(environment.removeEventListener.mock.calls).toMatchSnapshot(
+        'unmount remove events',
       )
 
       expect(result.current).toEqual({

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -109,7 +109,7 @@ function useCombobox(userProps = {}) {
       },
       [dispatch, latest],
     ),
-    useMemo(() => [toggleButtonRef, menuRef, inputRef], []),
+    useMemo(() => [menuRef, toggleButtonRef, inputRef], []),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(
     'getInputProps',

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -98,7 +98,6 @@ function useCombobox(userProps = {}) {
   })
   const mouseAndTouchTrackers = useMouseAndTouchTracker(
     environment,
-    [toggleButtonRef, menuRef, inputRef],
     useCallback(
       function handleBlur() {
         if (latest.current.state.isOpen) {
@@ -110,6 +109,7 @@ function useCombobox(userProps = {}) {
       },
       [dispatch, latest],
     ),
+    useMemo(() => [toggleButtonRef, menuRef, inputRef], []),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(
     'getInputProps',

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -109,7 +109,10 @@ function useCombobox(userProps = {}) {
       },
       [dispatch, latest],
     ),
-    useMemo(() => [menuRef, toggleButtonRef, inputRef], []),
+    useMemo(
+      () => [menuRef, toggleButtonRef, inputRef],
+      [menuRef.current, toggleButtonRef.current, inputRef.current],
+    ),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(
     'getInputProps',

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -131,7 +131,10 @@ function useSelect(userProps = {}) {
       },
       [dispatch, latest],
     ),
-    useMemo(() => [menuRef, toggleButtonRef], []),
+    useMemo(
+      () => [menuRef, toggleButtonRef],
+      [menuRef.current, toggleButtonRef.current],
+    ),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(
     'getMenuProps',

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -47,6 +47,7 @@ function useSelect(userProps = {}) {
   const toggleButtonRef = useRef(null)
   const menuRef = useRef(null)
   const itemRefs = useRef({})
+
   // used to keep the inputValue clearTimeout object between renders.
   const clearTimeoutRef = useRef(null)
   // prevent id re-generation between renders.
@@ -130,7 +131,7 @@ function useSelect(userProps = {}) {
       },
       [dispatch, latest],
     ),
-    useMemo(() => [toggleButtonRef, menuRef], []),
+    useMemo(() => [menuRef, toggleButtonRef], []),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(
     'getMenuProps',

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -120,7 +120,6 @@ function useSelect(userProps = {}) {
 
   const mouseAndTouchTrackers = useMouseAndTouchTracker(
     environment,
-    [toggleButtonRef, menuRef],
     useCallback(
       function handleBlur() {
         if (latest.current.state.isOpen) {
@@ -131,6 +130,7 @@ function useSelect(userProps = {}) {
       },
       [dispatch, latest],
     ),
+    useMemo(() => [toggleButtonRef, menuRef], []),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(
     'getMenuProps',

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -361,13 +361,13 @@ function getHighlightedIndexOnOpen(props, state, offset) {
  *
  * @param {Window} environment The environment to add the event listeners to, for instance window.
  * @param {() => void} handleBlur The function that is called if mouseDown or touchEnd occured outside the downshiftElements.
- * @param {Array<{current: HTMLElement}>} downshiftElementRefs The refs for the element that should not trigger a blur action from mouseDown or touchEnd.
+ * @param {Array<{current: HTMLElement}>} downshiftElementsRefs The refs for the elements that should not trigger a blur action from mouseDown or touchEnd.
  * @returns {{isMouseDown: boolean, isTouchMove: boolean, isTouchEnd: boolean}} The mouse and touch events information, if any of are happening.
  */
 function useMouseAndTouchTracker(
   environment,
   handleBlur,
-  downshiftElementRefs,
+  downshiftElementsRefs,
 ) {
   const mouseAndTouchTrackersRef = useRef({
     isMouseDown: false,
@@ -380,7 +380,7 @@ function useMouseAndTouchTracker(
       return noop
     }
 
-    const downshiftElements = downshiftElementRefs.map(ref => ref.current)
+    const downshiftElements = downshiftElementsRefs.map(ref => ref.current)
 
     function onMouseDown() {
       mouseAndTouchTrackersRef.current.isTouchEnd = false // reset this one.
@@ -431,7 +431,7 @@ function useMouseAndTouchTracker(
       environment.removeEventListener('touchmove', onTouchMove)
       environment.removeEventListener('touchend', onTouchEnd)
     }
-  }, [environment, handleBlur, downshiftElementRefs])
+  }, [downshiftElementsRefs, environment, handleBlur])
 
   return mouseAndTouchTrackersRef.current
 }

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -359,15 +359,15 @@ function getHighlightedIndexOnOpen(props, state, offset) {
 /**
  * Tracks mouse and touch events, such as mouseDown, touchMove and touchEnd.
  *
- * @param {Object} environment The environment to add the event listeners to, for instance window.
- * @param {Array<HTMLElement>} downshiftElementRefs The refs for the element that should not trigger a blur action from mouseDown or touchEnd.
- * @param {Function} handleBlur The function that is called if mouseDown or touchEnd occured outside the downshiftElements.
- * @returns {Object} The mouse and touch events information, if any of are happening.
+ * @param {Window} environment The environment to add the event listeners to, for instance window.
+ * @param {() => void} handleBlur The function that is called if mouseDown or touchEnd occured outside the downshiftElements.
+ * @param {Array<{current: HTMLElement}>} downshiftElementRefs The refs for the element that should not trigger a blur action from mouseDown or touchEnd.
+ * @returns {{isMouseDown: boolean, isTouchMove: boolean, isTouchEnd: boolean}} The mouse and touch events information, if any of are happening.
  */
 function useMouseAndTouchTracker(
   environment,
-  downshiftElementRefs,
   handleBlur,
+  downshiftElementRefs,
 ) {
   const mouseAndTouchTrackersRef = useRef({
     isMouseDown: false,
@@ -423,6 +423,7 @@ function useMouseAndTouchTracker(
     environment.addEventListener('touchstart', onTouchStart)
     environment.addEventListener('touchmove', onTouchMove)
     environment.addEventListener('touchend', onTouchEnd)
+    console.log('adds events', downshiftElementRefs)
 
     return function cleanup() {
       environment.removeEventListener('mousedown', onMouseDown)
@@ -430,9 +431,9 @@ function useMouseAndTouchTracker(
       environment.removeEventListener('touchstart', onTouchStart)
       environment.removeEventListener('touchmove', onTouchMove)
       environment.removeEventListener('touchend', onTouchEnd)
+      console.log('cleans up events', downshiftElementRefs)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs don't change
-  }, [environment, handleBlur])
+  }, [environment, handleBlur, downshiftElementRefs])
 
   return mouseAndTouchTrackersRef.current
 }

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -423,7 +423,6 @@ function useMouseAndTouchTracker(
     environment.addEventListener('touchstart', onTouchStart)
     environment.addEventListener('touchmove', onTouchMove)
     environment.addEventListener('touchend', onTouchEnd)
-    console.log('adds events', downshiftElementRefs)
 
     return function cleanup() {
       environment.removeEventListener('mousedown', onMouseDown)
@@ -431,7 +430,6 @@ function useMouseAndTouchTracker(
       environment.removeEventListener('touchstart', onTouchStart)
       environment.removeEventListener('touchmove', onTouchMove)
       environment.removeEventListener('touchend', onTouchEnd)
-      console.log('cleans up events', downshiftElementRefs)
     }
   }, [environment, handleBlur, downshiftElementRefs])
 


### PR DESCRIPTION
Alternative for https://github.com/downshift-js/downshift/pull/1609. It should avoid adding and removing event listeners on each render, while fixing the initial issue.

Closes https://github.com/downshift-js/downshift/issues/1600.