### PR TITLE
Escape React.useId to avoid jsdom SyntaxError

### DIFF
--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -92,7 +92,7 @@ const useElementIds =
         inputId,
       }) {
         // Avoid conditional useId call
-        const reactId = `downshift-${React.useId()}`
+        const reactId = `downshift-${CSS.escape(React.useId())}`
         if (!id) {
           id = reactId
         }


### PR DESCRIPTION
Per https://stackoverflow.com/questions/73894096/react-useid-creates-invalid-selector the `:` can cause `SyntaxError` due to React returning `:` charachter. This escape fixes that. Without this I am getting the following crash from nwsapi via jsdom.

```
SyntaxError: unknown pseudo-class selector ':r0:-menu.Menustyles__MenuPopper-sc-19x7i94-1 *'
    at emit (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:651:17)
    at compileSelector (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:1418:17)
    at compile (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:838:16)
    at collect (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:1693:22)
    at _querySelectorAll (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:1651:36)
    at Object._querySelector [as first] (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:1555:14)
    at HTMLUListElementImpl.querySelector (/frontend/node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:69:44)
    at HTMLUListElement.querySelector (/frontend/node_modules/jsdom/lib/jsdom/living/generated/Element.js:1094:58)
    at Array.Resolver (eval at compile (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:853:17), <anonymous>:3:98)
    at match_assert (/frontend/node_modules/jsdom/node_modules/nwsapi/src/nwsapi.js:1482:13)
```