### PR TITLE
fix: read elements from refs directly instead of keeping stale values in closure

### DIFF
--- a/src/hooks/useCombobox/index.js
+++ b/src/hooks/useCombobox/index.js
@@ -111,7 +111,8 @@ function useCombobox(userProps = {}) {
     ),
     useMemo(
       () => [menuRef, toggleButtonRef, inputRef],
-      [menuRef.current, toggleButtonRef.current, inputRef.current],
+      // dependencies can be left empty because refs are getting mutated
+      [],
     ),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(

--- a/src/hooks/useSelect/index.js
+++ b/src/hooks/useSelect/index.js
@@ -133,7 +133,8 @@ function useSelect(userProps = {}) {
     ),
     useMemo(
       () => [menuRef, toggleButtonRef],
-      [menuRef.current, toggleButtonRef.current],
+      // dependencies can be left empty because refs are getting mutated
+      [],
     ),
   )
   const setGetterPropCallInfo = useGetterPropsCalledChecker(

--- a/src/hooks/utils.js
+++ b/src/hooks/utils.js
@@ -375,12 +375,15 @@ function useMouseAndTouchTracker(
     isTouchEnd: false,
   })
 
+  // the elements should be retrieved the moment they are required because these are refs - they can be mutated
+  function getDownshiftElements() {
+    return downshiftElementsRefs.map(ref => ref.current)
+  }
+
   useEffect(() => {
     if (isReactNative || !environment) {
       return noop
     }
-
-    const downshiftElements = downshiftElementsRefs.map(ref => ref.current)
 
     function onMouseDown() {
       mouseAndTouchTrackersRef.current.isTouchEnd = false // reset this one.
@@ -390,7 +393,7 @@ function useMouseAndTouchTracker(
       mouseAndTouchTrackersRef.current.isMouseDown = false
 
       if (
-        !targetWithinDownshift(event.target, downshiftElements, environment)
+        !targetWithinDownshift(event.target, getDownshiftElements(), environment)
       ) {
         handleBlur()
       }
@@ -409,7 +412,7 @@ function useMouseAndTouchTracker(
         !mouseAndTouchTrackersRef.current.isTouchMove &&
         !targetWithinDownshift(
           event.target,
-          downshiftElements,
+          getDownshiftElements(),
           environment,
           false,
         )


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This is a fix which I discovered while upgrading to React v19, but it's for sure applicable to any version of React. 

**Why**:

The issue is: the downshift elements from refs were accessed in the main scope of the effect callback inside `useMouseAndTouchTracker`, which saves the version of the elements at the moment of the initialization of that effect. Since those are the refs, they can be updated at any point without causing re-rendering which leads to incorrect values being used in the event handlers (mouse up etc.).

**How**:

The fix is quite simple - read the elements from refs at the moment of the event to make sure we always get the actual values.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [ ] Flow Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
