### PR TITLE
aria-activedescendant: undefined instead of ''

### DIFF
--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -91,21 +91,21 @@ describe('getInputProps', () => {
       const {result} = renderUseCombobox({highlightedIndex: 2})
       const inputProps = result.current.getInputProps()
 
-      expect(inputProps['aria-activedescendant']).toBe('')
+      expect(inputProps['aria-activedescendant']).toBe(undefined)
     })
 
     test('do not assign aria-activedescendant if no item is highlighted', () => {
       const {result} = renderUseCombobox()
       const inputProps = result.current.getInputProps()
 
-      expect(inputProps['aria-activedescendant']).toBe('')
+      expect(inputProps['aria-activedescendant']).toBe(undefined)
     })
 
     test('do not assign aria-activedescendant if no item is highlighted and menu is open', () => {
       const {result} = renderUseCombobox({isOpen: true})
       const inputProps = result.current.getInputProps()
 
-      expect(inputProps['aria-activedescendant']).toBe('')
+      expect(inputProps['aria-activedescendant']).toBe(undefined)
     })
 
     test('assign default value to aria-labelledby', () => {
@@ -451,7 +451,7 @@ describe('getInputProps', () => {
 
         await changeInputValue('california')
 
-        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+        expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
       })
 
       test('should reset to defaultHighlightedIndex', async () => {
@@ -492,7 +492,7 @@ describe('getInputProps', () => {
         await keyDownOnInput('{ArrowDown}')
         await changeInputValue('a')
 
-        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+        expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
       })
     })
 
@@ -513,7 +513,7 @@ describe('getInputProps', () => {
 
           await keyDownOnInput('{ArrowUp}')
 
-          expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+          expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
           expect(getItems()).toHaveLength(0)
         })
 
@@ -525,7 +525,7 @@ describe('getInputProps', () => {
 
           await keyDownOnInput('{ArrowUp}')
 
-          expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+          expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
           expect(getItems()).toHaveLength(0)
         })
 
@@ -771,7 +771,7 @@ describe('getInputProps', () => {
 
           expect(input).toHaveValue(initialSelectedItem)
           expect(getItems()).toHaveLength(0)
-          expect(input).toHaveAttribute('aria-activedescendant', '')
+          expect(input).toHaveAttribute('aria-activedescendant', undefined)
         })
 
         test('with Alt closes the menu without resetting to user defaults if lhe list is empty', async () => {
@@ -789,7 +789,7 @@ describe('getInputProps', () => {
 
           expect(input).toHaveValue(initialSelectedItem)
           expect(getItems()).toHaveLength(0)
-          expect(input).toHaveAttribute('aria-activedescendant', '')
+          expect(input).toHaveAttribute('aria-activedescendant', undefined)
         })
 
         test('will continue from 0 to last item', async () => {
@@ -840,7 +840,7 @@ describe('getInputProps', () => {
 
           await keyDownOnInput('{ArrowDown}')
 
-          expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+          expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
           expect(getItems()).toHaveLength(0)
         })
 
@@ -852,7 +852,7 @@ describe('getInputProps', () => {
 
           await keyDownOnInput('{ArrowDown}')
 
-          expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+          expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
           expect(getItems()).toHaveLength(0)
         })
 
@@ -1046,7 +1046,7 @@ describe('getInputProps', () => {
 
           await keyDownOnInput('{Alt>}{ArrowDown}{/Alt}')
 
-          expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+          expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
         })
 
         test('with Alt it opens the menu and highlights with selected item highlighted', async () => {
@@ -1334,7 +1334,7 @@ describe('getInputProps', () => {
 
           expect(input).toHaveValue(initialSelectedItem)
           expect(getItems()).toHaveLength(0)
-          expect(input).toHaveAttribute('aria-activedescendant', '')
+          expect(input).toHaveAttribute('aria-activedescendant', undefined)
         })
 
         test('closes the menu without resetting to user defaults if the list is empty', async () => {
@@ -1352,7 +1352,7 @@ describe('getInputProps', () => {
 
           expect(input).toHaveValue(initialSelectedItem)
           expect(getItems()).toHaveLength(0)
-          expect(input).toHaveAttribute('aria-activedescendant', '')
+          expect(input).toHaveAttribute('aria-activedescendant', undefined)
         })
 
         test('while IME composing will not select highlighted item', async () => {
@@ -1376,7 +1376,7 @@ describe('getInputProps', () => {
 
           expect(input).toHaveValue(items[2])
           expect(getItems()).toHaveLength(0)
-          expect(input).toHaveAttribute('aria-activedescendant', '')
+          expect(input).toHaveAttribute('aria-activedescendant', undefined)
         })
 
         test('with a closed menu does nothing', async () => {
@@ -1974,7 +1974,7 @@ describe('getInputProps', () => {
         await clickOnInput()
         await clickOnInput()
 
-        expect(input).toHaveAttribute('aria-activedescendant', '')
+        expect(input).toHaveAttribute('aria-activedescendant', undefined)
       })
 
       test('it opens the closed menu at defaultHighlightedIndex, on every click', async () => {
@@ -2014,7 +2014,7 @@ describe('getInputProps', () => {
 
         await clickOnInput()
 
-        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+        expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
         expect(isItemDisabled).toHaveBeenNthCalledWith(
           1,
           items[initialHighlightedIndex],
@@ -2055,7 +2055,7 @@ describe('getInputProps', () => {
 
         await clickOnInput()
 
-        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+        expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
         expect(isItemDisabled).toHaveBeenNthCalledWith(
           1,
           items[defaultHighlightedIndex],
@@ -2078,7 +2078,7 @@ describe('getInputProps', () => {
 
         await clickOnInput()
 
-        expect(getInput()).toHaveAttribute('aria-activedescendant', '')
+        expect(getInput()).toHaveAttribute('aria-activedescendant', undefined)
       })
     })
   })

--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -470,7 +470,7 @@ function useCombobox(userProps = {}) {
         'aria-activedescendant':
           latestState.isOpen && latestState.highlightedIndex > -1
             ? elementIds.getItemId(latestState.highlightedIndex)
-            : '',
+            : undefined,
         'aria-autocomplete': 'list',
         'aria-controls': elementIds.menuId,
         'aria-expanded': latestState.isOpen,

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -364,7 +364,7 @@ function useSelect(userProps = {}) {
         'aria-activedescendant':
           latestState.isOpen && latestState.highlightedIndex > -1
             ? elementIds.getItemId(latestState.highlightedIndex)
-            : '',
+            : undefined,
         'aria-controls': elementIds.menuId,
         'aria-expanded': latest.current.state.isOpen,
         'aria-haspopup': 'listbox',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
An empty string aria-activedescendant may be considered a faulty value. 

**Why**:

<!-- How were these changes implemented? -->

Possibly Fixes #1626. I need to doublecheck when I am able to run these changes against our a11y testing suite.

ARIA attribute has invalid value.

**How**:

<!-- Have you done all of these things?  -->
Switched from '' to undefined when aria-activedescendant isn't set.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
