### PR TITLE
fix(getHighlightedIndexOnOpen): remove added check from migration

### DIFF
--- a/src/hooks/utils/__tests__/getHighlightedIndexOnOpen.test.ts
+++ b/src/hooks/utils/__tests__/getHighlightedIndexOnOpen.test.ts
@@ -186,3 +186,33 @@ test('returns -1 when no conditions match', () => {
     ),
   ).toBe(-1)
 })
+
+test('returns -1 when defaultHighlightedIndex is -1, even when selectedItem is set', () => {
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      undefined,
+      -1,
+      isItemDisabled,
+      itemToKey,
+      'b',
+      -1,
+      1,
+    ),
+  ).toBe(-1)
+})
+
+test('returns -1 when initialHighlightedIndex is -1 and highlightedIndex matches', () => {
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      -1,
+      undefined,
+      isItemDisabled,
+      itemToKey,
+      'b',
+      -1,
+      1,
+    ),
+  ).toBe(-1)
+})

--- a/src/hooks/utils/__tests__/getHighlightedIndexOnOpen.test.ts
+++ b/src/hooks/utils/__tests__/getHighlightedIndexOnOpen.test.ts
@@ -8,211 +8,421 @@ const isLastItemDisabled = (_item: string, index: number) =>
 const itemToKey = (item: string | null) => item
 
 test('returns -1 when items is empty', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 0
+
   expect(
     getHighlightedIndexOnOpen(
       [],
-      undefined,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      null,
-      -1,
-      0,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('returns initialHighlightedIndex when it matches state highlightedIndex and is not disabled', () => {
+  const initialHighlightedIndex = 1
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = 1
+  const offset = 0
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      1,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      null,
-      1,
-      0,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(1)
 })
 
 test('skips initialHighlightedIndex when state highlightedIndex does not match', () => {
+  const initialHighlightedIndex = 1
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = 0
+  const offset = 0
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      1,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      null,
-      0,
-      0,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('skips initialHighlightedIndex when that item is disabled', () => {
+  const initialHighlightedIndex = 0
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = 0
+  const offset = 1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      0,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isFirstItemDisabled,
       itemToKey,
-      null,
-      0,
-      1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('returns defaultHighlightedIndex when it is not disabled', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = 2
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 0
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      2,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      null,
-      -1,
-      0,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(2)
 })
 
 test('skips defaultHighlightedIndex when that item is disabled', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = 0
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      0,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isFirstItemDisabled,
       itemToKey,
-      null,
-      -1,
-      1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('returns index of selectedItem when selectedItem is set', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = 'b'
+  const highlightedIndex = -1
+  const offset = 0
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      'b',
-      -1,
-      0,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(1)
 })
 
 test('returns last index when offset is negative and last item is not disabled', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = -1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      null,
-      -1,
-      -1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(2)
 })
 
 test('skips last index when offset is negative and last item is disabled', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = -1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isLastItemDisabled,
       itemToKey,
-      null,
-      -1,
-      -1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('returns 0 when offset is positive and first item is not disabled', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      null,
-      -1,
-      1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(0)
 })
 
 test('skips 0 when offset is positive and first item is disabled', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isFirstItemDisabled,
       itemToKey,
-      null,
-      -1,
-      1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('returns -1 when no conditions match', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 0
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      null,
-      -1,
-      0,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('returns -1 when defaultHighlightedIndex is -1, even when selectedItem is set', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = -1
+  const selectedItem = 'b'
+  const highlightedIndex = -1
+  const offset = 1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      undefined,
-      -1,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      'b',
-      -1,
-      1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
 })
 
 test('returns -1 when initialHighlightedIndex is -1 and highlightedIndex matches', () => {
+  const initialHighlightedIndex = -1
+  const defaultHighlightedIndex = undefined
+  const selectedItem = 'b'
+  const highlightedIndex = -1
+  const offset = 1
+
   expect(
     getHighlightedIndexOnOpen(
       items,
-      -1,
-      undefined,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
       isItemDisabled,
       itemToKey,
-      'b',
-      -1,
-      1,
+      selectedItem,
+      highlightedIndex,
+      offset,
     ),
   ).toBe(-1)
+})
+
+test('skips initialHighlightedIndex when it is out of bounds', () => {
+  const initialHighlightedIndex = 10
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = 10
+  const offset = 1
+
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled,
+      itemToKey,
+      selectedItem,
+      highlightedIndex,
+      offset,
+    ),
+  ).toBe(0)
+})
+
+test('skips defaultHighlightedIndex when it is out of bounds', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = 10
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 1
+
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled,
+      itemToKey,
+      selectedItem,
+      highlightedIndex,
+      offset,
+    ),
+  ).toBe(0)
+})
+
+test('skips initialHighlightedIndex when it is a large negative', () => {
+  const initialHighlightedIndex = -5
+  const defaultHighlightedIndex = undefined
+  const selectedItem = null
+  const highlightedIndex = -5
+  const offset = 1
+
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled,
+      itemToKey,
+      selectedItem,
+      highlightedIndex,
+      offset,
+    ),
+  ).toBe(0)
+})
+
+test('skips defaultHighlightedIndex when it is a large negative', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = -5
+  const selectedItem = null
+  const highlightedIndex = -1
+  const offset = 1
+
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled,
+      itemToKey,
+      selectedItem,
+      highlightedIndex,
+      offset,
+    ),
+  ).toBe(0)
+})
+
+test('returns -1 when selectedItem is not found in items', () => {
+  const initialHighlightedIndex = undefined
+  const defaultHighlightedIndex = undefined
+  const selectedItem = 'z'
+  const highlightedIndex = -1
+  const offset = 0
+
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled,
+      itemToKey,
+      selectedItem,
+      highlightedIndex,
+      offset,
+    ),
+  ).toBe(-1)
+})
+
+test('initialHighlightedIndex takes priority over defaultHighlightedIndex when it matches highlightedIndex', () => {
+  const initialHighlightedIndex = 0
+  const defaultHighlightedIndex = 2
+  const selectedItem = null
+  const highlightedIndex = 0
+  const offset = 0
+
+  expect(
+    getHighlightedIndexOnOpen(
+      items,
+      initialHighlightedIndex,
+      defaultHighlightedIndex,
+      isItemDisabled,
+      itemToKey,
+      selectedItem,
+      highlightedIndex,
+      offset,
+    ),
+  ).toBe(0)
 })

--- a/src/hooks/utils/getHighlightedIndexOnOpen.ts
+++ b/src/hooks/utils/getHighlightedIndexOnOpen.ts
@@ -32,9 +32,8 @@ export function getHighlightedIndexOnOpen<Item>(
   if (
     initialHighlightedIndex !== undefined &&
     highlightedIndex === initialHighlightedIndex &&
-    (initialHighlightedIndex === -1 ||
-      (items[initialHighlightedIndex] &&
-        !isItemDisabled(items[initialHighlightedIndex], initialHighlightedIndex)))
+    (items[initialHighlightedIndex] === undefined ||
+      !isItemDisabled(items[initialHighlightedIndex], initialHighlightedIndex))
   ) {
     return initialHighlightedIndex
   }
@@ -42,8 +41,8 @@ export function getHighlightedIndexOnOpen<Item>(
   if (
     defaultHighlightedIndex !== undefined &&
     (defaultHighlightedIndex === -1 ||
-      (items[defaultHighlightedIndex] &&
-        !isItemDisabled(items[defaultHighlightedIndex], defaultHighlightedIndex)))
+      items[defaultHighlightedIndex] === undefined ||
+      !isItemDisabled(items[defaultHighlightedIndex], defaultHighlightedIndex))
   ) {
     return defaultHighlightedIndex
   }

--- a/src/hooks/utils/getHighlightedIndexOnOpen.ts
+++ b/src/hooks/utils/getHighlightedIndexOnOpen.ts
@@ -32,16 +32,18 @@ export function getHighlightedIndexOnOpen<Item>(
   if (
     initialHighlightedIndex !== undefined &&
     highlightedIndex === initialHighlightedIndex &&
-    items[initialHighlightedIndex] &&
-    !isItemDisabled(items[initialHighlightedIndex], initialHighlightedIndex)
+    (initialHighlightedIndex === -1 ||
+      (items[initialHighlightedIndex] &&
+        !isItemDisabled(items[initialHighlightedIndex], initialHighlightedIndex)))
   ) {
     return initialHighlightedIndex
   }
 
   if (
     defaultHighlightedIndex !== undefined &&
-    items[defaultHighlightedIndex] &&
-    !isItemDisabled(items[defaultHighlightedIndex], defaultHighlightedIndex)
+    (defaultHighlightedIndex === -1 ||
+      (items[defaultHighlightedIndex] &&
+        !isItemDisabled(items[defaultHighlightedIndex], defaultHighlightedIndex)))
   ) {
     return defaultHighlightedIndex
   }

--- a/src/hooks/utils/getHighlightedIndexOnOpen.ts
+++ b/src/hooks/utils/getHighlightedIndexOnOpen.ts
@@ -32,8 +32,12 @@ export function getHighlightedIndexOnOpen<Item>(
   if (
     initialHighlightedIndex !== undefined &&
     highlightedIndex === initialHighlightedIndex &&
-    (items[initialHighlightedIndex] === undefined ||
-      !isItemDisabled(items[initialHighlightedIndex], initialHighlightedIndex))
+    (initialHighlightedIndex === -1 ||
+      (items[initialHighlightedIndex] !== undefined &&
+        !isItemDisabled(
+          items[initialHighlightedIndex],
+          initialHighlightedIndex,
+        )))
   ) {
     return initialHighlightedIndex
   }
@@ -41,8 +45,11 @@ export function getHighlightedIndexOnOpen<Item>(
   if (
     defaultHighlightedIndex !== undefined &&
     (defaultHighlightedIndex === -1 ||
-      items[defaultHighlightedIndex] === undefined ||
-      !isItemDisabled(items[defaultHighlightedIndex], defaultHighlightedIndex))
+      (items[defaultHighlightedIndex] !== undefined &&
+        !isItemDisabled(
+          items[defaultHighlightedIndex],
+          defaultHighlightedIndex,
+        )))
   ) {
     return defaultHighlightedIndex
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

# Pull Request

## What

Removed added check during the TS migration PR.
Fixes https://github.com/downshift-js/downshift/issues/1688

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## Why
Causes a regression when opening the menu with a -1 highlighted index.
<!-- Why are these changes necessary? -->

## How
Remove the previously added guard.
<!-- How were these changes implemented? -->

## Changes
Change getHighlightedIndexOnOpen to remove the guard.
<!-- List the specific changes made (files modified, configurations updated, etc.) -->

## Checklist

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] TypeScript Types
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
