### PR TITLE
fix(types): add null to selectedItem type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -393,7 +393,7 @@ export interface UseSelectStateChange<Item>
 
 export interface UseSelectSelectedItemChange<Item>
   extends UseSelectStateChange<Item> {
-  selectedItem: Item
+  selectedItem: Item | null
 }
 
 export interface UseSelectHighlightedIndexChange<Item>
@@ -611,7 +611,7 @@ export interface UseComboboxStateChange<Item>
 
 export interface UseComboboxSelectedItemChange<Item>
   extends UseComboboxStateChange<Item> {
-  selectedItem: Item
+  selectedItem: Item | null
 }
 export interface UseComboboxHighlightedIndexChange<Item>
   extends UseComboboxStateChange<Item> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add `null` to the `selectedItem` type in `onSelectedItemChange` for both combobox and select.
<!-- Why are these changes necessary? -->

**Why**:

Closes https://github.com/downshift-js/downshift/issues/1639.
<!-- How were these changes implemented? -->

**How**:
Add type.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
