### PR TITLE
Ignore blur event inside the open menu

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -883,7 +883,13 @@ class Downshift extends Component {
         this._rootNode &&
         this._rootNode.contains(activeElement)
 
-      if (!downshiftButtonIsActive) {
+      // We check for the containment of the newly activeElement in the _menuNode here due to iOS emitting a blur event right away when the menu is opened (maybe due to not showing the keyboard?)
+      const activeElementWithinMenu =
+        this._menuNode &&
+        activeElement &&
+        this._menuNode.contains(activeElement)
+
+      if (!downshiftButtonIsActive && !activeElementWithinMenu) {
         this.reset({type: stateChangeTypes.blurInput})
       }
     })


### PR DESCRIPTION
This can happen on iOS. If the select is opened a blur event is fired immediately.


**What**:
This patch fixes a bug where the select would immediately close again on iOS Safari.

Possible fix for #443.


**Why**:

Safari on iOS could trigger a blur event immediately after the dropdown was opened.

**How**:

There is now a check that verifies that when an input blur event is received, the active element is not inside the menu since this would close the menu. 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] TypeScript Types N/A
- [ ] Flow Types N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

We originally patched this locally in version 6 and this has been in production for years together with the changes for https://github.com/downshift-js/downshift/pull/1647.
