### PR TITLE
fix: preserve pending a11y status messages

### DIFF
--- a/src/hooks/utils/__tests__/useA11yMessageStatus.multiple.test.ts
+++ b/src/hooks/utils/__tests__/useA11yMessageStatus.multiple.test.ts
@@ -1,0 +1,56 @@
+import {act, renderHook, screen} from '@testing-library/react'
+import {useA11yMessageStatus} from '../useA11yMessageStatus'
+
+jest.useFakeTimers()
+
+afterEach(() => {
+  act(() => jest.runOnlyPendingTimers())
+  document.body.innerHTML = ''
+})
+
+afterAll(() => jest.useRealTimers())
+
+test('empty status messages do not cancel pending non-empty status messages', () => {
+  const getA11yStatusMessage = ({message}: {message: string}) => message
+  const environment = {document}
+  const {rerender} = renderHook(
+    ({
+      firstMessage,
+      secondMessage,
+      updateCount,
+    }: {
+      firstMessage: string
+      secondMessage: string
+      updateCount: number
+    }) => {
+      useA11yMessageStatus(
+        getA11yStatusMessage,
+        {message: firstMessage},
+        [firstMessage, updateCount],
+        environment,
+      )
+      useA11yMessageStatus(
+        getA11yStatusMessage,
+        {message: secondMessage},
+        [secondMessage, updateCount],
+        environment,
+      )
+    },
+    {
+      initialProps: {
+        firstMessage: '',
+        secondMessage: '',
+        updateCount: 0,
+      },
+    },
+  )
+
+  rerender({
+    firstMessage: 'Item added.',
+    secondMessage: '',
+    updateCount: 1,
+  })
+  act(() => jest.advanceTimersByTime(200))
+
+  expect(screen.getByRole('status')).toHaveTextContent('Item added.')
+})

--- a/src/hooks/utils/useA11yMessageStatus.ts
+++ b/src/hooks/utils/useA11yMessageStatus.ts
@@ -35,6 +35,10 @@ export function useA11yMessageStatus<Options>(
 
     const status = getA11yStatusMessage(options)
 
+    if (!status) {
+      return
+    }
+
     updateA11yStatus(status, document)
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Pull Request

## What

Fixes an aria-live status edge case where an empty status message can cancel a pending non-empty status update from another `useA11yMessageStatus` caller.

## Why

When hooks such as `useMultipleSelection` and `useSelect` are composed together, one hook can have a real status message ready while a neighboring hook reports no status for the same render cycle. The empty status should be a no-op, not a cancellation of the pending message. This is related to #1298.

## How

`useA11yMessageStatus` now returns early when `getA11yStatusMessage` returns an empty value, before the shared debounced updater is called.

## Changes

- Added a regression test covering two status hook callers where the second returns an empty status.
- Skipped scheduling live-region updates for empty status messages.

## Checklist

- [x] Documentation N/A
- [x] Tests
- [x] TypeScript Types
- [x] Ready to be merged

Verified with:

- `CI=true npm test -- src/hooks/utils/__tests__/useA11yMessageStatus.multiple.test.ts --runInBand`
- `CI=true npm test -- src/hooks/utils/__tests__/useA11yMessageStatus.test.ts --runInBand`
- `CI=true npm test -- src/hooks/useMultipleSelection/__tests__/props.test.js --runInBand`
- `CI=true npm test -- src/hooks/useSelect/__tests__/props.test.js --runInBand`
- `npm run test:ts`
- `npx prettier --check src/hooks/utils/useA11yMessageStatus.ts src/hooks/utils/__tests__/useA11yMessageStatus.multiple.test.ts`
