### PR TITLE
fix(type): item in isItemDisabled may be undefined

### DIFF
--- a/src/hooks/useSelect/types.ts
+++ b/src/hooks/useSelect/types.ts
@@ -5,5 +5,5 @@ export interface GetItemIndexByCharacterKeyOptions<Item> {
   highlightedIndex: number
   items: Item[]
   itemToString(item: Item | null): string
-  isItemDisabled(item: Item, index: number): boolean
+  isItemDisabled(item: Item | undefined, index: number): boolean
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -339,7 +339,7 @@ export enum UseSelectStateChangeTypes {
 
 export interface UseSelectProps<Item> {
   items: Item[]
-  isItemDisabled?(item: Item, index: number): boolean
+  isItemDisabled?(item: Item | undefined, index: number): boolean
   itemToString?: (item: Item | null) => string
   itemToKey?: (item: Item | null) => any
   getA11yStatusMessage?: (options: UseSelectState<Item>) => string
@@ -552,7 +552,7 @@ export enum UseComboboxStateChangeTypes {
 
 export interface UseComboboxProps<Item> {
   items: Item[]
-  isItemDisabled?(item: Item, index: number): boolean
+  isItemDisabled?(item: Item | undefined, index: number): boolean
   itemToString?: (item: Item | null) => string
   itemToKey?: (item: Item | null) => any
   getA11yStatusMessage?: (options: UseComboboxState<Item>) => string


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Typings changed. Item in `isItemDisabled` may be undefined, e. g.
https://github.com/downshift-js/downshift/blob/59d3498faafd3c3b4832a20dab7485502ce67284/src/hooks/utils.js#L659-L659


<!-- Why are these changes necessary? -->

**Why**:

Developers should handle this case to avoid runtime errors.

<!-- How were these changes implemented? -->

**How**:

Only typings changed.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

**Offtopic**
Probably types of others methods should be check and fixed
e.g.
```diff
-itemToString?: (item: Item | null) => string
+itemToString?: (item: Item | undefined) => string
```
because https://github.com/downshift-js/downshift/blob/59d3498faafd3c3b4832a20dab7485502ce67284/src/hooks/utils.js#L609-L609