### PR TITLE
dev: fix leftover typescript migration issues

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -29,6 +29,12 @@ const config = {
       ({
         docs: false,
         blog: false,
+        theme: {
+          customCss: [
+            require.resolve('./docusaurus/pages/shared.css'),
+            require.resolve('./docusaurus/pages/useTagGroupCombobox.css'),
+          ],
+        },
         pages: {
           path: 'docusaurus/pages',
           include: ['**/*.{js,jsx,tsx}'],
@@ -42,6 +48,7 @@ const config = {
       name: 'configure-webpack-target',
       configureWebpack(webpackConfig, isServer) {
         webpackConfig.target = isServer ? 'node' : 'web'
+        return {devtool: 'source-map'}
       },
     }),
     require.resolve('./docusaurus/plugins/webpack5polyfills.js'),

--- a/docusaurus/pages/combobox.tsx
+++ b/docusaurus/pages/combobox.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import Downshift from '../../src'
 import {type ControllerStateAndHelpers} from '../../src/downshift.types'
 import {colors} from '../utils'
-import './shared.css'
 
 export default function ComboBox() {
   return (

--- a/docusaurus/pages/useCombobox.tsx
+++ b/docusaurus/pages/useCombobox.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 
 import {useCombobox} from '../../src'
 import {colors} from '../utils'
-import './shared.css'
 
 export default function DropdownCombobox() {
   const [inputItems, setInputItems] = React.useState(colors)

--- a/docusaurus/pages/useMultipleCombobox.tsx
+++ b/docusaurus/pages/useMultipleCombobox.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import {useCombobox, useMultipleSelection} from '../../src'
 import {type UseMultipleSelectionReturnValue} from '../../src/hooks/useMultipleSelection/index.types'
 import {colors} from '../utils'
-import './shared.css'
 
 const initialSelectedItems = colors.slice(0, 2)
 

--- a/docusaurus/pages/useMultipleSelect.tsx
+++ b/docusaurus/pages/useMultipleSelect.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import {useSelect, useMultipleSelection} from '../../src'
 import {type UseMultipleSelectionReturnValue} from '../../src/hooks/useMultipleSelection/index.types'
 import {colors} from '../utils'
-import './shared.css'
 
 const initialSelectedItems = colors.slice(0, 2)
 

--- a/docusaurus/pages/useSelect.tsx
+++ b/docusaurus/pages/useSelect.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 
 import {useSelect} from '../../src'
 import {colors} from '../utils'
-import './shared.css'
 
 export default function DropdownSelect() {
   const {

--- a/docusaurus/pages/useTagGroup.tsx
+++ b/docusaurus/pages/useTagGroup.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import {useTagGroup} from '../../src'
 import {colors} from '../utils'
 
-import './shared.css'
 
 export default function TagGroup() {
   const initialItems = colors.slice(0, 5)

--- a/docusaurus/pages/useTagGroupCombobox.tsx
+++ b/docusaurus/pages/useTagGroupCombobox.tsx
@@ -3,8 +3,6 @@ import * as React from 'react'
 import {useTagGroup, useCombobox} from '../../src'
 import {colors} from '../utils'
 
-import './shared.css'
-import './useTagGroupCombobox.css'
 
 export default function TagGroup() {
   const initialItems = colors.slice(0, 5)

--- a/docusaurus/tsconfig.json
+++ b/docusaurus/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
   "include": ["./**/*.tsx*", "../typings/**/*.d.ts"]
 }

--- a/docusaurus/tsconfig.json
+++ b/docusaurus/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": "."
+    "rootDir": ".."
   },
   "include": ["./**/*.tsx*", "../typings/**/*.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
@@ -11,14 +11,11 @@
     "module": "ESNext",
     "typeRoots": ["./node_modules/@types", "./node_modules/@testing-library"],
     "strictNullChecks": true,
+    "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "dist",
-    "emitDeclarationOnly": true,
-    "baseUrl": ".",
-    "paths": {
-      "*": ["*"]
-    }
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noUncheckedIndexedAccess": true,
     "module": "ESNext",
     "typeRoots": ["./node_modules/@types", "./node_modules/@testing-library"],
+    "types": ["jest", "jest-dom", "node"],
     "strictNullChecks": true,
     "rootDir": "src",
     "outDir": "dist",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

# Pull Request

## What

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

After the [TS migration ](https://github.com/downshift-js/downshift/pull/1683) some infra errors appeared in the repo. Fixing them.

## Why

- Make sure we're up to date and correct.
- Styles in docusaurus were broken.
- Files maps in docusaurus build were broken and could not break point.
- tsconfig had entries that were outdated.

<!-- Why are these changes necessary? -->

## How

<!-- How were these changes implemented? -->

## Changes

<!-- List the specific changes made (files modified, configurations updated, etc.) -->

## Checklist

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] TypeScript Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
