### PR TITLE
fix: Use passive event listeners

### DIFF
--- a/src/downshift.js
+++ b/src/downshift.js
@@ -1133,21 +1133,23 @@ class Downshift extends Component {
       }
       const {environment} = this.props
 
-      environment.addEventListener('mousedown', onMouseDown)
-      environment.addEventListener('mouseup', onMouseUp)
-      environment.addEventListener('touchstart', onTouchStart)
-      environment.addEventListener('touchmove', onTouchMove)
-      environment.addEventListener('touchend', onTouchEnd)
+      const options = {passive: true}
+
+      environment.addEventListener('mousedown', onMouseDown, options)
+      environment.addEventListener('mouseup', onMouseUp, options)
+      environment.addEventListener('touchstart', onTouchStart, options)
+      environment.addEventListener('touchmove', onTouchMove, options)
+      environment.addEventListener('touchend', onTouchEnd, options)
 
       this.cleanup = () => {
         this.internalClearTimeouts()
         this.updateStatus.cancel()
 
-        environment.removeEventListener('mousedown', onMouseDown)
-        environment.removeEventListener('mouseup', onMouseUp)
-        environment.removeEventListener('touchstart', onTouchStart)
-        environment.removeEventListener('touchmove', onTouchMove)
-        environment.removeEventListener('touchend', onTouchEnd)
+        environment.removeEventListener('mousedown', onMouseDown, options)
+        environment.removeEventListener('mouseup', onMouseUp, options)
+        environment.removeEventListener('touchstart', onTouchStart, options)
+        environment.removeEventListener('touchmove', onTouchMove, options)
+        environment.removeEventListener('touchend', onTouchEnd, options)
       }
     }
   }

--- a/src/hooks/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/hooks/__tests__/__snapshots__/utils.test.js.snap
@@ -5,22 +5,37 @@ exports[`utils useMouseAndTouchTracker adds and removes listeners to environment
   [
     mousedown,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     mouseup,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchstart,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchmove,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchend,
     [Function],
+    {
+      passive: true,
+    },
   ],
 ]
 `;
@@ -30,22 +45,37 @@ exports[`utils useMouseAndTouchTracker adds and removes listeners to environment
   [
     mousedown,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     mouseup,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchstart,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchmove,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchend,
     [Function],
+    {
+      passive: true,
+    },
   ],
 ]
 `;
@@ -55,22 +85,37 @@ exports[`utils useMouseAndTouchTracker adds and removes listeners to environment
   [
     mousedown,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     mouseup,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchstart,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchmove,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchend,
     [Function],
+    {
+      passive: true,
+    },
   ],
 ]
 `;
@@ -80,22 +125,37 @@ exports[`utils useMouseAndTouchTracker adds and removes listeners to environment
   [
     mousedown,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     mouseup,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchstart,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchmove,
     [Function],
+    {
+      passive: true,
+    },
   ],
   [
     touchend,
     [Function],
+    {
+      passive: true,
+    },
   ],
 ]
 `;

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -418,18 +418,20 @@ function useMouseAndTouchTracker(
       }
     }
 
-    environment.addEventListener('mousedown', onMouseDown)
-    environment.addEventListener('mouseup', onMouseUp)
-    environment.addEventListener('touchstart', onTouchStart)
-    environment.addEventListener('touchmove', onTouchMove)
-    environment.addEventListener('touchend', onTouchEnd)
+    const options = {passive: true}
+
+    environment.addEventListener('mousedown', onMouseDown, options)
+    environment.addEventListener('mouseup', onMouseUp, options)
+    environment.addEventListener('touchstart', onTouchStart, options)
+    environment.addEventListener('touchmove', onTouchMove, options)
+    environment.addEventListener('touchend', onTouchEnd, options)
 
     return function cleanup() {
-      environment.removeEventListener('mousedown', onMouseDown)
-      environment.removeEventListener('mouseup', onMouseUp)
-      environment.removeEventListener('touchstart', onTouchStart)
-      environment.removeEventListener('touchmove', onTouchMove)
-      environment.removeEventListener('touchend', onTouchEnd)
+      environment.removeEventListener('mousedown', onMouseDown, options)
+      environment.removeEventListener('mouseup', onMouseUp, options)
+      environment.removeEventListener('touchstart', onTouchStart, options)
+      environment.removeEventListener('touchmove', onTouchMove, options)
+      environment.removeEventListener('touchend', onTouchEnd, options)
     }
   }, [downshiftElementsRefs, environment, handleBlur])
 


### PR DESCRIPTION
**What**:

Closes https://github.com/downshift-js/downshift/issues/1650

**Why**:

Resolve console warnings in Chrome and potentially improve performance.

**How**:

Add `{ passive: true }` to `addEventListenter` and `removeEventListener` calls.

**Checklist**:

- [ ] Documentation
- [X] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [X] Ready to be merged

These changes assume that existing tests will cover any possible regression. The behavior is not expected to change.