### PR TITLE
fix(disabled): remove disabled from spread regression

### DIFF
--- a/src/hooks/useCombobox/__tests__/getInputProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getInputProps.test.js
@@ -52,6 +52,29 @@ afterAll(jest.restoreAllMocks)
 
 describe('getInputProps', () => {
   describe('hook props', () => {
+    test('returns an object with some default props', () => {
+      const {result} = renderUseCombobox()
+      const inputProps = result.current.getInputProps()
+
+      expect(Object.keys(inputProps)).toEqual([
+        'ref',
+        'aria-activedescendant',
+        'aria-autocomplete',
+        'aria-controls',
+        'aria-expanded',
+        'aria-labelledby',
+        'aria-label',
+        'autoComplete',
+        'id',
+        'role',
+        'value',
+        'onChange',
+        'onKeyDown',
+        'onBlur',
+        'onClick',
+      ])
+    })
+
     test("assign 'combobox' to role", () => {
       const {result} = renderUseCombobox()
       const inputProps = result.current.getInputProps()

--- a/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useCombobox/__tests__/getToggleButtonProps.test.js
@@ -37,6 +37,20 @@ afterAll(jest.restoreAllMocks)
 
 describe('getToggleButtonProps', () => {
   describe('hook props', () => {
+    test('returns an object with some default props', () => {
+      const {result} = renderUseCombobox()
+      const toggleButtonProps = result.current.getToggleButtonProps()
+
+      expect(Object.keys(toggleButtonProps)).toEqual([
+        'ref',
+        'aria-controls',
+        'aria-expanded',
+        'id',
+        'tabIndex',
+        'onClick',
+      ])
+    })
+
     test('assign default value to id', () => {
       const {result} = renderUseCombobox()
       const toggleButtonProps = result.current.getToggleButtonProps()

--- a/src/hooks/useCombobox/index.ts
+++ b/src/hooks/useCombobox/index.ts
@@ -21,16 +21,19 @@ import {
   dropdownDefaultProps,
   useScrollIntoView,
 } from '../utils'
+import {type GetPropsCommonOptions} from '../../downshift.types'
 import {getInitialState, useControlledReducer, propTypes} from './utils'
 import downshiftUseComboboxReducer from './reducer'
 import * as stateChangeTypes from './stateChangeTypes'
 import {
   UseComboboxGetInputProps,
+  UseComboboxGetInputPropsOptions,
   UseComboboxGetInputPropsReturnValue,
   UseComboboxGetItemProps,
   UseComboboxGetLabelProps,
   UseComboboxGetMenuProps,
   UseComboboxGetToggleButtonProps,
+  UseComboboxGetToggleButtonPropsOptions,
   UseComboboxMergedProps,
   UseComboboxProps,
   UseComboboxReturnValue,
@@ -366,13 +369,12 @@ function useCombobox<Item>(
   ) as UseComboboxGetItemProps<Item>
 
   const getToggleButtonProps = useCallback(
-    toggleButtonProps => {
+    (toggleButtonProps?: UseComboboxGetToggleButtonPropsOptions) => {
       const {
         onClick,
         onPress,
         refKey = 'ref',
         ref,
-        disabled,
         ...rest
       } = toggleButtonProps ?? {}
       const latestState = latest.current.state
@@ -390,7 +392,7 @@ function useCombobox<Item>(
         'aria-expanded': latestState.isOpen,
         id: elementIds.toggleButtonId,
         tabIndex: -1,
-        ...(!disabled && {
+        ...(!rest.disabled && {
           ...(isReactNative || isReactNativeWeb
             ? /* istanbul ignore next (react-native) */ {
                 onPress: callAllEventHandlers(onPress, toggleButtonHandleClick),
@@ -399,7 +401,6 @@ function useCombobox<Item>(
                 onClick: callAllEventHandlers(onClick, toggleButtonHandleClick),
               }),
         }),
-        disabled,
         ...rest,
       }
     },
@@ -407,10 +408,12 @@ function useCombobox<Item>(
   ) as UseComboboxGetToggleButtonProps
 
   const getInputProps = useCallback(
-    (inputProps, otherProps) => {
+    (
+      inputProps?: UseComboboxGetInputPropsOptions,
+      otherProps?: GetPropsCommonOptions,
+    ) => {
       const {
         'aria-label': ariaLabel,
-        disabled,
         onKeyDown,
         onChange,
         onInput,
@@ -484,7 +487,7 @@ function useCombobox<Item>(
         | 'onChangeText'
       >
 
-      if (!disabled) {
+      if (!rest.disabled) {
         eventHandlers = {
           [onChangeKey]: callAllEventHandlers(
             onChange,
@@ -531,7 +534,6 @@ function useCombobox<Item>(
         // https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
         // revert back since autocomplete="nope" is ignored on latest Chrome and Opera
         autoComplete: 'off',
-        disabled,
         id: elementIds.inputId,
         role: 'combobox',
         value: latestState.inputValue,

--- a/src/hooks/useCombobox/index.types.ts
+++ b/src/hooks/useCombobox/index.types.ts
@@ -346,7 +346,6 @@ export interface UseComboboxGetInputPropsReturnValue {
   'aria-labelledby': string | undefined
   'aria-label': string | undefined
   autoComplete: 'off'
-  disabled: boolean | undefined
   id: string
   role: 'combobox'
   value: string

--- a/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
+++ b/src/hooks/useSelect/__tests__/getToggleButtonProps.test.js
@@ -53,6 +53,26 @@ afterAll(jest.restoreAllMocks)
 
 describe('getToggleButtonProps', () => {
   describe('hook props', () => {
+    test('returns an object with some default props', () => {
+      const {result} = renderUseSelect()
+      const toggleButtonProps = result.current.getToggleButtonProps()
+
+      expect(Object.keys(toggleButtonProps)).toEqual([
+        'ref',
+        'aria-activedescendant',
+        'aria-controls',
+        'aria-expanded',
+        'aria-haspopup',
+        'aria-labelledby',
+        'id',
+        'role',
+        'tabIndex',
+        'onBlur',
+        'onClick',
+        'onKeyDown',
+      ])
+    })
+
     test('assign default value to aria-labelledby', () => {
       const {result} = renderUseSelect()
       const toggleButtonProps = result.current.getToggleButtonProps()

--- a/src/hooks/useSelect/index.ts
+++ b/src/hooks/useSelect/index.ts
@@ -22,6 +22,7 @@ import {
   dropdownDefaultProps,
   useScrollIntoView,
 } from '../utils'
+import {GetPropsCommonOptions} from '../../downshift.types'
 import {isReactNative, isReactNativeWeb} from '../../is.macro'
 import downshiftSelectReducer from './reducer'
 import {propTypes} from './utils'
@@ -31,6 +32,7 @@ import {
   UseSelectGetLabelProps,
   UseSelectGetMenuProps,
   UseSelectGetToggleButtonProps,
+  UseSelectGetToggleButtonPropsOptions,
   UseSelectMergedProps,
   UseSelectProps,
   UseSelectReducerAction,
@@ -301,8 +303,8 @@ function useSelect<Item>(
 
   const getToggleButtonProps = useCallback(
     (
-      toggleButtonProps?: Parameters<UseSelectGetToggleButtonProps>[0],
-      otherProps?: Parameters<UseSelectGetToggleButtonProps>[1],
+      toggleButtonProps?: UseSelectGetToggleButtonPropsOptions,
+      otherProps?: GetPropsCommonOptions,
     ) => {
       const {
         onBlur,
@@ -311,7 +313,6 @@ function useSelect<Item>(
         onKeyDown,
         refKey = 'ref',
         ref,
-        disabled,
         ...rest
       } = toggleButtonProps ?? {}
       const {suppressRefError = false} = otherProps ?? {}
@@ -364,11 +365,10 @@ function useSelect<Item>(
         role: 'combobox',
         tabIndex: 0,
         onBlur: callAllEventHandlers(onBlur, toggleButtonHandleBlur),
-        disabled,
         ...rest,
       }
 
-      if (!disabled) {
+      if (!rest.disabled) {
         /* istanbul ignore if (react-native) */
         if (isReactNative || isReactNativeWeb) {
           Object.assign(toggleProps, {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

# Pull Request

## What

Part of the fix for https://github.com/downshift-js/downshift/issues/1688.
Remove the `disabled` value from the getter props which was introduced in the ts migration changes PR.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Why
Causes a regression when spreading.
<!-- Why are these changes necessary? -->

## How
Only use the `disabled` value and not return it, unless the user adds it as props to the function.
<!-- How were these changes implemented? -->

## Changes
Remove from spread, only use `rest.disabled` to perform the checks.
<!-- List the specific changes made (files modified, configurations updated, etc.) -->

## Checklist

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] TypeScript Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
