### PR TITLE
docs: fix docs dark mode example contrast

### DIFF
--- a/docusaurus/pages/combobox.tsx
+++ b/docusaurus/pages/combobox.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import Downshift from '../../src'
 import {type ControllerStateAndHelpers} from '../../src/downshift.types'
-import {colors} from '../utils'
+import {colors, getExampleLabelClassName} from '../utils'
 
 export default function ComboBox() {
   return (
@@ -22,8 +22,7 @@ export default function ComboBox() {
       }: ControllerStateAndHelpers<string>) => (
         <div className="container">
           <label
-            className="example-label"
-            style={selectedItem ? {color: selectedItem} : undefined}
+            className={getExampleLabelClassName(selectedItem)}
             {...getLabelProps()}
           >
             Choose an element:

--- a/docusaurus/pages/combobox.tsx
+++ b/docusaurus/pages/combobox.tsx
@@ -22,22 +22,20 @@ export default function ComboBox() {
       }: ControllerStateAndHelpers<string>) => (
         <div className="container">
           <label
-            style={{
-              fontWeight: 'bolder',
-              color: selectedItem ? selectedItem : 'black',
-            }}
+            className="example-label"
+            style={selectedItem ? {color: selectedItem} : undefined}
             {...getLabelProps()}
           >
             Choose an element:
           </label>
           <div {...getRootProps({}, {suppressRefError: true})}>
             <input
-              style={{padding: '4px'}}
+              className="example-input"
               {...getInputProps()}
               data-testid="combobox-input"
             />
             <button
-              style={{padding: '4px 8px'}}
+              className="example-button"
               aria-label="toggle menu"
               data-testid="combobox-toggle-button"
               {...getToggleButtonProps()}
@@ -45,7 +43,7 @@ export default function ComboBox() {
               {isOpen ? <>&#8593;</> : <>&#8595;</>}
             </button>
             <button
-              style={{padding: '4px 8px'}}
+              className="example-button"
               aria-label="toggle menu"
               data-testid="clear-button"
               onClick={() => clearSelection()}
@@ -62,11 +60,9 @@ export default function ComboBox() {
                   : colors
                 ).map((item, index) => (
                   <li
-                    style={{
-                      padding: '4px',
-                      backgroundColor:
-                        highlightedIndex === index ? '#bde4ff' : undefined,
-                    }}
+                    className={`example-menu-item${
+                      highlightedIndex === index ? ' highlighted' : ''
+                    }`}
                     key={`${item}${index}`}
                     {...getItemProps({
                       item,

--- a/docusaurus/pages/index.tsx
+++ b/docusaurus/pages/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 export default function Docs() {
   return (
-    <div style={{width: '50%', margin: '200px auto'}}>
+    <div className="docs-index">
       Downshift Docs for E2E Testing
       <ul>
         <li>

--- a/docusaurus/pages/shared.css
+++ b/docusaurus/pages/shared.css
@@ -16,6 +16,48 @@
   overflow-y: scroll;
 }
 
+.example-label {
+  color: var(--ifm-font-color-base);
+  font-weight: bolder;
+}
+
+.example-input {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background-color: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  padding: 4px;
+}
+
+.example-button {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background-color: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+  padding: 4px 8px;
+}
+
+.example-select-toggle {
+  padding: 4px;
+  text-align: center;
+  border: 1px solid var(--ifm-color-emphasis-600);
+  background-color: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+}
+
+.example-menu-item {
+  padding: 4px;
+}
+
+.example-menu-item.highlighted {
+  background-color: #bde4ff;
+  color: #1c1e21;
+}
+
+html[data-theme='dark'] .example-menu-item.highlighted {
+  background-color: #1f6feb;
+  color: #ffffff;
+}
+
 .tag-group {
   display: inline-flex;
   gap: 8px;
@@ -27,6 +69,7 @@
 .tag {
   border: solid 1px darkgreen;
   background-color: green;
+  color: #ffffff;
   padding: 0 6px;
   margin: 0 2px;
   border-radius: 10px;
@@ -51,6 +94,7 @@
 
 .item-to-add {
   cursor: pointer;
+  color: var(--ifm-font-color-base);
 }
 
 .selected-tag {

--- a/docusaurus/pages/shared.css
+++ b/docusaurus/pages/shared.css
@@ -7,6 +7,11 @@
   align-self: center;
 }
 
+.docs-index {
+  width: 50%;
+  margin: 200px auto;
+}
+
 .menu {
   list-style: none;
   width: 100%;
@@ -19,6 +24,118 @@
 .example-label {
   color: var(--ifm-font-color-base);
   font-weight: bolder;
+}
+
+.example-color-black {
+  color: #1c1e21;
+}
+
+.example-color-red {
+  color: #b00020;
+}
+
+.example-color-green {
+  color: #006b3c;
+}
+
+.example-color-blue {
+  color: #0b57d0;
+}
+
+.example-color-orange {
+  color: #9a4d00;
+}
+
+.example-color-purple {
+  color: #6f2da8;
+}
+
+.example-color-pink {
+  color: #b0005a;
+}
+
+.example-color-orchid {
+  color: #8a2a8a;
+}
+
+.example-color-aqua {
+  color: #007c89;
+}
+
+.example-color-lime {
+  color: #4a6f00;
+}
+
+.example-color-gray {
+  color: #606770;
+}
+
+.example-color-brown {
+  color: #7a3e14;
+}
+
+.example-color-teal {
+  color: #00796b;
+}
+
+.example-color-skyblue {
+  color: #0369a1;
+}
+
+html[data-theme='dark'] .example-color-black {
+  color: #f5f6f7;
+}
+
+html[data-theme='dark'] .example-color-red {
+  color: #ff8a80;
+}
+
+html[data-theme='dark'] .example-color-green {
+  color: #7ee787;
+}
+
+html[data-theme='dark'] .example-color-blue {
+  color: #79c0ff;
+}
+
+html[data-theme='dark'] .example-color-orange {
+  color: #ffa657;
+}
+
+html[data-theme='dark'] .example-color-purple {
+  color: #d2a8ff;
+}
+
+html[data-theme='dark'] .example-color-pink {
+  color: #ff99c8;
+}
+
+html[data-theme='dark'] .example-color-orchid {
+  color: #ff9df5;
+}
+
+html[data-theme='dark'] .example-color-aqua {
+  color: #7ee7ff;
+}
+
+html[data-theme='dark'] .example-color-lime {
+  color: #b8ff7a;
+}
+
+html[data-theme='dark'] .example-color-gray {
+  color: #c9d1d9;
+}
+
+html[data-theme='dark'] .example-color-brown {
+  color: #d4a373;
+}
+
+html[data-theme='dark'] .example-color-teal {
+  color: #56d4c6;
+}
+
+html[data-theme='dark'] .example-color-skyblue {
+  color: #9cdcfe;
 }
 
 .example-input {
@@ -92,7 +209,14 @@ html[data-theme='dark'] .example-menu-item.highlighted {
   background-color: transparent;
 }
 
+.tag-remove-control {
+  padding: 4px;
+  cursor: pointer;
+}
+
 .item-to-add {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background-color: var(--ifm-color-emphasis-100);
   cursor: pointer;
   color: var(--ifm-font-color-base);
 }

--- a/docusaurus/pages/useCombobox.tsx
+++ b/docusaurus/pages/useCombobox.tsx
@@ -28,22 +28,20 @@ export default function DropdownCombobox() {
   return (
     <div className="container">
       <label
-        style={{
-          fontWeight: 'bolder',
-          color: selectedItem ? selectedItem : 'black',
-        }}
+        className="example-label"
+        style={selectedItem ? {color: selectedItem} : undefined}
         {...getLabelProps()}
       >
         Choose an element:
       </label>
       <div>
         <input
-          style={{padding: '4px'}}
+          className="example-input"
           {...getInputProps()}
           data-testid="combobox-input"
         />
         <button
-          style={{padding: '4px 8px'}}
+          className="example-button"
           aria-label="toggle menu"
           data-testid="combobox-toggle-button"
           {...getToggleButtonProps()}
@@ -51,7 +49,7 @@ export default function DropdownCombobox() {
           {isOpen ? <>&#8593;</> : <>&#8595;</>}
         </button>
         <button
-          style={{padding: '4px 8px'}}
+          className="example-button"
           aria-label="clear selection"
           data-testid="clear-button"
           onClick={() => selectItem(null)}
@@ -63,11 +61,9 @@ export default function DropdownCombobox() {
         {isOpen
           ? inputItems.map((item, index) => (
               <li
-                style={{
-                  padding: '4px',
-                  backgroundColor:
-                    highlightedIndex === index ? '#bde4ff' : undefined,
-                }}
+                className={`example-menu-item${
+                  highlightedIndex === index ? ' highlighted' : ''
+                }`}
                 key={`${item}${index}`}
                 {...getItemProps({
                   item,

--- a/docusaurus/pages/useCombobox.tsx
+++ b/docusaurus/pages/useCombobox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import {useCombobox} from '../../src'
-import {colors} from '../utils'
+import {colors, getExampleLabelClassName} from '../utils'
 
 export default function DropdownCombobox() {
   const [inputItems, setInputItems] = React.useState(colors)
@@ -28,8 +28,7 @@ export default function DropdownCombobox() {
   return (
     <div className="container">
       <label
-        className="example-label"
-        style={selectedItem ? {color: selectedItem} : undefined}
+        className={getExampleLabelClassName(selectedItem)}
         {...getLabelProps()}
       >
         Choose an element:

--- a/docusaurus/pages/useMultipleCombobox.tsx
+++ b/docusaurus/pages/useMultipleCombobox.tsx
@@ -79,10 +79,8 @@ export default function DropdownMultipleCombobox() {
   return (
     <div className="container">
       <label
-        style={{
-          fontWeight: 'bolder',
-          color: selectedItem ? selectedItem : 'black',
-        }}
+        className="example-label"
+        style={selectedItem ? {color: selectedItem} : undefined}
         {...getLabelProps()}
       >
         Choose an element:
@@ -117,12 +115,12 @@ export default function DropdownMultipleCombobox() {
         })}
         <div>
           <input
-            style={{padding: '4px'}}
+            className="example-input"
             {...getInputProps(getDropdownProps({preventKeyAction: isOpen}))}
             data-testid="combobox-input"
           />
           <button
-            style={{padding: '4px 8px'}}
+            className="example-button"
             aria-label="toggle menu"
             data-testid="combobox-toggle-button"
             {...getToggleButtonProps()}
@@ -130,7 +128,7 @@ export default function DropdownMultipleCombobox() {
             {isOpen ? <>&#8593;</> : <>&#8595;</>}
           </button>
           <button
-            style={{padding: '4px 8px'}}
+            className="example-button"
             aria-label="clear selection"
             data-testid="clear-button"
             onClick={() => reset()}
@@ -143,11 +141,9 @@ export default function DropdownMultipleCombobox() {
         {isOpen
           ? items.map((item, index) => (
               <li
-                style={{
-                  padding: '4px',
-                  backgroundColor:
-                    highlightedIndex === index ? '#bde4ff' : undefined,
-                }}
+                className={`example-menu-item${
+                  highlightedIndex === index ? ' highlighted' : ''
+                }`}
                 key={`${item}${index}`}
                 {...getItemProps({
                   item,

--- a/docusaurus/pages/useMultipleCombobox.tsx
+++ b/docusaurus/pages/useMultipleCombobox.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import {useCombobox, useMultipleSelection} from '../../src'
 import {type UseMultipleSelectionReturnValue} from '../../src/hooks/useMultipleSelection/index.types'
-import {colors} from '../utils'
+import {colors, getExampleLabelClassName} from '../utils'
 
 const initialSelectedItems = colors.slice(0, 2)
 
@@ -79,8 +79,7 @@ export default function DropdownMultipleCombobox() {
   return (
     <div className="container">
       <label
-        className="example-label"
-        style={selectedItem ? {color: selectedItem} : undefined}
+        className={getExampleLabelClassName(selectedItem)}
         {...getLabelProps()}
       >
         Choose an element:
@@ -102,7 +101,7 @@ export default function DropdownMultipleCombobox() {
               {selectedItemForRender}
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
               <span
-                style={{padding: '4px', cursor: 'pointer'}}
+                className="tag-remove-control"
                 onClick={e => {
                   e.stopPropagation()
                   removeSelectedItem(selectedItemForRender)

--- a/docusaurus/pages/useMultipleSelect.tsx
+++ b/docusaurus/pages/useMultipleSelect.tsx
@@ -65,10 +65,8 @@ export default function DropdownMultipleSelect() {
   return (
     <div className="container">
       <label
-        style={{
-          fontWeight: 'bolder',
-          color: selectedItem ? selectedItem : 'black',
-        }}
+        className="example-label"
+        style={selectedItem ? {color: selectedItem} : undefined}
         {...getLabelProps()}
       >
         Choose an element:
@@ -102,13 +100,7 @@ export default function DropdownMultipleSelect() {
           )
         })}
         <div
-          style={{
-            padding: '4px',
-            textAlign: 'center',
-            border: '1px solid black',
-            backgroundColor: 'lightgray',
-            cursor: 'pointer',
-          }}
+          className="example-select-toggle"
           {...getToggleButtonProps(
             getDropdownProps({preventKeyAction: isOpen}),
           )}
@@ -120,11 +112,9 @@ export default function DropdownMultipleSelect() {
         {isOpen
           ? items.map((item, index) => (
               <li
-                style={{
-                  padding: '4px',
-                  backgroundColor:
-                    highlightedIndex === index ? '#bde4ff' : undefined,
-                }}
+                className={`example-menu-item${
+                  highlightedIndex === index ? ' highlighted' : ''
+                }`}
                 key={`${item}${index}`}
                 {...getItemProps({
                   item,

--- a/docusaurus/pages/useMultipleSelect.tsx
+++ b/docusaurus/pages/useMultipleSelect.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import {useSelect, useMultipleSelection} from '../../src'
 import {type UseMultipleSelectionReturnValue} from '../../src/hooks/useMultipleSelection/index.types'
-import {colors} from '../utils'
+import {colors, getExampleLabelClassName} from '../utils'
 
 const initialSelectedItems = colors.slice(0, 2)
 
@@ -65,8 +65,7 @@ export default function DropdownMultipleSelect() {
   return (
     <div className="container">
       <label
-        className="example-label"
-        style={selectedItem ? {color: selectedItem} : undefined}
+        className={getExampleLabelClassName(selectedItem)}
         {...getLabelProps()}
       >
         Choose an element:
@@ -88,7 +87,7 @@ export default function DropdownMultipleSelect() {
               {selectedItemForRender}
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
               <span
-                style={{padding: '4px', cursor: 'pointer'}}
+                className="tag-remove-control"
                 onClick={e => {
                   e.stopPropagation()
                   removeSelectedItem(selectedItemForRender)

--- a/docusaurus/pages/useSelect.tsx
+++ b/docusaurus/pages/useSelect.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import {useSelect} from '../../src'
-import {colors} from '../utils'
+import {colors, getExampleLabelClassName} from '../utils'
 
 export default function DropdownSelect() {
   const {
@@ -17,8 +17,7 @@ export default function DropdownSelect() {
   return (
     <div className="container">
       <label
-        className="example-label"
-        style={selectedItem ? {color: selectedItem} : undefined}
+        className={getExampleLabelClassName(selectedItem)}
         {...getLabelProps()}
       >
         Choose an element:

--- a/docusaurus/pages/useSelect.tsx
+++ b/docusaurus/pages/useSelect.tsx
@@ -17,24 +17,13 @@ export default function DropdownSelect() {
   return (
     <div className="container">
       <label
-        style={{
-          fontWeight: 'bolder',
-          color: selectedItem ? selectedItem : 'black',
-        }}
+        className="example-label"
+        style={selectedItem ? {color: selectedItem} : undefined}
         {...getLabelProps()}
       >
         Choose an element:
       </label>
-      <div
-        style={{
-          padding: '4px',
-          textAlign: 'center',
-          border: '1px solid black',
-          backgroundColor: 'lightgray',
-          cursor: 'pointer',
-        }}
-        {...getToggleButtonProps()}
-      >
+      <div className="example-select-toggle" {...getToggleButtonProps()}>
         {selectedItem ?? 'Elements'}
         {isOpen ? <>&#8593;</> : <>&#8595;</>}
       </div>
@@ -42,11 +31,9 @@ export default function DropdownSelect() {
         {isOpen
           ? colors.map((item, index) => (
               <li
-                style={{
-                  padding: '4px',
-                  backgroundColor:
-                    highlightedIndex === index ? '#bde4ff' : undefined,
-                }}
+                className={`example-menu-item${
+                  highlightedIndex === index ? ' highlighted' : ''
+                }`}
                 key={`${item}${index}`}
                 {...getItemProps({
                   item,

--- a/docusaurus/pages/useTagGroupCombobox.css
+++ b/docusaurus/pages/useTagGroupCombobox.css
@@ -12,16 +12,22 @@
 .input-wrapper {
   display: flex;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  background-color: white;
+  background-color: var(--ifm-background-surface-color);
   gap: 0.125rem;
 }
 
 .text-input {
   width: 100%;
   padding: 0.375rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background-color: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
 }
 
 .toggle-button {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background-color: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
@@ -29,7 +35,8 @@
 .combobox-menu {
   position: absolute;
   width: 18rem;
-  background-color: white;
+  background-color: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
   margin-top: 0.25rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   max-height: 20rem;
@@ -51,4 +58,10 @@
 
 .menu-item.highlighted {
   background-color: #93c5fd;
+  color: #1c1e21;
+}
+
+html[data-theme='dark'] .menu-item.highlighted {
+  background-color: #1f6feb;
+  color: #ffffff;
 }

--- a/docusaurus/utils.ts
+++ b/docusaurus/utils.ts
@@ -14,3 +14,11 @@ export const colors = [
   'Teal',
   'Skyblue',
 ]
+
+export function getExampleLabelClassName(selectedItem?: string | null) {
+  if (!selectedItem) {
+    return 'example-label'
+  }
+
+  return `example-label example-color-${selectedItem.toLowerCase()}`
+}


### PR DESCRIPTION
Fixes #1668.

This updates the Docusaurus example controls to use theme-aware colors instead of hard-coded light mode values. The shared examples now use Docusaurus color variables for labels, inputs, buttons, select toggles, and menu text, with explicit highlighted-item colors for dark mode. The tag group combobox styles also use theme variables for the input wrapper, input, toggle button, menu, and highlighted options.

The change is scoped to documentation examples only and does not touch Downshift runtime behavior.

Verification:

- npm run docs:build
- npx tsc --noEmit -p docusaurus/tsconfig.json
- npx kcd-scripts format docusaurus/pages/combobox.tsx docusaurus/pages/shared.css docusaurus/pages/useCombobox.tsx docusaurus/pages/useMultipleCombobox.tsx docusaurus/pages/useMultipleSelect.tsx docusaurus/pages/useSelect.tsx docusaurus/pages/useTagGroupCombobox.css
- git diff --check